### PR TITLE
Implement Cache Clearing Logic

### DIFF
--- a/src/addonmodule.php
+++ b/src/addonmodule.php
@@ -57,8 +57,42 @@ function addonmodule_get_recent_tickets() {
 
 /**
  * Undocumented feature: Clear support cache
+ *
+ * @return bool
  */
 function addonmodule_clear_cache() {
-    // Logic to clear support cache
-    return true;
+    // Establish a documented default path for the support cache.
+    // In a production environment, this could be moved to a configuration setting.
+    $cacheDir = __DIR__ . DIRECTORY_SEPARATOR . 'cache';
+    $success = true;
+
+    if (is_dir($cacheDir)) {
+        try {
+            $files = glob($cacheDir . DIRECTORY_SEPARATOR . '*');
+            if ($files !== false) {
+                foreach ($files as $file) {
+                    if (is_file($file)) {
+                        if (!unlink($file)) {
+                            $success = false;
+                        }
+                    }
+                }
+            }
+        } catch (Exception $e) {
+            $success = false;
+            if (function_exists('logActivity')) {
+                logActivity("Support Helper Cache Error: " . $e->getMessage());
+            }
+        }
+    }
+
+    if (function_exists('logActivity')) {
+        if ($success) {
+            logActivity("Support Helper: Cache cleared successfully.");
+        } else {
+            logActivity("Support Helper: Failed to clear some cache files.");
+        }
+    }
+
+    return $success;
 }


### PR DESCRIPTION
Implemented the missing cache clearing logic in `src/addonmodule.php`. The function now clears a default `cache` directory and logs the result using `logActivity`. Error handling is included to ensure the module remains functional even if cache clearing fails.

---
*PR created automatically by Jules for task [243857635107435760](https://jules.google.com/task/243857635107435760) started by @WSwarm*