### PR TITLE
docs(frameworks): add value lenses and visual guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -610,10 +610,22 @@ This file contains specific capabilities, protocols, and workflows when interact
 Execute n8n operations silently. Call tools in parallel and report back only upon completion.
 
 #### 2. Multi-Level Validation
-When configuring nodes, use minimal validation first, then comprehensive runtime validation before building workflows.
+When configuring nodes, validate in layers:
+
+- credentials
+- node parameters
+- expressions
+- branch routing
+- workflow runtime behavior
 
 #### 3. Never Trust Defaults
 Always explicitly define configurations when interacting with nodes rather than relying on default parameters which often fail at runtime.
+
+#### 4. Do Not Assume Hidden Helper Tools
+Do not invent template catalogs, node validators, or workflow helper methods unless the orchestrator explicitly provides them. If the runtime only exposes JSON files or the n8n API, work within that real surface.
+
+#### 5. Prefer Current Node Types
+Use current built-in node types and explicit `typeVersion` values. Treat older workflow JSON as illustrative until verified against the target n8n release.
 
 ### Slack Protocol
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -562,10 +562,22 @@ This file contains specific capabilities, protocols, and workflows when interact
 Execute n8n operations silently. Call tools in parallel and report back only upon completion.
 
 #### 2. Multi-Level Validation
-When configuring nodes, use minimal validation first, then comprehensive runtime validation before building workflows.
+When configuring nodes, validate in layers:
+
+- credentials
+- node parameters
+- expressions
+- branch routing
+- workflow runtime behavior
 
 #### 3. Never Trust Defaults
 Always explicitly define configurations when interacting with nodes rather than relying on default parameters which often fail at runtime.
+
+#### 4. Do Not Assume Hidden Helper Tools
+Do not invent template catalogs, node validators, or workflow helper methods unless the orchestrator explicitly provides them. If the runtime only exposes JSON files or the n8n API, work within that real surface.
+
+#### 5. Prefer Current Node Types
+Use current built-in node types and explicit `typeVersion` values. Treat older workflow JSON as illustrative until verified against the target n8n release.
 
 ### Slack Protocol
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Project NoéMI — Reference Architecture & Agents Library
 
-Project NoéMI is the **public reference architecture** for NewPush's AI fluency and Virtual Workforce model, and the **agent specification library** that backs it. It defines AI agent personas, MCP (Model Context Protocol) integrations, governance frameworks, and Phase 0 security guidance as Markdown files. It is **not** a runtime or execution engine — external orchestrators like [Gemini CLI](https://github.com/google-gemini/gemini-cli), [n8n](https://n8n.io/), or [LangChain](https://www.langchain.com/) consume these specifications to execute tasks.
+Project NoéMI is the **public reference architecture** for NewPush's AI fluency and Virtual Workforce model, and the **agent specification library** that backs it. It defines AI agent personas, MCP (Model Context Protocol) integrations, governance frameworks, and Phase 0 security guidance as Markdown files. It is **not** a runtime or execution engine — external orchestrators like [Gemini CLI](https://github.com/google-gemini/gemini-cli), Claude Code, OpenAI Codex, [n8n](https://n8n.io/), or [LangChain](https://www.langchain.com/) consume these specifications to execute tasks.
 
 > **New here?** Start with the [**Project Reference**](docs/PROJECT_REFERENCE.md) — the comprehensive public guide to NoéMI's philosophy, framework, curriculum, and technology stack.
 
 **Audience paths:**
 - **Client / Buyer:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Phase 0 Security Baseline](docs/PHASE_ZERO_SECURITY_BASELINE.md) → [Phase 0 Assessment Kit](docs/phase-zero-assessment/README.md)
 - **MSP / MSSP:** [Project Reference](docs/PROJECT_REFERENCE.md) → [MSP Deployment Guide](docs/examples/msp-deployment.md) → [Fleet / governance docs](docs/agents/operations/)
-- **Builder / Accelerator:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Secure Secret Management](docs/tool-usages/secure-secret-management.md) → [Gemini Workspace Quickstart](docs/tool-usages/gemini-workspace-quickstart.md) or [n8n Google Workspace Quickstart](docs/examples/n8n-google-workspace-quickstart.md) → [Builder First 30 Minutes](docs/examples/builder-first-30-minutes.md) → [Docker Agent Home](docs/examples/docker-agent-home.md) → [Orchestrator Runtime Contract](docs/tool-usages/orchestrator-runtime-contract.md)
+- **Builder / Accelerator:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Secure Secret Management](docs/tool-usages/secure-secret-management.md) → [Agentic Local Workspaces](docs/tool-usages/agentic-local-workspaces.md) → [Google Local Workspace](docs/tool-usages/google-local-workspace.md), [Claude Code Local Workspace](docs/tool-usages/claude-code-local-workspace.md), or [OpenAI Codex Local Workspace](docs/tool-usages/openai-codex-local-workspace.md) → [Google Workspace For Agentic Clients](docs/mcp-setup/google-workspace-agentic-clients.md) or [Microsoft 365 For Agentic Clients](docs/mcp-setup/microsoft-365-agentic-clients.md) → [Gemini Workspace Quickstart](docs/tool-usages/gemini-workspace-quickstart.md) or [n8n Google Workspace Quickstart](docs/examples/n8n-google-workspace-quickstart.md) → [Builder First 30 Minutes](docs/examples/builder-first-30-minutes.md) → [Docker Agent Home](docs/examples/docker-agent-home.md) → [Orchestrator Runtime Contract](docs/tool-usages/orchestrator-runtime-contract.md)
 
 ## Table of Contents
 
@@ -71,7 +71,7 @@ When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-
 |----------|------------|------------|
 | **Client / Buyer** | [`docs/PROJECT_REFERENCE.md`](docs/PROJECT_REFERENCE.md) | [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](docs/PHASE_ZERO_SECURITY_BASELINE.md), [`docs/phase-zero-assessment/README.md`](docs/phase-zero-assessment/README.md) |
 | **MSP / MSSP** | [`docs/PROJECT_REFERENCE.md`](docs/PROJECT_REFERENCE.md) | [`docs/examples/msp-deployment.md`](docs/examples/msp-deployment.md), [`docs/agents/operations/`](docs/agents/operations/) |
-| **Builder / Accelerator** | [`docs/tool-usages/secure-secret-management.md`](docs/tool-usages/secure-secret-management.md) | [`docs/tool-usages/gemini-workspace-quickstart.md`](docs/tool-usages/gemini-workspace-quickstart.md), [`docs/examples/n8n-google-workspace-quickstart.md`](docs/examples/n8n-google-workspace-quickstart.md), [`docs/mcp-setup/google-n8n-credential-matrix.md`](docs/mcp-setup/google-n8n-credential-matrix.md), [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md), [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md), [`docs/examples/docker-runtime-verification.md`](docs/examples/docker-runtime-verification.md), [`docs/tool-usages/orchestrator-runtime-contract.md`](docs/tool-usages/orchestrator-runtime-contract.md), [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md) |
+| **Builder / Accelerator** | [`docs/tool-usages/secure-secret-management.md`](docs/tool-usages/secure-secret-management.md) | [`docs/tool-usages/agentic-local-workspaces.md`](docs/tool-usages/agentic-local-workspaces.md), [`docs/tool-usages/google-local-workspace.md`](docs/tool-usages/google-local-workspace.md), [`docs/tool-usages/claude-code-local-workspace.md`](docs/tool-usages/claude-code-local-workspace.md), [`docs/tool-usages/openai-codex-local-workspace.md`](docs/tool-usages/openai-codex-local-workspace.md), [`docs/mcp-setup/google-workspace-agentic-clients.md`](docs/mcp-setup/google-workspace-agentic-clients.md), [`docs/mcp-setup/microsoft-365-agentic-clients.md`](docs/mcp-setup/microsoft-365-agentic-clients.md), [`docs/tool-usages/gemini-workspace-quickstart.md`](docs/tool-usages/gemini-workspace-quickstart.md), [`docs/examples/n8n-google-workspace-quickstart.md`](docs/examples/n8n-google-workspace-quickstart.md), [`docs/mcp-setup/google-n8n-credential-matrix.md`](docs/mcp-setup/google-n8n-credential-matrix.md), [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md), [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md), [`docs/examples/docker-runtime-verification.md`](docs/examples/docker-runtime-verification.md), [`docs/tool-usages/orchestrator-runtime-contract.md`](docs/tool-usages/orchestrator-runtime-contract.md), [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md) |
 
 ---
 
@@ -84,6 +84,7 @@ When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-
 | MCP protocol definitions | `mcp-protocols/` | Behavioral rules for 16 tool integrations (Google Workspace, Slack, GitHub, n8n, etc.) |
 | Deployment examples | `examples/` | Docker Compose stacks, workflow templates, and testing suites |
 | Documentation | `docs/` | Framework docs, setup guides, agent-specific documentation |
+| Operating profiles | `operating-profiles/` | Localized language, regional, and audience overlays for culturally grounded agent execution |
 | Build scripts | `scripts/` | Context generation, repo auditing, retry helpers, and environment verification |
 | Test harness | `tests/`, `package.json` | Built-in Node contract, golden fixture, example smoke, and Docker e2e tests |
 | Runtime diagnostics | `test-artifacts/docker-smoke/` | Failure artifacts emitted by Docker smoke verification on real hosts and in CI |
@@ -124,12 +125,14 @@ When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-
 │   ├── GOVERNANCE.md                # AI TRiSM and Red Teaming protocols
 │   ├── PHASE_ZERO_SECURITY_BASELINE.md # Client-side cybersecurity grounding guide
 │   ├── REQUIREMENTS.md              # Project requirements and drift tracking
+│   ├── frameworks/                  # Meta-frameworks such as localized operating profiles
 │   ├── phase-zero-assessment/       # Consent, findings, roadmap, and readiness kit
 │   ├── agents/                      # Per-agent documentation (mirrors agents/)
 │   ├── examples/                    # Deployment guides (MSP, RFP responder, etc.)
 │   ├── mcp-setup/                   # MCP infrastructure setup guides
-│   ├── lifecycle/                   # 4D Framework lifecycle documentation
-│   └── frameworks/                  # Gartner TRiSM reference
+│   └── lifecycle/                   # 4D Framework lifecycle documentation
+│
+├── operating-profiles/              # Localized workstyle overlays and templates
 │
 ├── examples/                        # Deployable examples
 │   ├── docker/                      # Docker sandbox with pgvector memory
@@ -238,7 +241,7 @@ For setup instructions, see [`docs/mcp-setup/`](docs/mcp-setup/).
 
 ### Context Generation Pipeline
 
-The core build step combines your agent specs and MCP protocols into context files that orchestrators consume. Two parallel pipelines exist — one for Gemini CLI and one for Claude Code:
+The core build step combines your agent specs and MCP protocols into context files that orchestrators consume. Two generated context pipelines exist today — one for Gemini CLI and one for Claude Code:
 
 ```
 {GEMINI,CLAUDE}.template.md + mcp.config.json + AGENTS.md
@@ -278,6 +281,9 @@ Open this repository in Claude Code. It reads `CLAUDE.md` as project instruction
 ```bash
 infisical run --env=dev -- gemini -p GEMINI.md "Analyze the server logs on web01"
 ```
+
+**OpenAI Codex** (local agentic workspace):
+Use the repo's `AGENTS.md`, `mcp-protocols/`, and the builder-facing docs in [`docs/tool-usages/agentic-local-workspaces.md`](docs/tool-usages/agentic-local-workspaces.md). Codex configuration lives in `~/.codex/config.toml`, while project-level app actions and setup scripts can live in `.codex/`.
 
 **n8n** (automated workflows):
 Import workflow templates from `examples/workflows/` into your n8n instance. The workflows reference agent personas and MCP integrations defined in this repository.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Project NoéMI is the **public reference architecture** for NewPush's AI fluency
 **Audience paths:**
 - **Client / Buyer:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Phase 0 Security Baseline](docs/PHASE_ZERO_SECURITY_BASELINE.md) → [Phase 0 Assessment Kit](docs/phase-zero-assessment/README.md)
 - **MSP / MSSP:** [Project Reference](docs/PROJECT_REFERENCE.md) → [MSP Deployment Guide](docs/examples/msp-deployment.md) → [Fleet / governance docs](docs/agents/operations/)
-- **Builder / Accelerator:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Secure Secret Management](docs/tool-usages/secure-secret-management.md) → [Builder First 30 Minutes](docs/examples/builder-first-30-minutes.md) → [Docker Agent Home](docs/examples/docker-agent-home.md) → [Orchestrator Runtime Contract](docs/tool-usages/orchestrator-runtime-contract.md)
+- **Builder / Accelerator:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Secure Secret Management](docs/tool-usages/secure-secret-management.md) → [Gemini Workspace Quickstart](docs/tool-usages/gemini-workspace-quickstart.md) or [n8n Google Workspace Quickstart](docs/examples/n8n-google-workspace-quickstart.md) → [Builder First 30 Minutes](docs/examples/builder-first-30-minutes.md) → [Docker Agent Home](docs/examples/docker-agent-home.md) → [Orchestrator Runtime Contract](docs/tool-usages/orchestrator-runtime-contract.md)
 
 ## Table of Contents
 
@@ -71,7 +71,7 @@ When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-
 |----------|------------|------------|
 | **Client / Buyer** | [`docs/PROJECT_REFERENCE.md`](docs/PROJECT_REFERENCE.md) | [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](docs/PHASE_ZERO_SECURITY_BASELINE.md), [`docs/phase-zero-assessment/README.md`](docs/phase-zero-assessment/README.md) |
 | **MSP / MSSP** | [`docs/PROJECT_REFERENCE.md`](docs/PROJECT_REFERENCE.md) | [`docs/examples/msp-deployment.md`](docs/examples/msp-deployment.md), [`docs/agents/operations/`](docs/agents/operations/) |
-| **Builder / Accelerator** | [`docs/tool-usages/secure-secret-management.md`](docs/tool-usages/secure-secret-management.md) | [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md), [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md), [`docs/examples/docker-runtime-verification.md`](docs/examples/docker-runtime-verification.md), [`docs/tool-usages/orchestrator-runtime-contract.md`](docs/tool-usages/orchestrator-runtime-contract.md), [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md) |
+| **Builder / Accelerator** | [`docs/tool-usages/secure-secret-management.md`](docs/tool-usages/secure-secret-management.md) | [`docs/tool-usages/gemini-workspace-quickstart.md`](docs/tool-usages/gemini-workspace-quickstart.md), [`docs/examples/n8n-google-workspace-quickstart.md`](docs/examples/n8n-google-workspace-quickstart.md), [`docs/mcp-setup/google-n8n-credential-matrix.md`](docs/mcp-setup/google-n8n-credential-matrix.md), [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md), [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md), [`docs/examples/docker-runtime-verification.md`](docs/examples/docker-runtime-verification.md), [`docs/tool-usages/orchestrator-runtime-contract.md`](docs/tool-usages/orchestrator-runtime-contract.md), [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ Project NoéMI is the **public reference architecture** for NewPush's AI fluency
 
 > **New here?** Start with the [**Project Reference**](docs/PROJECT_REFERENCE.md) — the comprehensive public guide to NoéMI's philosophy, framework, curriculum, and technology stack.
 
+> **Need the fastest orientation?** Start with the [**Visual Guides**](docs/visuals/README.md) for the system map, audience path, runtime flow, and workshop mind map.
+
 **Audience paths:**
 - **Client / Buyer:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Phase 0 Security Baseline](docs/PHASE_ZERO_SECURITY_BASELINE.md) → [Phase 0 Assessment Kit](docs/phase-zero-assessment/README.md)
 - **MSP / MSSP:** [Project Reference](docs/PROJECT_REFERENCE.md) → [MSP Deployment Guide](docs/examples/msp-deployment.md) → [Fleet / governance docs](docs/agents/operations/)
-- **Builder / Accelerator:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Secure Secret Management](docs/tool-usages/secure-secret-management.md) → [Agentic Local Workspaces](docs/tool-usages/agentic-local-workspaces.md) → [Google Local Workspace](docs/tool-usages/google-local-workspace.md), [Claude Code Local Workspace](docs/tool-usages/claude-code-local-workspace.md), or [OpenAI Codex Local Workspace](docs/tool-usages/openai-codex-local-workspace.md) → [Google Workspace For Agentic Clients](docs/mcp-setup/google-workspace-agentic-clients.md) or [Microsoft 365 For Agentic Clients](docs/mcp-setup/microsoft-365-agentic-clients.md) → [Gemini Workspace Quickstart](docs/tool-usages/gemini-workspace-quickstart.md) or [n8n Google Workspace Quickstart](docs/examples/n8n-google-workspace-quickstart.md) → [Builder First 30 Minutes](docs/examples/builder-first-30-minutes.md) → [Docker Agent Home](docs/examples/docker-agent-home.md) → [Orchestrator Runtime Contract](docs/tool-usages/orchestrator-runtime-contract.md)
+- **Builder / Accelerator:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Secure Secret Management](docs/tool-usages/secure-secret-management.md) → [Agentic Local Workspaces](docs/tool-usages/agentic-local-workspaces.md) → [Google Local Workspace](docs/tool-usages/google-local-workspace.md), [Claude Code Local Workspace](docs/tool-usages/claude-code-local-workspace.md), or [OpenAI Codex Local Workspace](docs/tool-usages/openai-codex-local-workspace.md) → [Google Workspace For Agentic Clients](docs/mcp-setup/google-workspace-agentic-clients.md) or [Microsoft 365 For Agentic Clients](docs/mcp-setup/microsoft-365-agentic-clients.md) → [Value Lenses](docs/frameworks/value-lenses.md) → [Gemini Workspace Quickstart](docs/tool-usages/gemini-workspace-quickstart.md) or [n8n Google Workspace Quickstart](docs/examples/n8n-google-workspace-quickstart.md) → [Builder First 30 Minutes](docs/examples/builder-first-30-minutes.md) → [Docker Agent Home](docs/examples/docker-agent-home.md) → [Orchestrator Runtime Contract](docs/tool-usages/orchestrator-runtime-contract.md)
 
 ## Table of Contents
 
@@ -84,7 +86,9 @@ When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-
 | MCP protocol definitions | `mcp-protocols/` | Behavioral rules for 16 tool integrations (Google Workspace, Slack, GitHub, n8n, etc.) |
 | Deployment examples | `examples/` | Docker Compose stacks, workflow templates, and testing suites |
 | Documentation | `docs/` | Framework docs, setup guides, agent-specific documentation |
+| Visual guides | `docs/visuals/` | Mermaid system maps, onboarding diagrams, and workshop-friendly mental models |
 | Operating profiles | `operating-profiles/` | Localized language, regional, and audience overlays for culturally grounded agent execution |
+| Value lenses | `value-lenses/` | Explicit success criteria and tradeoff overlays for comparing outcomes under different enterprise logics |
 | Build scripts | `scripts/` | Context generation, repo auditing, retry helpers, and environment verification |
 | Test harness | `tests/`, `package.json` | Built-in Node contract, golden fixture, example smoke, and Docker e2e tests |
 | Runtime diagnostics | `test-artifacts/docker-smoke/` | Failure artifacts emitted by Docker smoke verification on real hosts and in CI |
@@ -125,7 +129,8 @@ When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-
 │   ├── GOVERNANCE.md                # AI TRiSM and Red Teaming protocols
 │   ├── PHASE_ZERO_SECURITY_BASELINE.md # Client-side cybersecurity grounding guide
 │   ├── REQUIREMENTS.md              # Project requirements and drift tracking
-│   ├── frameworks/                  # Meta-frameworks such as localized operating profiles
+│   ├── frameworks/                  # Meta-frameworks such as localized operating profiles and value lenses
+│   ├── visuals/                     # Visual system maps, runtime flows, and onboarding diagrams
 │   ├── phase-zero-assessment/       # Consent, findings, roadmap, and readiness kit
 │   ├── agents/                      # Per-agent documentation (mirrors agents/)
 │   ├── examples/                    # Deployment guides (MSP, RFP responder, etc.)
@@ -133,6 +138,7 @@ When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-
 │   └── lifecycle/                   # 4D Framework lifecycle documentation
 │
 ├── operating-profiles/              # Localized workstyle overlays and templates
+├── value-lenses/                    # Explicit success-criteria overlays and templates
 │
 ├── examples/                        # Deployable examples
 │   ├── docker/                      # Docker sandbox with pgvector memory
@@ -498,6 +504,7 @@ All documentation lives in `docs/`. Here's where to find what:
 | Phase 0 assessment kit | [`docs/phase-zero-assessment/README.md`](docs/phase-zero-assessment/README.md) |
 | Builder onboarding walkthrough | [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md) |
 | Builder-facing Docker home guide | [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md) |
+| Visual orientation maps | [`docs/visuals/README.md`](docs/visuals/README.md) |
 | How to create a new agent | [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md) |
 | The 4D Framework methodology | [`docs/METHODOLOGY.md`](docs/METHODOLOGY.md) |
 | Governance and compliance | [`docs/GOVERNANCE.md`](docs/GOVERNANCE.md) |

--- a/docs/PROJECT_REFERENCE.md
+++ b/docs/PROJECT_REFERENCE.md
@@ -6,6 +6,8 @@
 
 This document is the canonical public reference for Project NoéMI. It introduces the project's philosophy, framework, curriculum, and technology stack, and serves as a guide to the other documents in this repository.
 
+Readers who want the fastest structural overview should start with the visual set in [`docs/visuals/`](visuals/).
+
 ---
 
 ## Table of Contents
@@ -465,6 +467,7 @@ This document serves as the entry point to the NoéMI Agents Library. Below is a
 | [`docs/AGENT_TEMPLATE.md`](AGENT_TEMPLATE.md) | Canonical template for all agent specifications |
 | [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](PHASE_ZERO_SECURITY_BASELINE.md) | Client-side guide to grounding cybersecurity before advanced AI work |
 | [`docs/phase-zero-assessment/`](phase-zero-assessment/) | Assessment kit: consent, findings, roadmap, and readiness rubric |
+| [`docs/visuals/`](visuals/) | Visual system map, audience entry map, runtime flow, and workshop mind map |
 
 ### Agent Documentation
 
@@ -485,6 +488,7 @@ This document serves as the entry point to the NoéMI Agents Library. Below is a
 | --- | --- |
 | [`docs/lifecycle/`](lifecycle/) | The 4D lifecycle documents (Delegation, Description, Discernment, Diligence) |
 | [`docs/frameworks/gartner-trism.md`](frameworks/gartner-trism.md) | Gartner AI TRiSM framework reference |
+| [`docs/frameworks/value-lenses.md`](frameworks/value-lenses.md) | Explicit success-criteria overlays for comparing outcomes under different enterprise logics |
 | [`docs/mcp-setup/`](mcp-setup/) | MCP server setup guides (Google Workspace, n8n, Slack, Web Search) |
 | [`docs/tool-usages/`](tool-usages/) | Tool-specific guides and integration patterns |
 | [`docs/examples/`](examples/) | Example implementations (Docker sandbox, RFP Responder, Video Automation) |

--- a/docs/examples/builder-first-30-minutes.md
+++ b/docs/examples/builder-first-30-minutes.md
@@ -11,6 +11,8 @@ Read these two guides first:
 1. [`../tool-usages/secure-secret-management.md`](../tool-usages/secure-secret-management.md)
 2. [`docker-agent-home.md`](docker-agent-home.md)
 3. [`../tool-usages/orchestrator-runtime-contract.md`](../tool-usages/orchestrator-runtime-contract.md)
+4. Choose one implementation path:
+   [`../tool-usages/gemini-workspace-quickstart.md`](../tool-usages/gemini-workspace-quickstart.md) for human-led Gemini CLI work or [`n8n-google-workspace-quickstart.md`](n8n-google-workspace-quickstart.md) for event-driven automation
 
 Those explain the security contract, the shape of the Docker home you are about to launch, and the runtime responsibilities your orchestrator must own.
 

--- a/docs/examples/builder-first-30-minutes.md
+++ b/docs/examples/builder-first-30-minutes.md
@@ -6,12 +6,14 @@ It does not turn Project NoeMI into a runtime engine. It shows how to validate t
 
 ## Before You Start
 
-Read these two guides first:
+Read these guides first:
 
 1. [`../tool-usages/secure-secret-management.md`](../tool-usages/secure-secret-management.md)
 2. [`docker-agent-home.md`](docker-agent-home.md)
 3. [`../tool-usages/orchestrator-runtime-contract.md`](../tool-usages/orchestrator-runtime-contract.md)
-4. Choose one implementation path:
+4. Read the local-workspace overview:
+   [`../tool-usages/agentic-local-workspaces.md`](../tool-usages/agentic-local-workspaces.md)
+5. Choose one implementation path:
    [`../tool-usages/gemini-workspace-quickstart.md`](../tool-usages/gemini-workspace-quickstart.md) for human-led Gemini CLI work or [`n8n-google-workspace-quickstart.md`](n8n-google-workspace-quickstart.md) for event-driven automation
 
 Those explain the security contract, the shape of the Docker home you are about to launch, and the runtime responsibilities your orchestrator must own.

--- a/docs/examples/n8n-google-workspace-quickstart.md
+++ b/docs/examples/n8n-google-workspace-quickstart.md
@@ -1,0 +1,122 @@
+# n8n + Google Workspace Quickstart
+
+This is the supported path for repeatable, event-driven workflows that use Google Workspace and Gemini inside n8n.
+
+Use this guide when you want:
+
+- Gmail-triggered workflows
+- Google Docs or Sheets updates inside a workflow
+- recurring or webhook-driven automations
+- human approval gates before sending, writing, or mutating data
+
+This path uses **n8n credentials**, not the Gemini CLI Workspace extension.
+
+If you want ad-hoc human-led work in the terminal, use [`../tool-usages/gemini-workspace-quickstart.md`](../tool-usages/gemini-workspace-quickstart.md) instead.
+
+## Recommended Starting Shape
+
+Start with one event source, one Gemini classification step, one Google Workspace write, and one human-reviewed action.
+
+That is exactly the shape shown by:
+
+- [`../../examples/workflows/rfp-responder.json`](../../examples/workflows/rfp-responder.json)
+- [`rfp-responder.md`](rfp-responder.md)
+
+## Prerequisites
+
+- an n8n instance
+- Google Workspace access for the Google nodes you plan to use
+- a Google Gemini API credential in n8n for the Gemini model node
+- a clear human-approval boundary for any mutating action
+
+If you also want to manage workflows through the n8n API, you additionally need the n8n API enabled and an API key. That is a separate concern from Gmail, Docs, Sheets, and Gemini node credentials.
+
+## Credentials You Usually Need
+
+For a Gmail-to-Docs flow like the RFP responder, expect at least:
+
+- Gmail credential in n8n
+- Google Docs credential in n8n
+- Google Gemini credential in n8n
+
+For spreadsheet-driven work, add:
+
+- Google Sheets credential in n8n
+
+For a full matrix of which credential surface applies where, use [`../mcp-setup/google-n8n-credential-matrix.md`](../mcp-setup/google-n8n-credential-matrix.md).
+
+## Step 1: Import the Reference Workflow
+
+Import [`../../examples/workflows/rfp-responder.json`](../../examples/workflows/rfp-responder.json) into n8n.
+
+This example uses:
+
+- `n8n-nodes-base.gmailTrigger`
+- `@n8n/n8n-nodes-langchain.googleGemini`
+- `n8n-nodes-base.if`
+- `n8n-nodes-base.googleDocs`
+- `n8n-nodes-base.gmail`
+
+## Step 2: Replace the Placeholder Credentials
+
+The workflow JSON contains obvious placeholder credential IDs and names where applicable. Replace them with credentials from your own n8n instance before activating the workflow.
+
+At minimum, check:
+
+- Gmail Trigger node
+- Analyze Request (Gemini) node
+- Draft Gmail Reply node
+- Create Google Doc node
+
+## Step 3: Validate the Workflow Shape in n8n
+
+Before activating:
+
+- confirm the Gmail trigger can load labels
+- confirm the Gemini node can see the intended model
+- confirm the Google Docs node can create a test document
+- confirm the final Gmail node creates a **draft**, not a sent message
+
+## Step 4: Keep the Persona Context Narrow
+
+Do not paste the entire generated `GEMINI.md` into an n8n system prompt.
+
+Instead:
+
+- use the repository personas as design guidance
+- extract only the minimal prompt text the node needs for the task
+- keep the node prompt focused on one outcome and one JSON shape
+
+This reduces token bloat and makes node behavior easier to debug.
+
+## Step 5: Add Human Approval at the Last Mutating Step
+
+The default safe pattern is:
+
+1. classify with Gemini
+2. write a Google Doc draft or structured record
+3. create a Gmail draft or queue a review task
+4. let a human approve the final outbound action
+
+Do not start with fully autonomous send flows.
+
+## Common Mistakes
+
+- assuming the n8n API key configures Gmail, Docs, or Gemini nodes
+- assuming Gemini CLI Workspace auth carries over into n8n
+- using service accounts without configuring impersonation where Gmail access is required
+- using outdated Gemini node types from older examples
+- putting too much persona text into the Gemini node prompt
+
+## Good First Workflow Types
+
+- Gmail triage with draft creation
+- Drive or Docs summarization for internal knowledge work
+- Sheets append/update workflows with human review before outbound messaging
+
+## Related Guides
+
+- [`rfp-responder.md`](rfp-responder.md)
+- [`../mcp-setup/n8n.md`](../mcp-setup/n8n.md)
+- [`../mcp-setup/google-n8n-credential-matrix.md`](../mcp-setup/google-n8n-credential-matrix.md)
+- [`../tool-usages/gemini-workspace-quickstart.md`](../tool-usages/gemini-workspace-quickstart.md)

--- a/docs/examples/rfp-responder.md
+++ b/docs/examples/rfp-responder.md
@@ -1,6 +1,6 @@
 # End-to-End Example: Autonomous RFP/RFQ Responder
 
-This guide walks you through deploying an end-to-end event-driven agent workflow using **n8n**, **Gmail**, **Google Docs**, and the **Gemini LLM**.
+This guide walks you through deploying an end-to-end event-driven agent workflow using **n8n**, **Gmail**, **Google Docs**, and the **Google Gemini node**.
 
 ## The Scenario
 Your organization frequently receives Requests for Proposals (RFPs) and Requests for Quotes (RFQs) via email. Reviewing these, extracting the requirements, and setting up the initial draft documents takes valuable human time. 
@@ -17,10 +17,13 @@ We will deploy an agentic workflow that:
 
 ## Prerequisites
 1.  An active instance of **n8n** (Cloud or Self-Hosted).
-2.  Google Workspace Credentials configured in n8n for:
+2.  Google Workspace credentials configured in n8n for:
     *   **Gmail API** (Read and Compose Drafts)
     *   **Google Docs API** (Create Documents)
-3.  A Gemini API Key configured in n8n.
+3.  A Google Gemini credential configured in n8n.
+4.  Review the credential split first:
+    *   [`n8n-google-workspace-quickstart.md`](n8n-google-workspace-quickstart.md)
+    *   [`../mcp-setup/google-n8n-credential-matrix.md`](../mcp-setup/google-n8n-credential-matrix.md)
 
 ---
 
@@ -43,9 +46,9 @@ Once imported, you will see a visual representation of the **Delegation** phase 
 This node acts as the **Event-Driven Trigger**. It polls the authenticated Gmail account every minute for any new, unread emails. When one arrives, it pushes the email payload down the pipeline.
 
 ### 2. Analyze Request (Gemini)
-This is where the synthetic intelligence acts. It uses a LangChain LLM node powered by Gemini. 
+This is where the synthetic intelligence acts. It uses the current n8n Google Gemini node. 
 *   **The System Prompt:** We inject instructions telling the model to act as a triage agent. It reads the email body and is strictly instructed to return structured JSON containing an `is_rfp_rfq` boolean, a `summary`, `requirements`, and a `deadline`.
-*   *Note: In a production environment, you would use `generate_gemini.js` to build a robust context file and inject it into this node's System Message parameter.*
+*   *Note: In a production environment, use the repo personas as design input, but keep the node prompt narrowly scoped instead of pasting all of `GEMINI.md` into the workflow.*
 
 ### 3. Is RFP/RFQ? (IF Router)
 This node parses the JSON returned by Gemini. 
@@ -64,7 +67,7 @@ Instead, it uses the Gmail API to create a **Draft** reply to the original sende
 
 ## Step 3: Activate and Test
 
-1.  Open the credentials for the Gmail, Google Docs, and Gemini nodes and link them to your authenticated accounts.
+1.  Replace the placeholder credential IDs in [`../../examples/workflows/rfp-responder.json`](../../examples/workflows/rfp-responder.json) and link the Gmail, Google Docs, and Gemini nodes to your authenticated accounts.
 2.  Click the **Test Workflow** button in n8n.
 3.  Send an email to your connected Gmail account with a subject like "RFP: Enterprise Software Overhaul" and a body detailing some software requirements and a deadline.
 4.  Watch the workflow execute! Within a minute, you should see a new Google Doc appear in your Drive, and a Draft reply sitting in your Gmail outbox.

--- a/docs/frameworks/localized-operating-profiles.md
+++ b/docs/frameworks/localized-operating-profiles.md
@@ -34,6 +34,8 @@ A localized operating profile defines **how that work should be carried out for 
 
 Keep those layers separate.
 
+For explicit success criteria and tradeoff logic, use the separate Value Lens layer described in [value-lenses.md](value-lenses.md).
+
 ## Recommended Layering Model
 
 Use inheritance from broad to specific:
@@ -135,6 +137,17 @@ The agent should receive:
 
 The operating profile should refine execution style, not replace the core role.
 
+Operating profiles answer:
+
+- how do we work here?
+
+They do not answer:
+
+- what counts as success overall?
+- which tradeoffs should dominate?
+
+Those belong in Value Lenses.
+
 ## Governance Rules
 
 - every profile needs an evidence source
@@ -168,3 +181,4 @@ But only after the content is reviewed by local operators who can separate real 
 
 - [`../../operating-profiles/README.md`](../../operating-profiles/README.md)
 - [`../../operating-profiles/PROFILE_TEMPLATE.md`](../../operating-profiles/PROFILE_TEMPLATE.md)
+- [`value-lenses.md`](value-lenses.md)

--- a/docs/frameworks/localized-operating-profiles.md
+++ b/docs/frameworks/localized-operating-profiles.md
@@ -1,0 +1,170 @@
+# Localized Operating Profiles
+
+Project NoeMI needs a way to adapt agent work across languages, regions, subregions, and local business customs without collapsing everything into simple translation.
+
+This document defines that layer as **Localized Operating Profiles**.
+
+## Why This Is Needed
+
+A translated answer can still feel wrong locally.
+
+Examples:
+
+- the expected level of directness can differ by region
+- meeting cadence and response timing can differ inside the same country
+- trust signals, formality, and escalation norms can differ by industry or geography
+- the same task can require different documentation depth or handoff style depending on local practice
+
+That means the adaptation layer should not only ask:
+
+- what language should the agent use?
+
+It should also ask:
+
+- how is this work normally performed here?
+- what tone earns trust in this region?
+- what level of initiative is expected before escalation?
+- what local compliance, etiquette, and review norms matter?
+
+## Core Principle
+
+An agent persona defines **what the role does**.
+
+A localized operating profile defines **how that work should be carried out for a specific local context**.
+
+Keep those layers separate.
+
+## Recommended Layering Model
+
+Use inheritance from broad to specific:
+
+1. language family
+2. country or national market
+3. subregion or city cluster
+4. industry or sector overlay
+5. audience overlay
+
+Examples:
+
+- `fr` -> shared French-language conventions
+- `fr/fr-fr` -> France-wide conventions
+- `fr/fr-fr/north` -> northern France subregional overlay
+- `fr/fr-fr/south` -> southern France subregional overlay
+- `fr/fr-fr/healthcare` -> French healthcare overlay
+- `fr/fr-fr/north/executive-buyers` -> audience-specific overlay
+
+## What Belongs In A Profile
+
+- language and register
+- formality and politeness norms
+- decision-making and escalation expectations
+- documentation depth and evidence expectations
+- meeting and scheduling norms
+- response-time expectations
+- trust signals and phrases to prefer
+- phrases, framing, or approaches to avoid
+- local regulatory or compliance notes when they affect execution
+
+## What Does Not Belong In A Profile
+
+- stereotypes presented as facts
+- unsupported assumptions about competence, seniority, or personality
+- inferred identity attributes
+- raw secrets, customer data, or protected personal information
+
+## Gender And Identity Differences
+
+This is the most sensitive part of the design.
+
+Project NoeMI should **not** create default agent variants based on inferred gender.
+
+If identity-aware adaptation is ever needed, it should be handled as:
+
+- an explicit audience preference
+- a clearly documented communications requirement
+- a locally validated convention
+- an opt-in overlay, not a hidden default
+
+Safe examples:
+
+- a customer explicitly requests inclusive French forms for a community program
+- a local campaign requires a women-founder audience lens that has been reviewed by a human operator
+
+Unsafe examples:
+
+- assuming a different work style because the audience is male or female
+- changing authority, empathy, assertiveness, or competence based on gender
+
+## Recommended Repo Structure
+
+```text
+operating-profiles/
+├── README.md
+├── PROFILE_TEMPLATE.md
+├── fr/
+│   └── fr-fr/
+│       ├── core.md
+│       ├── north.md
+│       └── south.md
+└── en/
+    └── en-us/
+        └── core.md
+```
+
+The profile files can start as Markdown. If the repo later needs machine-readable routing, a small metadata header can be added on top.
+
+## Recommended Metadata Fields
+
+- `language`
+- `locale`
+- `subregion`
+- `sector`
+- `audience`
+- `inherits`
+- `evidence_sources`
+- `last_validated_on`
+- `validated_by`
+
+## Activation Model
+
+The agent should receive:
+
+1. the base persona
+2. the relevant tools and protocols
+3. the selected operating profile
+
+The operating profile should refine execution style, not replace the core role.
+
+## Governance Rules
+
+- every profile needs an evidence source
+- every profile needs a validation owner
+- every profile should distinguish hard requirements from preferences
+- subregional overlays should be additive and minimal
+- profiles should be reviewed by someone grounded in that local context
+
+## First Safe Rollout
+
+Start with:
+
+1. one language
+2. one national market
+3. one subregional difference
+4. one audience overlay
+
+Do not try to model the whole world at once.
+
+## Suggested First Pilot
+
+A safe first pilot could be:
+
+- `fr/fr-fr/core`
+- `fr/fr-fr/north`
+- `fr/fr-fr/south`
+
+But only after the content is reviewed by local operators who can separate real practice from stereotypes.
+
+## Related Files
+
+- [`../../operating-profiles/README.md`](../../operating-profiles/README.md)
+- [`../../operating-profiles/PROFILE_TEMPLATE.md`](../../operating-profiles/PROFILE_TEMPLATE.md)

--- a/docs/frameworks/value-lenses.md
+++ b/docs/frameworks/value-lenses.md
@@ -1,0 +1,187 @@
+# Value Lenses
+
+Project NoeMI needs a way to evaluate work through more than one success logic without embedding that logic invisibly into every agent.
+
+This document defines that layer as **Value Lenses**.
+
+## Why This Is Needed
+
+Two teams can look at the same output and disagree honestly because they are optimizing for different things.
+
+One team may reward:
+
+- speed
+- throughput
+- efficiency
+- measurable output
+- short-cycle gains
+
+Another team may reward:
+
+- continuity
+- sustainability
+- care
+- relational stability
+- long-term habitability
+
+Both may be rational within their own frame.
+
+The system needs a clean way to say:
+
+- what counts as success here?
+- whose benefit is being counted?
+- what time horizon matters?
+- what tradeoffs are acceptable?
+
+## Core Principle
+
+An agent persona defines **what role is acting**.
+
+An operating profile defines **how the work should be carried out in a local context**.
+
+A value lens defines **how success and tradeoffs should be judged**.
+
+Keep those layers separate.
+
+## Why Not Use Gendered Operational Labels
+
+Some of the background scholarship that inspires this distinction contrasts different civilizational or ethical logics, including highly gendered language.
+
+For enterprise implementation, Project NoeMI should use **neutral operational names**.
+
+Reason:
+
+- it avoids turning a governance tool into a cultural fight
+- it avoids stereotyping or essentializing people
+- it keeps the implementation reviewable by business, legal, and HR stakeholders
+
+That means the implementation can preserve the conceptual distinction without saying:
+
+- men evaluate like this
+- women evaluate like that
+
+## Recommended Starter Lenses
+
+### 1. Performance-Efficiency Lens
+
+Optimizes for:
+
+- speed
+- cost discipline
+- throughput
+- predictability
+- clear measurable output
+
+### 2. Care-Continuity Lens
+
+Optimizes for:
+
+- long-term sustainability
+- relational health
+- human impact
+- continuity
+- habitability and trust
+
+### 3. Balanced-Enterprise Lens
+
+Optimizes for:
+
+- practical business viability
+- human and organizational sustainability
+- acceptable pace and efficiency without degrading the system that must live with the result
+
+## What Belongs In A Value Lens
+
+- success criteria
+- stakeholders counted
+- time horizon
+- acceptable tradeoffs
+- evidence required
+- common blind spots
+- failure modes
+- questions the lens asks first
+
+## What Does Not Belong In A Value Lens
+
+- stereotypes about identity groups
+- hidden moral assumptions with no explicit review
+- local language or register rules that belong in operating profiles
+- role-specific process steps that belong in agent personas
+
+## Recommended Repo Structure
+
+```text
+value-lenses/
+├── README.md
+├── LENS_TEMPLATE.md
+├── performance-efficiency.md
+├── care-continuity.md
+└── balanced-enterprise.md
+```
+
+## Activation Model
+
+The agent should receive:
+
+1. the base persona
+2. the relevant tools and protocols
+3. the selected operating profile, if any
+4. the selected value lens
+
+The value lens should refine the definition of success, not replace the role.
+
+## Selection Rules
+
+- the lens should be explicit
+- the lens should be human-selected for high-stakes work
+- the lens should never be silently inferred from gender or identity
+- if no lens is chosen, default to a documented enterprise baseline
+
+## Comparison Mode
+
+The safest first implementation pattern is **comparison mode**.
+
+That means the agent can:
+
+1. propose one or more options
+2. score them under multiple lenses
+3. explain where the lenses agree
+4. explain where the lenses conflict
+
+This is safer than silently optimizing for one value system.
+
+## Governance Rules
+
+- every lens needs an owner
+- every lens needs explicit success dimensions
+- every lens needs failure modes
+- high-stakes use should show the active lens in the audit trail
+- a lens must never be hidden when it materially changes recommendations
+
+## First Safe Rollout
+
+Start with:
+
+1. one template
+2. three starter lenses
+3. one example comparison workflow
+
+Do not start with dozens of lenses.
+
+## Relationship To Operating Profiles
+
+Operating profiles answer:
+
+- how do we work here?
+
+Value lenses answer:
+
+- what does good mean here?
+
+Both can be active at the same time, but they solve different problems.
+
+## Related Files
+
+- [`../../value-lenses/README.md`](../../value-lenses/README.md)
+- [`../../value-lenses/LENS_TEMPLATE.md`](../../value-lenses/LENS_TEMPLATE.md)
+- [`localized-operating-profiles.md`](localized-operating-profiles.md)

--- a/docs/mcp-setup/README.md
+++ b/docs/mcp-setup/README.md
@@ -9,7 +9,9 @@ Developer-facing setup guides for configuring MCP (Model Context Protocol) integ
 | Guide | Covers | Protocol Files |
 |-------|--------|----------------|
 | [Google Workspace](google-workspace.md) | Gmail, Calendar, Chat, Contacts, Docs, Drive, Forms, Keep, Meet, Sheets, Slides, Admin | `mcp-protocols/gmail.md`, `mcp-protocols/google-calendar.md`, `mcp-protocols/google-chat.md`, `mcp-protocols/google-contacts.md`, `mcp-protocols/google-docs.md`, `mcp-protocols/google-drive.md`, `mcp-protocols/google-forms.md`, `mcp-protocols/google-keep.md`, `mcp-protocols/google-meet.md`, `mcp-protocols/google-sheets.md`, `mcp-protocols/google-slides.md`, `mcp-protocols/google-admin.md` |
+| [Google Workspace For Agentic Clients](google-workspace-agentic-clients.md) | How Gemini CLI, Antigravity, Codex, and Claude Code connect to Google Workspace | Cross-cutting guide |
 | [Google + n8n Credential Matrix](google-n8n-credential-matrix.md) | How Gemini CLI, generic Google MCP auth, n8n Google nodes, and n8n Gemini credentials differ | Cross-cutting guide |
+| [Microsoft 365 For Agentic Clients](microsoft-365-agentic-clients.md) | How Gemini CLI, Antigravity, Codex, and Claude Code connect to Microsoft 365 / Office 365 | Cross-cutting guide |
 | [Slack](slack.md) | Slack workspace integration | `mcp-protocols/slack.md` |
 | [n8n](n8n.md) | n8n workflow orchestrator | `mcp-protocols/n8n.md` |
 | [Web Search](web-search.md) | Built-in web_fetch / web_search | `mcp-protocols/web-search.md` |

--- a/docs/mcp-setup/README.md
+++ b/docs/mcp-setup/README.md
@@ -9,6 +9,7 @@ Developer-facing setup guides for configuring MCP (Model Context Protocol) integ
 | Guide | Covers | Protocol Files |
 |-------|--------|----------------|
 | [Google Workspace](google-workspace.md) | Gmail, Calendar, Chat, Contacts, Docs, Drive, Forms, Keep, Meet, Sheets, Slides, Admin | `mcp-protocols/gmail.md`, `mcp-protocols/google-calendar.md`, `mcp-protocols/google-chat.md`, `mcp-protocols/google-contacts.md`, `mcp-protocols/google-docs.md`, `mcp-protocols/google-drive.md`, `mcp-protocols/google-forms.md`, `mcp-protocols/google-keep.md`, `mcp-protocols/google-meet.md`, `mcp-protocols/google-sheets.md`, `mcp-protocols/google-slides.md`, `mcp-protocols/google-admin.md` |
+| [Google + n8n Credential Matrix](google-n8n-credential-matrix.md) | How Gemini CLI, generic Google MCP auth, n8n Google nodes, and n8n Gemini credentials differ | Cross-cutting guide |
 | [Slack](slack.md) | Slack workspace integration | `mcp-protocols/slack.md` |
 | [n8n](n8n.md) | n8n workflow orchestrator | `mcp-protocols/n8n.md` |
 | [Web Search](web-search.md) | Built-in web_fetch / web_search | `mcp-protocols/web-search.md` |

--- a/docs/mcp-setup/google-n8n-credential-matrix.md
+++ b/docs/mcp-setup/google-n8n-credential-matrix.md
@@ -1,0 +1,101 @@
+# Google Workspace + n8n Credential Matrix
+
+This guide exists because "Google Workspace integration" means different things in different runtimes.
+
+Project NoeMI currently supports three distinct patterns:
+
+1. Gemini CLI using the Google Workspace extension
+2. generic or self-hosted Google Workspace MCP servers using `GOOGLE_*` environment variables
+3. n8n workflows using built-in Google nodes plus a separate Gemini credential
+
+Do not mix these up. They are the main source of failed first implementations.
+
+## Credential Matrix
+
+| Runtime surface | Use this when | Credential model | Where credentials live | Common gotcha |
+|---|---|---|---|---|
+| Gemini CLI + Workspace extension | Human-led terminal work | Google account login via the extension | Gemini CLI extension auth state | Setting `GOOGLE_CLIENT_ID` does not configure this path |
+| Generic Google Workspace MCP server | Custom or self-hosted MCP server runtime | OAuth client + refresh token or service account | Vault-injected `GOOGLE_*` env vars | Works for your MCP server, but not automatically for Gemini CLI or n8n |
+| n8n Gmail / Docs / Drive / Sheets nodes | Repeatable workflow automation | n8n Google credential(s) | n8n credential store | n8n API key does not configure these nodes |
+| n8n Google Gemini node | Gemini in an n8n workflow | n8n Gemini API credential | n8n credential store | Gemini credential is separate from Gmail/Docs/Drive credentials |
+| n8n API access | Workflow management through API | n8n API key | Vault + runtime env vars | Public API availability depends on your n8n plan/setup |
+
+## Decision Rule
+
+Use this shortcut:
+
+- **Need ad-hoc human work in the terminal?** Use [`../tool-usages/gemini-workspace-quickstart.md`](../tool-usages/gemini-workspace-quickstart.md).
+- **Need recurring or event-driven automation?** Use [`../examples/n8n-google-workspace-quickstart.md`](../examples/n8n-google-workspace-quickstart.md).
+- **Need a custom MCP server runtime outside both of those?** Use [`google-workspace.md`](google-workspace.md).
+
+## Minimum Credential Sets by Workflow Type
+
+### Gmail triage in n8n
+
+- Gmail credential
+- Google Gemini credential
+
+### Gmail triage plus Google Doc output
+
+- Gmail credential
+- Google Docs credential
+- Google Gemini credential
+
+### Sheets enrichment workflow
+
+- Google Sheets credential
+- optional Gmail credential
+- Google Gemini credential if the flow uses AI classification or generation
+
+### Gemini CLI Workspace exploration
+
+- Gemini CLI Workspace extension login only
+
+## Troubleshooting
+
+### "Gemini CLI can access Drive, but n8n cannot"
+
+These are different auth surfaces. Your Gemini CLI Workspace extension login does not configure n8n credentials.
+
+### "My `GOOGLE_CLIENT_ID` and `GOOGLE_REFRESH_TOKEN` are set, but Gemini CLI still can't use Gmail"
+
+Those variables are for a generic MCP server path. Gemini CLI's Workspace extension uses its own auth flow.
+
+### "The n8n Gmail node says 'Forbidden - perhaps check your credentials?'"
+
+This often happens when:
+
+- the Gmail API is not enabled
+- the granted scopes are incomplete
+- a service account is being used without impersonation where Gmail access is required
+
+### "The n8n Gmail node returns `unauthorized_client`"
+
+Check:
+
+- the correct Google API is enabled
+- the right scopes are granted
+- domain-wide delegation is configured if you are using a service account for user mailboxes
+
+### "The Gemini model node works, but Gmail or Docs does not"
+
+That usually means your Gemini credential is fine but your Google Workspace node credentials are not. Treat them as separate setups.
+
+### "The n8n API check fails, but the workflow editor works"
+
+The n8n API key path is separate from node credentials and may also depend on your plan or instance settings.
+
+### "Service account auth works for Drive or Sheets, but not for Gmail"
+
+Gmail is stricter. If you are automating mailbox access with a service account, you usually need domain-wide delegation and impersonation configured correctly.
+
+## Recommended Starting Point
+
+For most first implementations:
+
+1. prove the Google surface manually in Gemini CLI
+2. move one narrow use case into n8n
+3. keep the last mutating action human-reviewed
+4. only then expand the workflow surface
+
+That sequence is more reliable than trying to stand up full Gmail + Docs + Sheets + Gemini automation on day one.

--- a/docs/mcp-setup/google-workspace-agentic-clients.md
+++ b/docs/mcp-setup/google-workspace-agentic-clients.md
@@ -1,0 +1,140 @@
+# Google Workspace For Agentic Clients
+
+This guide explains how to connect Google Workspace to the main local agentic clients used in Project NoeMI:
+
+- Gemini CLI
+- Antigravity, Google's IDE-style Gemini workspace layer
+- OpenAI Codex
+- Claude Code app
+- Claude Code CLI
+
+The important point is that **Google Workspace does not look the same in every client**.
+
+## Fast Decision Rule
+
+| Client | Preferred Path | Why |
+|------|----------------|-----|
+| Gemini CLI | Official Google Workspace extension | This is the cleanest first-party Google path |
+| Antigravity | Follow the same Google account and Gemini setup discipline as Gemini CLI | Treat Gemini CLI as the setup anchor |
+| OpenAI Codex | MCP server | Codex is strongest when Google access is exposed through MCP |
+| Claude Code app | MCP server | Durable and team-repeatable |
+| Claude Code CLI | MCP server | Most explicit and scriptable path |
+
+## Shared Security Rule
+
+Do not paste Google OAuth secrets or refresh tokens into saved client config.
+
+If the Google connection depends on a custom MCP server, register the **wrapper command**, not the secret itself.
+
+Safe pattern:
+
+```bash
+op run --env-file=.env.template -- node path/to/google-workspace-mcp.js
+```
+
+Unsafe pattern:
+
+- storing `GOOGLE_CLIENT_SECRET` directly in a local config file
+- hardcoding bearer tokens in headers that get saved to disk
+
+## Gemini CLI
+
+For direct Google Workspace access, use the official Workspace extension:
+
+```bash
+gemini extensions install https://github.com/gemini-cli-extensions/workspace
+gemini
+```
+
+Then complete the normal Google sign-in flow.
+
+Use this path when you want:
+
+- Drive search
+- Docs summarization
+- Gmail and Calendar assistance
+- human-led local work
+
+If you need a **custom** Google Workspace MCP server instead of the official extension:
+
+```bash
+gemini mcp add googleWorkspace -- op run --env-file=.env.template -- node path/to/google-workspace-mcp.js
+```
+
+## Antigravity
+
+Treat Antigravity as the visual Google workspace layer on top of Gemini habits.
+
+Recommended pattern:
+
+1. Validate the Google connection in Gemini CLI first.
+2. Confirm the correct Workspace account is in use.
+3. Reuse the same extension and MCP discipline when working in Antigravity.
+
+That reduces the chance that a builder trusts a visual surface whose underlying auth state they do not actually understand.
+
+## OpenAI Codex
+
+Codex uses the MCP path for Google Workspace work:
+
+```bash
+codex mcp add googleWorkspace -- op run --env-file=.env.template -- node path/to/google-workspace-mcp.js
+```
+
+For HTTP MCP servers:
+
+```bash
+codex mcp add googleWorkspace --url https://your-google-mcp.example.com/mcp
+```
+
+Validate with a low-risk read first:
+
+- list a Drive file
+- read a document title
+- inspect calendar availability without writing changes
+
+## Claude Code App
+
+The durable setup path is still to register the server explicitly, then use the app as the interactive surface.
+
+Example:
+
+```bash
+claude mcp add googleWorkspace -- op run --env-file=.env.template -- node path/to/google-workspace-mcp.js
+```
+
+Once the server is registered and tested, use the app for co-work and review. Do not assume the app should be configured first just because it feels more approachable.
+
+## Claude Code CLI
+
+Claude Code CLI exposes the most explicit setup path:
+
+```bash
+claude mcp add googleWorkspace -- op run --env-file=.env.template -- node path/to/google-workspace-mcp.js
+```
+
+Or for an HTTP MCP endpoint:
+
+```bash
+claude mcp add --transport http googleWorkspace https://your-google-mcp.example.com/mcp
+```
+
+Keep verification simple:
+
+1. Read from Drive.
+2. Read from Docs or Calendar.
+3. Only then allow writes such as drafting or document creation.
+
+## Recommended Order
+
+1. Gemini CLI when Google Workspace is your main daily surface
+2. Antigravity for a more visual Google-side workflow
+3. Codex or Claude Code when Google must be one tool among several governed MCP integrations
+
+## Related Guides
+
+- [`../tool-usages/agentic-local-workspaces.md`](../tool-usages/agentic-local-workspaces.md)
+- [`../tool-usages/google-local-workspace.md`](../tool-usages/google-local-workspace.md)
+- [`../tool-usages/claude-code-local-workspace.md`](../tool-usages/claude-code-local-workspace.md)
+- [`../tool-usages/openai-codex-local-workspace.md`](../tool-usages/openai-codex-local-workspace.md)
+- [`google-workspace.md`](google-workspace.md)

--- a/docs/mcp-setup/google-workspace.md
+++ b/docs/mcp-setup/google-workspace.md
@@ -1,8 +1,17 @@
 # Google Workspace MCP Setup
 
-Covers setup for all 12 Google Workspace MCPs: Gmail, Calendar, Chat, Contacts, Docs, Drive, Forms, Keep, Meet, Sheets, Slides, and Admin.
+This guide covers the **generic Google Workspace MCP server pattern** for builders running a custom or self-hosted Google integration that expects `GOOGLE_*` environment variables.
 
-All Google MCPs share the same authentication and connection pattern — configure once, enable individually.
+It is **not** the primary setup guide for:
+
+- Gemini CLI with the official Workspace extension
+- n8n Google Workspace nodes
+
+Use these guides for those paths:
+
+- [`../tool-usages/gemini-workspace-quickstart.md`](../tool-usages/gemini-workspace-quickstart.md)
+- [`../examples/n8n-google-workspace-quickstart.md`](../examples/n8n-google-workspace-quickstart.md)
+- [`google-n8n-credential-matrix.md`](google-n8n-credential-matrix.md)
 
 ## Prerequisites
 
@@ -73,9 +82,8 @@ Scopes are configured per MCP. Enable only the scopes each agent needs (principl
 op run --env-file=.env.template -- node -e "
   console.log('Client ID:', process.env.GOOGLE_CLIENT_ID ? 'set' : 'MISSING');
   console.log('Client Secret:', process.env.GOOGLE_CLIENT_SECRET ? 'set' : 'MISSING');
+  console.log('Refresh Token:', process.env.GOOGLE_REFRESH_TOKEN ? 'set' : 'MISSING');
 "
-
-# Quick API smoke test (Gmail list labels)
-curl -s -H "Authorization: Bearer $(gcloud auth print-access-token)" \
-  "https://gmail.googleapis.com/gmail/v1/users/me/labels" | head -20
 ```
+
+After env injection is confirmed, start your chosen Google Workspace MCP server with those variables and validate one low-risk read operation first.

--- a/docs/mcp-setup/microsoft-365-agentic-clients.md
+++ b/docs/mcp-setup/microsoft-365-agentic-clients.md
@@ -1,0 +1,117 @@
+# Microsoft 365 For Agentic Clients
+
+This guide explains how to connect Microsoft 365, also commonly called Office 365, to the main local agentic clients used in Project NoeMI:
+
+- Gemini CLI
+- Antigravity, Google's IDE-style Gemini workspace layer
+- OpenAI Codex
+- Claude Code app
+- Claude Code CLI
+
+Unlike Gemini's first-party Google Workspace extension path, the Microsoft 365 story in this repository is standardized around **MCP servers**.
+
+## What "Microsoft 365" Usually Means Here
+
+Most teams want one or more of:
+
+- Outlook
+- OneDrive
+- SharePoint
+- Teams
+- directory and calendar access through Microsoft Graph
+
+## Shared Security Rule
+
+Do not store Microsoft tenant secrets, client secrets, or bearer tokens directly in saved local client config.
+
+Prefer wrapper-based MCP launches so Entra ID or Graph credentials are resolved only at runtime:
+
+```bash
+op run --env-file=.env.template -- node path/to/microsoft-365-mcp.js
+```
+
+## Common Prerequisites
+
+Before any client-specific setup:
+
+1. Register or obtain a Microsoft 365 / Graph-capable MCP server.
+2. Create the required Entra ID app registration or service principal.
+3. Grant only the minimum Graph scopes required.
+4. Verify the MCP server can perform one read-only action before enabling writes.
+
+## Gemini CLI
+
+Microsoft 365 in Gemini CLI is handled through MCP:
+
+```bash
+gemini mcp add microsoft365 -- op run --env-file=.env.template -- node path/to/microsoft-365-mcp.js
+```
+
+Use this path when Gemini is your preferred local shell but the business system is Microsoft-first.
+
+## Antigravity
+
+For Antigravity, the safest pattern is still:
+
+1. configure the Microsoft 365 MCP path from Gemini CLI first
+2. verify read-only access
+3. use Antigravity as the visual operating layer
+
+That keeps the IDE-style experience grounded in the same repeatable setup.
+
+## OpenAI Codex
+
+Codex uses the same MCP-first pattern:
+
+```bash
+codex mcp add microsoft365 -- op run --env-file=.env.template -- node path/to/microsoft-365-mcp.js
+```
+
+Or with an HTTP MCP endpoint:
+
+```bash
+codex mcp add microsoft365 --url https://your-m365-mcp.example.com/mcp
+```
+
+Good first checks:
+
+- list a OneDrive folder
+- read a calendar event
+- inspect a SharePoint document title
+
+## Claude Code App
+
+Register the Microsoft 365 MCP server first, then use the app as the interactive surface:
+
+```bash
+claude mcp add microsoft365 -- op run --env-file=.env.template -- node path/to/microsoft-365-mcp.js
+```
+
+That keeps the saved client setup free of raw credentials.
+
+## Claude Code CLI
+
+The CLI path is the most explicit:
+
+```bash
+claude mcp add microsoft365 -- op run --env-file=.env.template -- node path/to/microsoft-365-mcp.js
+```
+
+Or for a hosted MCP service:
+
+```bash
+claude mcp add --transport http microsoft365 https://your-m365-mcp.example.com/mcp
+```
+
+## Recommended Verification Order
+
+1. Outlook or calendar read
+2. OneDrive or SharePoint read
+3. Teams or write operations only after the read path is stable
+
+## Related Guides
+
+- [`../tool-usages/agentic-local-workspaces.md`](../tool-usages/agentic-local-workspaces.md)
+- [`../tool-usages/google-local-workspace.md`](../tool-usages/google-local-workspace.md)
+- [`../tool-usages/claude-code-local-workspace.md`](../tool-usages/claude-code-local-workspace.md)
+- [`../tool-usages/openai-codex-local-workspace.md`](../tool-usages/openai-codex-local-workspace.md)

--- a/docs/mcp-setup/n8n.md
+++ b/docs/mcp-setup/n8n.md
@@ -1,6 +1,13 @@
 # n8n MCP Setup
 
-Setup guide for the n8n workflow orchestrator MCP integration.
+Setup guide for the **n8n API and workflow-management surface** used by Project NoeMI.
+
+Important: this guide covers how a runtime talks to **n8n itself**. It does **not** configure Gmail, Google Docs, Google Sheets, Google Drive, or Gemini nodes inside n8n. Those are separate credentials inside the n8n editor.
+
+If you want the user-first Google automation path, start here instead:
+
+- [`../examples/n8n-google-workspace-quickstart.md`](../examples/n8n-google-workspace-quickstart.md)
+- [`google-n8n-credential-matrix.md`](google-n8n-credential-matrix.md)
 
 ## Prerequisites
 
@@ -35,6 +42,17 @@ n8n MCP authenticates via an **API key**.
 
 For the fleet deployment example, each cohort has its own n8n instance — see `examples/fleet-deployment/docker-compose.yml`.
 
+## What This Does Not Configure
+
+The n8n API key path does not automatically configure:
+
+- Gmail node credentials
+- Google Docs / Sheets / Drive credentials
+- Google Gemini credentials
+- workflow-level OAuth scopes for downstream apps
+
+Treat those as separate setup work inside n8n.
+
 ## Error Handling
 
 | Error | Cause | Resolution |
@@ -42,6 +60,7 @@ For the fleet deployment example, each cohort has its own n8n instance — see `
 | `401 Unauthorized` | Invalid or expired API key | Regenerate the key in n8n settings |
 | `ECONNREFUSED` | n8n instance is down or unreachable | Check that the instance is running and the URL is correct |
 | `404 /api/v1/workflows` | API not enabled on the instance | Enable the public API in n8n settings |
+| API key setup unavailable | Plan or instance configuration does not expose the API | Verify your n8n edition and API availability before depending on API-driven workflow management |
 | Workflow execution timeout | Long-running workflow exceeds limit | Increase timeout in n8n settings or break into sub-workflows |
 
 ## Verification

--- a/docs/tool-usages/agentic-local-workspaces.md
+++ b/docs/tool-usages/agentic-local-workspaces.md
@@ -1,0 +1,86 @@
+# Agentic Local Workspaces
+
+Project NoeMI treats Gemini CLI, Claude Code, and OpenAI Codex as **local agentic workspaces**, not just coding tools.
+
+They can absolutely write and review code, but that is only one slice of the job. In practice, Builders, Practitioners, and Accelerators also use them to:
+
+- inspect repositories and operating environments
+- normalize documents and operating procedures
+- review prompts, workflows, and security boundaries
+- run repeatable local automation
+- connect governed MCP tools to business systems such as Google Workspace, Slack, GitHub, or Microsoft 365
+
+## Why The CLI Matters
+
+For NoeMI, the CLI is not a scary developer ritual. It is a chat surface that happens to sit closer to the machine.
+
+That matters because the CLI is the layer that is easiest to:
+
+- run under `infisical run` or `op run`
+- version and document
+- reproduce on another workstation
+- use over SSH, WSL, or remote shells
+- connect to local scripts, worktrees, and MCP servers
+
+The visual surfaces are valuable, but the CLI is usually the most durable source of truth.
+
+## NoeMI Taxonomy
+
+- **Explorers** do not need deep CLI fluency. They mostly need to understand what these tools are and when to ask for help.
+- **Builders / Practitioners** should get comfortable launching the CLI, approving actions, and running a few safe commands.
+- **Accelerators** should be able to standardize local environments, secret-injection patterns, MCP setup, and repeatable workflows across teams.
+
+## The Three Main Stacks
+
+| Stack | CLI | Visual Surface | Best Fit | Main Tradeoff |
+|------|-----|----------------|----------|---------------|
+| Google | Gemini CLI | Antigravity, Google's IDE-style Gemini workspace layer | Google-heavy local work, fast iteration, Workspace-first flows | Google Workspace has a strong first-party path, but not every external business system is equally turnkey |
+| Anthropic | Claude Code CLI | Claude Code app | Co-work, repository understanding, interactive editing, MCP-rich local work | Strong interactive experience, but teams still need discipline around repeatable CLI setup |
+| OpenAI | Codex CLI | Codex app and IDE surfaces | Local agentic execution, reviews, worktrees, governed automation, OpenAI-native workflows | Powerful local/project controls, but setup is clearer for practitioners once the CLI basics click |
+
+## Advantages Of CLI-First Builders
+
+- easier SecretOps discipline
+- easier to teach approval and sandbox habits
+- simpler to automate
+- fewer mysteries when something breaks
+- easier to share exact working commands with a cohort or client
+
+## Advantages Of The Visual Tools
+
+- less intimidating at first contact
+- easier multi-pane context for documents, code, and terminal output
+- better for interactive co-work and inspection
+- better for people who are still building confidence
+
+## Disadvantages To Be Honest About
+
+### CLI Friction
+
+- the terminal can feel unfamiliar
+- permission flags and config names can look technical
+- users may fear they can "break everything" when they usually cannot
+
+### Visual Tool Friction
+
+- hidden state is harder to debug
+- people can forget what was configured under the hood
+- it is easier to drift away from reproducible team habits
+
+## NoeMI Recommendation
+
+For Builders, Practitioners, and Accelerators:
+
+1. Learn the CLI first at a basic comfort level.
+2. Use the visual surface as the friendlier cockpit.
+3. Keep secret injection, MCP wiring, and reusable commands anchored in the CLI.
+
+That gives you the best of both worlds: a less intimidating daily workspace and a more reliable operating foundation.
+
+## Where To Go Next
+
+- [`google-local-workspace.md`](google-local-workspace.md)
+- [`claude-code-local-workspace.md`](claude-code-local-workspace.md)
+- [`openai-codex-local-workspace.md`](openai-codex-local-workspace.md)
+- [`../mcp-setup/google-workspace-agentic-clients.md`](../mcp-setup/google-workspace-agentic-clients.md)
+- [`../mcp-setup/microsoft-365-agentic-clients.md`](../mcp-setup/microsoft-365-agentic-clients.md)

--- a/docs/tool-usages/claude-code-local-workspace.md
+++ b/docs/tool-usages/claude-code-local-workspace.md
@@ -1,0 +1,93 @@
+# Claude Code Local Workspace
+
+Claude Code should be understood as a local agentic workspace with two complementary surfaces:
+
+- **Claude Code CLI** for the durable, automatable operating layer
+- **Claude Code app** for interactive co-work, review, and a less intimidating daily experience
+
+## Why It Is More Than A Coding Tool
+
+In NoeMI, Claude Code is useful for far more than code generation. It is also strong at:
+
+- repository comprehension
+- PR and change review
+- local workflow cleanup
+- documentation work
+- MCP-driven business operations
+- governance-sensitive human-in-the-loop tasks
+
+## Why The CLI Still Matters
+
+The CLI gives Builders, Practitioners, and Accelerators a repeatable place to learn:
+
+- worktrees
+- permission modes
+- non-interactive runs
+- MCP registration
+- portable launch commands
+
+Useful surfaces exposed by the current CLI include:
+
+```bash
+claude mcp
+claude --worktree
+claude --print
+```
+
+## Where The App Fits
+
+The Claude Code app is the friendlier co-work surface. It is better when you want:
+
+- a more guided interactive experience
+- less terminal anxiety
+- inspection and editing with richer local context
+
+The app is not a separate philosophy. It works best when the team still understands the CLI underneath it.
+
+## Recommended Configuration Pattern
+
+### 1. Configure MCP Through Durable Commands
+
+Claude Code supports direct MCP registration:
+
+```bash
+claude mcp add --transport http my-server https://example.com/mcp
+```
+
+For local stdio servers that need vault-backed credentials, keep the launcher wrapped:
+
+```bash
+claude mcp add googleWorkspace -- op run --env-file=.env.template -- node path/to/server.js
+```
+
+That pattern avoids storing raw secrets in config.
+
+### 2. Use Project Or Repo MCP Config Where Helpful
+
+Claude Code also supports `--mcp-config` and project-scoped MCP configuration. That is useful when a team wants repeatable setup inside a repository rather than ad-hoc per-user memory.
+
+### 3. Use The App After The CLI Baseline Is Clear
+
+Once the MCP and secret-injection model is understood, the app becomes safer to scale across a cohort because people can reason about what is happening when something fails.
+
+## Strengths
+
+- excellent co-work experience
+- strong repository reasoning
+- flexible MCP management
+- good bridge between visual comfort and local automation
+
+## Weaknesses
+
+- users can forget which behavior came from app state vs project state
+- teams still need explicit Phase 0 setup discipline
+
+## Recommended Next Docs
+
+- [`agentic-local-workspaces.md`](agentic-local-workspaces.md)
+- [`../mcp-setup/google-workspace-agentic-clients.md`](../mcp-setup/google-workspace-agentic-clients.md)
+- [`../mcp-setup/microsoft-365-agentic-clients.md`](../mcp-setup/microsoft-365-agentic-clients.md)
+
+## Official References
+
+- [Claude Code overview](https://docs.anthropic.com/en/docs/claude-code/overview)

--- a/docs/tool-usages/gemini-mcp-setup.md
+++ b/docs/tool-usages/gemini-mcp-setup.md
@@ -1,154 +1,115 @@
-# Gemini CLI - Modular MCP Setup Guide
+# Gemini CLI Modular MCP Setup Guide
 
-This guide explains how to use the Modular Model Context Protocol (MCP) system within the NewPush Agents Repository.
+This guide covers **context generation**, not every possible authentication path for every external tool.
 
-## 🌟 The Concept: Why Modular Context?
+Its purpose is simple:
 
-When working with an AI agent like Gemini CLI, providing too much system context (instructions on how to behave) can lead to:
-1.  **Token Bloat:** Wasting token limits on instructions the agent doesn't need for the current task.
-2.  **Hallucinations/Distraction:** An agent might try to use a tool or follow a rule meant for a completely different system.
+- choose the MCP protocols you want active
+- generate a focused `GEMINI.md`
+- keep Gemini CLI context narrow enough to stay useful
 
-To solve this, Project NoeMI utilizes a **Modular Context Generation** system. Instead of one massive `GEMINI.md` file containing rules for every possible tool, we dynamically build `GEMINI.md` based *only* on the tools the agent needs right now.
+If you need actual Google Workspace connectivity, pick the correct runtime guide first:
 
----
+- [`gemini-workspace-quickstart.md`](gemini-workspace-quickstart.md) for Gemini CLI with the Google Workspace extension
+- [`../examples/n8n-google-workspace-quickstart.md`](../examples/n8n-google-workspace-quickstart.md) for n8n workflows
+- [`../mcp-setup/google-workspace.md`](../mcp-setup/google-workspace.md) for generic or self-hosted Google MCP server auth
 
-## ⚙️ How it Works
+## Why Modular Context Exists
 
-The system relies on three components:
+When you hand Gemini CLI one giant instruction file, three bad things happen:
 
-1.  **`GEMINI.template.md`**: The base persona and repository rules.
-2.  **`mcp-protocols/` Directory**: Contains granular Markdown files, each defining the rules for a single MCP service (e.g., `slack.md`, `gmail.md`, `google-sheets.md`).
-3.  **`mcp.config.json`**: The configuration file where you declare which MCPs to activate.
-4.  **`scripts/generate_gemini.js`**: The build script that merges the base template with the selected protocols.
+1. token waste
+2. tool confusion
+3. cross-domain instruction bleed
 
----
+Project NoeMI avoids that by generating `GEMINI.md` from only the active skills and MCP protocols required for the current job.
 
-## 🔌 Connecting Official Google MCP Servers
+## The Four Inputs
 
-Before generating instructions for the agent via `GEMINI.md`, the actual underlying tools must be available to your Gemini CLI. 
+The generation pipeline uses:
 
-Google provides an official Workspace extension specifically designed for Gemini CLI (found at the `gemini-cli-extensions/workspace` repository on GitHub) which seamlessly integrates using your Google account.
+1. `GEMINI.template.md`
+2. `AGENTS.md`
+3. `mcp.config.json`
+4. `scripts/generate_gemini.js`
 
-**To enable the official Google Workspace MCP Server in your CLI:**
-Run the following command in your terminal. This registers the server (which includes Gmail, Drive, Docs, Calendar, etc.) and will prompt you to securely log in to your Google account:
-```bash
-gemini extensions install https://github.com/gemini-cli-extensions/workspace
-```
+The generated output is `GEMINI.md`.
 
-*(Note: If you are new to the Gemini CLI, it is highly recommended to complete the [Getting Started with Gemini CLI Extensions Codelab](https://codelabs.developers.google.com/getting-started-gemini-cli-extensions) as a prerequisite to understand how extension management works).*
+## Step 1: Pick Only the MCPs You Need
 
-> **⚠️ Installation Warning Notice**
-> When running the command above, Gemini CLI will display the following warning:
-> *"The extension you are about to install may have been created by a third-party developer and sourced from a public repository. Google does not vet, endorse, or guarantee the functionality or security of extensions. Please carefully inspect any extension and its source code before installing to understand the permissions it requires and the actions it may perform."*
->
-> **This is normal and expected.** The CLI is designed with a "trust no one by default" security model. It requires you to acknowledge the risk of running code that can access personal data (emails, docs, etc.) because the code is sourced directly from a GitHub URL rather than a pre-compiled, locked-down binary.
+Edit [`mcp.config.json`](../../mcp.config.json) and keep the `active_mcps` list as small as practical.
 
-*Note: Once the server is connected, you do NOT want to overwhelm the AI with all the rules for every Google app. That is why we use the modular setup below to inject only the instructions relevant to the agent's current persona!*
+Example for a document-research session:
 
----
-
-## 🛠️ Step-by-Step Setup
-
-### Step 1: Define Your Active MCPs
-Open the `mcp.config.json` file in the root of the repository. Update the `active_mcps` array to include the exact filenames (without the `.md` extension) of the protocols you need from the `mcp-protocols/` folder.
-
-**Example 1: The "Support Helper" Agent**
-This agent only needs to read Google Docs for knowledge and send Slack messages.
 ```json
 {
   "active_mcps": [
     "google-docs",
-    "slack"
+    "google-drive",
+    "web-search"
   ]
 }
 ```
 
-**Example 2: The "Executive Assistant" Agent**
-This agent handles email, calendar scheduling, and organizing Drive folders.
+Example for an operations session:
+
 ```json
 {
   "active_mcps": [
-    "gmail",
-    "google-calendar",
-    "google-drive"
+    "github",
+    "slack",
+    "n8n"
   ]
 }
 ```
 
-**Example 3: The "Automation Engineer" Agent**
-This agent builds workflows and needs access to n8n and Google Sheets for data mapping.
-```json
-{
-  "active_mcps": [
-    "n8n",
-    "google-sheets"
-  ]
-}
-```
-
-### Step 2: Generate the Context File
-Once your `mcp.config.json` is configured, run the generation script from your terminal:
+## Step 2: Generate the Context
 
 ```bash
 node scripts/generate_gemini.js
 ```
 
-**What happens?**
-The script will output:
-```text
-Generating modular GEMINI.md...
-Injecting module: gmail
-Injecting module: google-calendar
-Injecting module: google-drive
-Successfully generated GEMINI.md with active integrations: gmail, google-calendar, google-drive
+Or regenerate both orchestrator context files together:
+
+```bash
+node scripts/generate_all.js
 ```
-A new `GEMINI.md` file is instantly created (or overwritten) in the root directory. It now contains the core repository rules *plus* the specific instructions for Gmail, Calendar, and Drive appended to the bottom.
 
-### Step 3: Start Gemini
-You are now ready to start your Gemini CLI session. Because `GEMINI.md` is automatically read by the CLI on startup, the agent will instantly possess the highly focused, token-efficient context needed to execute the requested persona flawlessly.
+## Step 3: Validate Before You Start
 
----
+```bash
+npm run validate
+```
 
-## 🧠 Strategies for Token Efficiency (Large Datasets)
+This confirms the generator, templates, and current protocol inventory still align.
 
-When your agent needs to process massive amounts of information—like searching through hundreds of emails or reading a massive spreadsheet—it is crucial to employ token-efficient strategies to prevent overwhelming the context window.
+## Step 4: Launch Gemini with the Right Runtime Wrapper
 
-### 1. Targeted Filtering & Search
-Never ask an agent to "Read all emails from this week." Instead, enforce the use of strict search operators within the MCP tools.
-*   **Inefficient:** Fetching all recent emails and having the AI sift through them.
-*   **Efficient:** Utilizing Gmail search syntax in the tool call: `from:boss@example.com subject:"Q3 Report" newer_than:2d`.
+If the task needs vault-backed secrets beyond Gemini CLI's own auth state:
 
-### 2. Metadata Before Body (The Two-Step Approach)
-When processing emails or large documents, instruct the agent to fetch *only* the metadata first, and then fetch the full body of only the relevant items.
-*   **Step 1:** "List the subjects, senders, and IDs of the last 20 emails."
-*   **Step 2:** "Now, fetch the full body content for email ID `12345`."
+```bash
+infisical run --env=dev -- gemini
+```
 
-### 3. Pagination & Chunking
-If an agent must read a large dataset, ensure the tool calls utilize `limit` and `offset` (or pagination token) parameters.
-*   "Fetch the first 10 responses from the form. Analyze them, then fetch the next 10."
+or
 
-### 4. Targeted Extraction
-If the external MCP server supports server-side extraction or summarization, rely on that instead of piping raw data back to Gemini. Alternatively, ask the tool to return only the specific fields you care about (e.g., just the `amount` column from a spreadsheet) rather than the entire row object.
+```bash
+op run --env-file=.env.template -- gemini
+```
 
----
+## Token-Discipline Rules
 
-## 📚 Available MCP Protocols
+When the active MCPs include large Google surfaces like Gmail, Drive, or Sheets:
 
-As of the current version, the following protocols are available in the `mcp-protocols/` directory and can be used in `mcp.config.json`:
+- search or filter before reading
+- fetch metadata before full bodies
+- paginate large result sets
+- ask for targeted fields, not full records
 
-*   `n8n`
-*   `slack`
-*   `gmail`
-*   `google-admin`
-*   `google-calendar`
-*   `google-chat`
-*   `google-contacts`
-*   `google-docs`
-*   `google-drive`
-*   `google-forms`
-*   `google-keep`
-*   `google-meet`
-*   `google-sheets`
-*   `google-slides`
+## Important Boundary
 
-*To add a new protocol, simply create a new `.md` file in the `mcp-protocols/` directory detailing the specific rules and instructions for that tool.*
+`mcp.config.json` controls which **instructions** are injected into `GEMINI.md`.
+
+It does **not** install tools, configure Gemini CLI extensions, or create n8n credentials by itself.
+
+That is why the runtime-specific setup guides above matter.

--- a/docs/tool-usages/gemini-workspace-quickstart.md
+++ b/docs/tool-usages/gemini-workspace-quickstart.md
@@ -1,0 +1,127 @@
+# Gemini CLI + Google Workspace Quickstart
+
+This is the supported path for a human using Gemini CLI directly with Google Workspace.
+
+Use this guide when you want ad-hoc, interactive work such as:
+
+- searching Google Drive
+- summarizing Google Docs
+- checking Gmail or Calendar manually
+- drafting content before handing it to another system
+
+This path uses the official Google Workspace extension for Gemini CLI. It does **not** use the generic `GOOGLE_CLIENT_ID` / `GOOGLE_REFRESH_TOKEN` environment-variable pattern described in the generic MCP setup guide, and it does **not** configure n8n credentials.
+
+If you want repeatable event-driven automation, use [`../examples/n8n-google-workspace-quickstart.md`](../examples/n8n-google-workspace-quickstart.md) instead.
+
+## What This Path Is Good For
+
+- individual builders and operators
+- discovery work and document lookup
+- low-volume, human-reviewed tasks
+- prototyping before converting a flow into n8n
+
+## What This Path Is Not
+
+- not the right path for background automation
+- not the right path for shared team credentials
+- not the right path for webhook-driven business workflows
+- not a replacement for n8n credential setup
+
+## Prerequisites
+
+- Gemini CLI installed
+- a Google account or Google Workspace account
+- a local browser for sign-in, or a headless environment where you can complete the extension's headless login flow
+- this repository checked out locally
+
+## Step 1: Install the Google Workspace Extension
+
+```bash
+gemini extensions install https://github.com/gemini-cli-extensions/workspace
+```
+
+This installs the official Workspace extension, which gives Gemini CLI access to Google Docs, Drive, Calendar, Gmail, and related Workspace surfaces.
+
+## Step 2: Authenticate the Extension
+
+For most local setups, start Gemini CLI and complete the normal Google sign-in flow:
+
+```bash
+gemini
+```
+
+For SSH, WSL, Cloud Shell, or another environment without a browser, use the extension's headless login flow as documented by the extension repository.
+
+## Step 3: Activate Only the Google Protocols You Actually Need
+
+Edit [`mcp.config.json`](../../mcp.config.json) so the generated context includes only the Google protocols relevant to the task at hand.
+
+Example for lightweight document research:
+
+```json
+{
+  "active_mcps": [
+    "google-docs",
+    "google-drive"
+  ]
+}
+```
+
+Example for executive-assistant style work:
+
+```json
+{
+  "active_mcps": [
+    "gmail",
+    "google-calendar",
+    "google-drive"
+  ]
+}
+```
+
+## Step 4: Regenerate Context
+
+```bash
+node scripts/generate_all.js
+npm run validate
+```
+
+This keeps `GEMINI.md` aligned with the Google surfaces you actually intend to use.
+
+## Step 5: Start Gemini with the Right Security Wrapper
+
+If your session also needs non-Google secrets, run Gemini under `infisical run` or `op run` as usual:
+
+```bash
+infisical run --env=dev -- gemini
+```
+
+If the task only needs the Workspace extension and no additional secrets, a normal `gemini` launch is enough.
+
+## First Tasks to Prove the Setup
+
+Start with low-risk reads:
+
+- "Find the Google Doc named 'Quarterly Planning' in Drive."
+- "Summarize the last update made to that document."
+- "What is on my calendar tomorrow?"
+
+Only after that should you move into mutating actions such as drafting emails or creating documents.
+
+## Common Mistakes
+
+- setting `GOOGLE_CLIENT_ID` and expecting Gemini CLI to automatically use it
+- assuming n8n Google credentials configure Gemini CLI
+- enabling every Google protocol in `mcp.config.json` instead of the minimum needed set
+- using this path for unattended background automation
+
+## Security Notes
+
+The Workspace extension can read and modify Workspace data. Do not aim it at untrusted documents, emails, or shared content without human review. Treat Workspace data as a potential indirect prompt-injection surface.
+
+## Related Guides
+
+- [`gemini-mcp-setup.md`](gemini-mcp-setup.md) for modular context generation
+- [`../mcp-setup/google-workspace.md`](../mcp-setup/google-workspace.md) for generic Google MCP server auth patterns
+- [`../examples/n8n-google-workspace-quickstart.md`](../examples/n8n-google-workspace-quickstart.md) for repeatable automation
+- [`../mcp-setup/google-n8n-credential-matrix.md`](../mcp-setup/google-n8n-credential-matrix.md) for Google vs n8n credential troubleshooting

--- a/docs/tool-usages/gemini-workspace-quickstart.md
+++ b/docs/tool-usages/gemini-workspace-quickstart.md
@@ -11,6 +11,8 @@ Use this guide when you want ad-hoc, interactive work such as:
 
 This path uses the official Google Workspace extension for Gemini CLI. It does **not** use the generic `GOOGLE_CLIENT_ID` / `GOOGLE_REFRESH_TOKEN` environment-variable pattern described in the generic MCP setup guide, and it does **not** configure n8n credentials.
 
+For the broader comparison between Gemini CLI, Antigravity, Claude Code, and Codex as local agentic workspaces, start with [`agentic-local-workspaces.md`](agentic-local-workspaces.md) and [`google-local-workspace.md`](google-local-workspace.md).
+
 If you want repeatable event-driven automation, use [`../examples/n8n-google-workspace-quickstart.md`](../examples/n8n-google-workspace-quickstart.md) instead.
 
 ## What This Path Is Good For
@@ -122,6 +124,9 @@ The Workspace extension can read and modify Workspace data. Do not aim it at unt
 ## Related Guides
 
 - [`gemini-mcp-setup.md`](gemini-mcp-setup.md) for modular context generation
+- [`agentic-local-workspaces.md`](agentic-local-workspaces.md) for the builder-facing local workspace model
+- [`google-local-workspace.md`](google-local-workspace.md) for Gemini CLI plus Antigravity positioning
 - [`../mcp-setup/google-workspace.md`](../mcp-setup/google-workspace.md) for generic Google MCP server auth patterns
+- [`../mcp-setup/google-workspace-agentic-clients.md`](../mcp-setup/google-workspace-agentic-clients.md) for Google Workspace across Gemini, Antigravity, Codex, and Claude Code
 - [`../examples/n8n-google-workspace-quickstart.md`](../examples/n8n-google-workspace-quickstart.md) for repeatable automation
 - [`../mcp-setup/google-n8n-credential-matrix.md`](../mcp-setup/google-n8n-credential-matrix.md) for Google vs n8n credential troubleshooting

--- a/docs/tool-usages/google-local-workspace.md
+++ b/docs/tool-usages/google-local-workspace.md
@@ -1,0 +1,108 @@
+# Google Local Workspace
+
+This guide explains the Google stack as a **local agentic workspace**:
+
+- **Gemini CLI** as the operational core
+- **Antigravity** as Google's IDE-style Gemini workspace layer
+
+For NoeMI, the key idea is simple: Antigravity makes the experience friendlier, but Gemini CLI is still the layer that teaches durable builder habits.
+
+## What This Stack Is Good At
+
+- Google Workspace-heavy day-to-day work
+- document research and synthesis
+- drive and calendar exploration
+- moving from ad-hoc work into governed automation
+
+## Why Gemini CLI Matters
+
+Gemini CLI is not just a coding shell. It is the easiest Google-side surface to:
+
+- launch under `infisical run` or `op run`
+- connect to MCP servers
+- install and manage extensions
+- run from SSH, WSL, or a remote shell
+- standardize across a practitioner cohort
+
+Local command surfaces available in the current CLI include:
+
+```bash
+gemini mcp
+gemini extensions
+gemini skills
+```
+
+## Where Antigravity Fits
+
+Antigravity is Google's IDE-style Gemini workspace layer. It is useful when you want:
+
+- a more visual multi-pane environment
+- interactive review of files and outputs
+- a smoother on-ramp for less terminal-comfortable builders
+
+The practical NoeMI stance is:
+
+- use Gemini CLI to establish the working setup
+- use Antigravity as the visual operating layer on top of that
+
+## Recommended Configuration Pattern
+
+### 1. Start With Gemini CLI
+
+Install and validate Gemini CLI first. This keeps the setup reproducible even if a builder later prefers Antigravity.
+
+If you are using Google Workspace directly, the supported first-party route is the Workspace extension:
+
+```bash
+gemini extensions install https://github.com/gemini-cli-extensions/workspace
+```
+
+See [`gemini-workspace-quickstart.md`](gemini-workspace-quickstart.md) for the Google-first path.
+
+### 2. Add MCP Servers When You Need Non-Google Systems
+
+Gemini CLI supports MCP server management directly:
+
+```bash
+gemini mcp add my-server -- op run --env-file=.env.template -- node path/to/server.js
+```
+
+This pattern matters because it preserves Project NoeMI's Phase 0 security model. The config stores the launcher command, not the underlying secrets.
+
+### 3. Keep Secret Injection Outside The Client Config
+
+Do not paste OAuth tokens, API keys, or Microsoft / Google client secrets into local config files.
+
+Prefer wrapper-based launches such as:
+
+```bash
+infisical run --env=dev -- gemini
+op run --env-file=.env.template -- gemini
+```
+
+### 4. Then Use Antigravity As The Friendlier Surface
+
+Once Gemini CLI, extensions, and any MCP server launches are understood, Antigravity becomes much easier to trust. The builder knows what is happening under the hood instead of treating the IDE as magic.
+
+## Strengths
+
+- strong fit for Google Workspace-first teams
+- approachable path from chat to local automation
+- good balance between ad-hoc work and governed tool use
+
+## Weaknesses
+
+- builders can over-rely on the visual layer and skip CLI habits
+- Google Workspace is the cleanest first-party story; other suites often still require MCP discipline
+
+## Recommended Next Docs
+
+- [`agentic-local-workspaces.md`](agentic-local-workspaces.md)
+- [`gemini-workspace-quickstart.md`](gemini-workspace-quickstart.md)
+- [`../mcp-setup/google-workspace-agentic-clients.md`](../mcp-setup/google-workspace-agentic-clients.md)
+- [`../mcp-setup/microsoft-365-agentic-clients.md`](../mcp-setup/microsoft-365-agentic-clients.md)
+
+## Official References
+
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- [Google Workspace extension for Gemini CLI](https://github.com/gemini-cli-extensions/workspace)

--- a/docs/tool-usages/n8n-expert-persona.md
+++ b/docs/tool-usages/n8n-expert-persona.md
@@ -3,7 +3,7 @@
 This document defines the specialized persona and workflow for n8n automation tasks within the NewPush agent ecosystem.
 
 ## Role
-Expert in n8n automation software using n8n-MCP tools, focused on designing, building, and validating workflows with maximum accuracy and efficiency.
+Expert in n8n automation software, focused on designing, building, and validating workflows with maximum accuracy and efficiency.
 
 ## Core Principles
 
@@ -14,10 +14,10 @@ CRITICAL: Execute tools without commentary. Only respond AFTER all tools complet
 When operations are independent, execute them in parallel for maximum performance.
 
 ### 3. Templates First
-ALWAYS check templates before building from scratch (2,709 available).
+ALWAYS check repository examples and current n8n templates before building from scratch.
 
 ### 4. Multi-Level Validation
-Use `validate_node(mode='minimal')` → `validate_node(mode='full')` → `validate_workflow` pattern.
+Validate in layers: node credentials, node parameters, workflow routing, then runtime behavior in the n8n editor or API.
 
 ### 5. Never Trust Defaults
 ⚠️ CRITICAL: Default parameter values are the #1 source of runtime failures. ALWAYS explicitly configure ALL parameters that control node behavior.
@@ -26,14 +26,14 @@ Use `validate_node(mode='minimal')` → `validate_node(mode='full')` → `valida
 
 ## Workflow Process
 
-1. **Start**: Call `tools_documentation()` for best practices.
-2. **Template Discovery**: Search by metadata, task, keyword, or node types.
-3. **Node Discovery**: Deep dive into requirements and parallel node searches.
-4. **Configuration**: Fetch standard, minimal, or full node details and documentation.
-5. **Validation**: Parallel checks of node configurations.
-6. **Building**: MANDATORY ATTRIBUTION for templates; explicit parameter setting.
-7. **Workflow Validation**: Complete connection, expression, and structure checks.
-8. **Deployment**: Create, validate, and test workflows via n8n API.
+1. **Start**: Read the current node documentation and the relevant repo example first.
+2. **Template Discovery**: Reuse existing workflows when they match the target shape.
+3. **Node Discovery**: Confirm the exact node types, credential types, and `typeVersion` values in the target n8n release.
+4. **Configuration**: Explicitly set important parameters and do not rely on defaults.
+5. **Validation**: Check credentials, expressions, routing branches, and required downstream scopes.
+6. **Building**: Keep workflow JSON importable and keep placeholder credential IDs obvious.
+7. **Workflow Validation**: Test the workflow in the n8n editor and via API if the API is available.
+8. **Deployment**: Activate only after the mutating steps and human approval boundaries are clear.
 
 ---
 

--- a/docs/tool-usages/openai-codex-local-workspace.md
+++ b/docs/tool-usages/openai-codex-local-workspace.md
@@ -1,0 +1,96 @@
+# OpenAI Codex Local Workspace
+
+OpenAI Codex is also best understood as a local agentic workspace, not merely a coding assistant.
+
+The important pair is:
+
+- **Codex CLI** for the durable operating surface
+- **Codex app** for interactive local work, project actions, and visual review
+
+## Why It Is More Than A Coding Tool
+
+Codex is useful for:
+
+- code generation and review
+- local repository operations
+- governed task execution
+- project-specific setup actions
+- MCP-driven access to external systems
+- repeatable automation and non-interactive runs
+
+## Why The CLI Matters
+
+Codex CLI exposes the most reproducible working model:
+
+```bash
+codex
+codex exec
+codex review
+codex mcp add
+```
+
+It also uses a documented user config file at `~/.codex/config.toml`.
+
+OpenAI's docs also document MCP setup from the CLI and note that the MCP configuration is shared between the CLI and IDE extension.
+
+## Where The App Fits
+
+The Codex app is valuable when you want a friendlier local cockpit around the same project:
+
+- project actions
+- worktree setup
+- integrated local terminal actions
+- richer inspection of state while staying inside the repo
+
+OpenAI's local-environments docs also describe project-level setup scripts and actions stored inside the project's `.codex` folder, which makes the app especially useful for standardizing a team workspace once the CLI basics are already understood.
+
+## Recommended Configuration Pattern
+
+### 1. Start With Codex CLI
+
+Use the CLI to establish authentication, model defaults, and MCP connections first.
+
+For MCP:
+
+```bash
+codex mcp add my-server --url https://example.com/mcp
+```
+
+For local stdio servers that need vault-backed credentials:
+
+```bash
+codex mcp add microsoft365 -- op run --env-file=.env.template -- node path/to/server.js
+```
+
+This keeps secret resolution in the wrapper, not in the saved config.
+
+### 2. Use The App For Shared Project Actions
+
+After the CLI is working, use the app's local-environment features to define shared setup scripts and common actions in `.codex/`. That is a strong NoeMI fit for Accelerators who want to make a builder environment more repeatable.
+
+### 3. Keep Google And Microsoft Integrations MCP-Based
+
+Unlike Gemini's Google Workspace extension path, the clean Codex story for Google Workspace and Microsoft 365 is the MCP route.
+
+## Strengths
+
+- strong local agent execution model
+- excellent fit for review, automation, and worktrees
+- good project-level environment standardization
+
+## Weaknesses
+
+- practitioners benefit from a little CLI coaching before the tool feels natural
+- teams need to stay disciplined about where MCP setup lives
+
+## Recommended Next Docs
+
+- [`agentic-local-workspaces.md`](agentic-local-workspaces.md)
+- [`../mcp-setup/google-workspace-agentic-clients.md`](../mcp-setup/google-workspace-agentic-clients.md)
+- [`../mcp-setup/microsoft-365-agentic-clients.md`](../mcp-setup/microsoft-365-agentic-clients.md)
+
+## Official References
+
+- [Codex docs](https://developers.openai.com/codex)
+- [Codex Docs MCP](https://developers.openai.com/learn/docs-mcp)
+- [Codex local environments](https://developers.openai.com/codex/app/local-environments)

--- a/docs/tool-usages/secure-secret-management.md
+++ b/docs/tool-usages/secure-secret-management.md
@@ -76,8 +76,8 @@ When running Python scripts or Node apps, wrap your execution:
 *(Infisical will automatically inject all secrets from the 'dev' environment into the process).*
 ```
 
-## Part 3: Configuring Local "Vibe Coding" (Gemini CLI)
-Context: When a Practitioner is "vibe coding" locally, they can authenticate using their human user identity (SSO) rather than managing long-lived machine tokens.
+## Part 3: Configuring Local Agentic Workspaces
+Context: When a Practitioner is working locally, they can authenticate using their human user identity (SSO) rather than managing long-lived machine tokens.
 
 **Step 1: Authenticate Locally**
 Practitioners log in via their browser (often via Casdoor SSO in NewPush Labs).
@@ -85,20 +85,35 @@ Practitioners log in via their browser (often via Casdoor SSO in NewPush Labs).
 infisical login
 ```
 
-**Step 2: Running the Agent Securely**
-To give the Gemini CLI access to secrets (e.g., if it needs to run a database script it just wrote), the Practitioner wraps the agent execution. Unlike 1Password, which requires a `.env.template` with reference strings, Infisical dynamically pulls the environment you specify.
+**Step 2: Running The Local Client Securely**
+To give a local client access to secrets, the Practitioner wraps the execution. Unlike 1Password, which requires a `.env.template` with reference strings, Infisical dynamically pulls the environment you specify.
 
-**Command:**
+**Examples:**
 ```bash
 # This injects the 'dev' secrets into the shell where Gemini runs
-infisical run --env=dev -- gemini chat
+infisical run --env=dev -- gemini
+
+# Claude Code CLI
+infisical run --env=dev -- claude
+
+# OpenAI Codex CLI
+infisical run --env=dev -- codex
 ```
 
 **Pro Tip (Alias):**
 Add this to your `~/.zshrc` or `~/.bashrc` to build secure muscle memory:
 ```bash
 alias safe-gemini='infisical run --env=dev -- gemini'
+alias safe-claude='infisical run --env=dev -- claude'
+alias safe-codex='infisical run --env=dev -- codex'
 ```
+
+For the client-by-client comparison and the role of Google's Antigravity, Claude Code app, and Codex app on top of these CLI habits, see:
+
+- [`agentic-local-workspaces.md`](agentic-local-workspaces.md)
+- [`google-local-workspace.md`](google-local-workspace.md)
+- [`claude-code-local-workspace.md`](claude-code-local-workspace.md)
+- [`openai-codex-local-workspace.md`](openai-codex-local-workspace.md)
 
 ## Part 4: The "Agent Contract" (Prompting Guide)
 To ensure the agent writes secure code, Practitioners must master Process Description.

--- a/docs/visuals/README.md
+++ b/docs/visuals/README.md
@@ -1,0 +1,27 @@
+# NoeMI Visual Guides
+
+These visual guides are the fastest way to understand how Project NoeMI fits together.
+
+They are intentionally split by purpose:
+
+- the **system map** shows the architecture at a glance
+- the **audience entry map** shows where each kind of reader should start
+- the **runtime flow** shows how one task actually moves through the system
+- the **mind map** shows the breadth of the ecosystem for workshops and onboarding
+
+## Start Here
+
+1. [`noemi-system-map.md`](noemi-system-map.md)
+2. [`noemi-audience-entry-map.md`](noemi-audience-entry-map.md)
+3. [`noemi-runtime-flow.md`](noemi-runtime-flow.md)
+4. [`noemi-workshop-mind-map.md`](noemi-workshop-mind-map.md)
+
+## Why This Set Exists
+
+A single diagram is rarely enough:
+
+- mind maps are helpful for exploration, but weak at showing sequence and governance
+- architecture diagrams are helpful for structure, but can feel abstract without audience paths
+- runtime flows explain execution, but not the full repository story
+
+Together, these four views give a fast but accurate mental model.

--- a/docs/visuals/noemi-audience-entry-map.md
+++ b/docs/visuals/noemi-audience-entry-map.md
@@ -1,0 +1,38 @@
+# NoeMI Audience Entry Map
+
+This visual helps a reader find the right entry path without reading the whole repository first.
+
+```mermaid
+flowchart TD
+    start["Start Here\nProject Reference"]
+
+    client["Client / Buyer"]
+    msp["MSP / MSSP"]
+    builder["Builder / Accelerator"]
+
+    phase0["Phase 0 Security Baseline"]
+    assess["Phase 0 Assessment Kit"]
+    mspGuide["MSP Deployment Guide"]
+    ops["Fleet and Governance Docs"]
+    secrets["Secure Secret Management"]
+    workspaces["Agentic Local Workspaces"]
+    integrations["Google Workspace and Microsoft 365 Client Guides"]
+    quickstarts["Gemini and n8n Quickstarts"]
+    docker["Builder First 30 Minutes and Docker Agent Home"]
+    visuals["Visual Guides"]
+
+    start --> visuals
+    start --> client
+    start --> msp
+    start --> builder
+
+    client --> phase0 --> assess
+    msp --> mspGuide --> ops
+    builder --> secrets --> workspaces --> integrations --> quickstarts --> docker
+```
+
+## Best Use
+
+- send this to a new stakeholder who asks, "Where do I begin?"
+- use it at the top of onboarding sessions
+- keep it close to the README and the public reference

--- a/docs/visuals/noemi-runtime-flow.md
+++ b/docs/visuals/noemi-runtime-flow.md
@@ -1,0 +1,34 @@
+# NoeMI Runtime Flow
+
+This visual shows how one real task moves through the system once the architecture is in place.
+
+```mermaid
+sequenceDiagram
+    participant H as Human Operator
+    participant C as Agentic Client
+    participant P as Persona and Skills
+    participant O as Operating Profile
+    participant V as Value Lens
+    participant M as MCP Tools
+    participant G as Guardian and Governance
+    participant A as Audit and ROI
+
+    H->>C: Submit goal, constraints, and context
+    C->>P: Load persona, workflow, and skills
+    C->>O: Apply local execution overlay when needed
+    C->>V: Apply explicit success and tradeoff lens
+    P->>M: Execute through MCP protocols and integrations
+    M-->>P: Return data, actions, or errors
+    P-->>C: Produce draft result or recommendation
+    C->>G: Run policy checks, diligence, and review gates
+    G-->>H: Escalate if blocked, risky, or ambiguous
+    G-->>C: Approve or require revision
+    C->>A: Emit audit summary, observability events, and ROI evidence
+    C-->>H: Deliver final output or handoff package
+```
+
+## What This Clarifies
+
+- the client is the execution surface, not the repository itself
+- operating profiles and value lenses are overlays, not replacements for the persona
+- governance and audit happen around execution, not only after the fact

--- a/docs/visuals/noemi-system-map.md
+++ b/docs/visuals/noemi-system-map.md
@@ -1,0 +1,41 @@
+# NoeMI System Map
+
+This is the primary architecture visual for the repository.
+
+It shows the major layers in the order most people need to understand them.
+
+```mermaid
+flowchart TD
+    phase0["Phase 0 Security\nIdentity, data perimeter, secrets, readiness"]
+    people["Human Roles\nExplorers, Practitioners, Accelerators"]
+    personas["Agent Personas\nRole, mission, workflow, audit log"]
+    skills["Skills\nReusable task recipes"]
+    mcps["MCP Protocols and Integrations\nGoogle Workspace, Microsoft 365, Slack, GitHub, n8n, web"]
+    clients["Agentic Clients and Orchestrators\nGemini CLI, Antigravity, Claude Code, Codex, n8n"]
+    profiles["Operating Profiles\nLocale, subregion, sector, audience"]
+    lenses["Value Lenses\nPerformance-efficiency, care-continuity, balanced-enterprise"]
+    runtime["Runtime Execution\nPrompts, approvals, retries, human review"]
+    governance["Governance and Guardian Layer\nTRiSM, red teaming, diligence, refusal principle"]
+    audit["Audit, ROI, and Observability\nLogs, dashboards, decision traces, ROI"]
+
+    phase0 --> people
+    people --> personas
+    personas --> skills
+    skills --> mcps
+    mcps --> clients
+    clients --> runtime
+    profiles --> runtime
+    lenses --> runtime
+    runtime --> governance
+    governance --> audit
+    phase0 --> governance
+```
+
+## Read It Like This
+
+- **Phase 0 Security** is the precondition, not a later add-on.
+- **Personas, skills, and MCPs** define what agents are allowed to do and how they do it.
+- **Clients and orchestrators** are the runtime surfaces that consume this repository.
+- **Operating profiles** adapt work to local culture.
+- **Value lenses** adapt how success and tradeoffs are judged.
+- **Governance, audit, and ROI** make the system reviewable and enterprise-safe.

--- a/docs/visuals/noemi-workshop-mind-map.md
+++ b/docs/visuals/noemi-workshop-mind-map.md
@@ -1,0 +1,54 @@
+# NoeMI Workshop Mind Map
+
+This is the supplementary exploration visual.
+
+Use it in workshops, presentations, and onboarding conversations when people need to see the breadth of the ecosystem.
+
+```mermaid
+mindmap
+  root((Project NoeMI))
+    Philosophy
+      Phase 0 Security
+      Virtual Workforce
+      1:50 Equilibrium
+      Guardian Layer
+      Refusal Principle
+    People
+      Explorers
+      Practitioners
+      Accelerators
+    Frameworks
+      4D Framework
+      TRiSM
+      Operating Profiles
+      Value Lenses
+    Execution
+      Agent Personas
+      Skills
+      MCP Protocols
+      Agentic Clients
+      n8n Workflows
+    Platforms
+      Gemini CLI
+      Antigravity
+      Claude Code
+      Codex
+      Google Workspace
+      Microsoft 365
+    Governance
+      Audit Trails
+      Red Teaming
+      Observability
+      ROI
+    Delivery
+      Workshops
+      Intensive
+      Velocity
+      Assessment
+```
+
+## Important Note
+
+This is the most expansive view, not the most operational one.
+
+If a reader needs fast comprehension, start with [`noemi-system-map.md`](noemi-system-map.md) before using this mind map.

--- a/examples/workflows/rfp-responder.json
+++ b/examples/workflows/rfp-responder.json
@@ -10,108 +10,153 @@
             }
           ]
         },
+        "simple": false,
         "filters": {
           "labelIds": [
             "INBOX",
             "UNREAD"
           ]
-        }
+        },
+        "options": {}
       },
-      "id": "1",
-      "name": "Gmail Trigger (New Emails)",
       "type": "n8n-nodes-base.gmailTrigger",
-      "typeVersion": 1,
+      "typeVersion": 1.3,
       "position": [
-        250,
-        300
-      ]
+        120,
+        240
+      ],
+      "id": "e47b7bc9-a9ab-4b1d-b4d1-1b99fcadc4b1",
+      "name": "Gmail Trigger (New Emails)",
+      "credentials": {
+        "gmailOAuth2": {
+          "id": "REPLACE_WITH_YOUR_GMAIL_CREDENTIAL_ID",
+          "name": "Gmail account"
+        }
+      }
     },
     {
       "parameters": {
-        "model": "gemini-1.5-pro",
-        "systemMessage": "You are the Knowledge Manager & Researcher agent. Analyze the incoming email to determine if it is a Request for Proposal (RFP) or a Request for Quote (RFQ).\n\nIf it IS an RFP/RFQ, extract the core requirements, deadlines, and key questions being asked. If it is NOT an RFP/RFQ, simply state so.\n\nOutput ONLY valid JSON in the following format:\n{\n  \"is_rfp_rfq\": true/false,\n  \"summary\": \"Brief summary of the request...\",\n  \"requirements\": [\"req 1\", \"req 2\"],\n  \"deadline\": \"YYYY-MM-DD or Not specified\"\n}",
+        "modelId": {
+          "__rl": true,
+          "value": "models/gemini-2.5-flash",
+          "mode": "list",
+          "cachedResultName": "models/gemini-2.5-flash"
+        },
         "messages": {
-          "messageValues": [
+          "values": [
             {
-              "message": "=Subject: {{ $json.snippet }}\nBody: {{ $json.textPlain }}"
+              "content": "=You are the Knowledge Manager & Researcher agent. Analyze the incoming email to determine if it is a Request for Proposal (RFP) or a Request for Quote (RFQ).\n\nIf it IS an RFP/RFQ, extract the core requirements, deadlines, and key questions being asked. If it is NOT an RFP/RFQ, simply state so.\n\nReturn only valid JSON using this exact shape:\n{\n  \"is_rfp_rfq\": true,\n  \"summary\": \"Brief summary of the request\",\n  \"requirements\": [\"Requirement 1\", \"Requirement 2\"],\n  \"deadline\": \"YYYY-MM-DD or Not specified\"\n}\n\nSubject: {{ $('Gmail Trigger (New Emails)').item.json.subject || $('Gmail Trigger (New Emails)').item.json.snippet }}\nBody: {{ $('Gmail Trigger (New Emails)').item.json.textPlain || $('Gmail Trigger (New Emails)').item.json.text }}"
             }
           ]
-        }
+        },
+        "jsonOutput": true,
+        "simplify": false,
+        "builtInTools": {},
+        "options": {}
       },
-      "id": "2",
-      "name": "Analyze Request (Gemini)",
-      "type": "@n8n/n8n-nodes-langchain.chainLlm",
-      "typeVersion": 1,
+      "type": "@n8n/n8n-nodes-langchain.googleGemini",
+      "typeVersion": 1.1,
       "position": [
-        450,
-        300
-      ]
+        360,
+        240
+      ],
+      "id": "3fb03353-8b71-4854-ab46-c8c8481b8567",
+      "name": "Analyze Request (Gemini)",
+      "credentials": {
+        "googlePalmApi": {
+          "id": "REPLACE_WITH_YOUR_GEMINI_API_CREDENTIAL_ID",
+          "name": "Google Gemini(PaLM) Api account"
+        }
+      }
     },
     {
       "parameters": {
-        "options": {
-          "string": [
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 3
+          },
+          "conditions": [
             {
-              "value": "={{ JSON.parse($json.text).is_rfp_rfq }}",
-              "action": "isTrue"
+              "id": "55c1a52d-d203-4f65-b905-f1be58b516fe",
+              "leftValue": "={{ $('Analyze Request (Gemini)').item.json.candidates[0].content.parts[0].text }}",
+              "rightValue": "\"is_rfp_rfq\": true",
+              "operator": {
+                "type": "string",
+                "operation": "contains"
+              }
             }
-          ]
-        }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
       },
-      "id": "3",
-      "name": "Is RFP/RFQ?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.3,
       "position": [
-        650,
-        300
-      ]
+        600,
+        240
+      ],
+      "id": "09bb633c-f2d2-4782-857d-80fbf97274ec",
+      "name": "Is RFP/RFQ?"
     },
     {
       "parameters": {
         "resource": "document",
         "operation": "create",
-        "title": "=RFP Draft: {{ $('Gmail Trigger (New Emails)').item.json.snippet }}",
-        "content": "=RFP / RFQ Analysis\n\nSender: {{ $('Gmail Trigger (New Emails)').item.json.from }}\nDate: {{ $('Gmail Trigger (New Emails)').item.json.date }}\n\nSummary:\n{{ JSON.parse($('Analyze Request (Gemini)').item.json.text).summary }}\n\nRequirements:\n{{ JSON.parse($('Analyze Request (Gemini)').item.json.text).requirements.join('\\n- ') }}\n\nDeadline: {{ JSON.parse($('Analyze Request (Gemini)').item.json.text).deadline }}\n\n---\nDraft Response Section:\n[Agent to continue drafting proposal here]"
+        "title": "=RFP Draft: {{ $('Gmail Trigger (New Emails)').item.json.subject || $('Gmail Trigger (New Emails)').item.json.snippet }}",
+        "content": "=RFP / RFQ Analysis\n\nSender: {{ $('Gmail Trigger (New Emails)').item.json.from }}\nDate: {{ $('Gmail Trigger (New Emails)').item.json.date }}\n\nSummary:\n{{ JSON.parse($('Analyze Request (Gemini)').item.json.candidates[0].content.parts[0].text).summary }}\n\nRequirements:\n{{ JSON.parse($('Analyze Request (Gemini)').item.json.candidates[0].content.parts[0].text).requirements.map((requirement) => '- ' + requirement).join('\\n') }}\n\nDeadline: {{ JSON.parse($('Analyze Request (Gemini)').item.json.candidates[0].content.parts[0].text).deadline }}\n\n---\nDraft Response Section:\n[Human reviewer to finalize proposal response here]"
       },
-      "id": "4",
-      "name": "Create Google Doc",
       "type": "n8n-nodes-base.googleDocs",
       "typeVersion": 2,
       "position": [
-        850,
-        150
-      ]
+        840,
+        120
+      ],
+      "id": "120ad01e-96a3-4c55-ae12-c5e9d53fd16c",
+      "name": "Create Google Doc"
     },
     {
       "parameters": {
         "resource": "draft",
         "operation": "create",
-        "subject": "=Re: {{ $('Gmail Trigger (New Emails)').item.json.snippet }}",
-        "message": "=Hello,\n\nThank you for reaching out with your request. Our internal Knowledge Manager agent has reviewed your requirements and prepared an initial draft for our team to finalize.\n\nInternal Reference Document: https://docs.google.com/document/d/{{ $json.documentId }}/edit\n\nWe will be in touch shortly.\n\nBest,\nProject NoeMI Team",
-        "toEmail": "={{ $('Gmail Trigger (New Emails)').item.json.from }}"
+        "subject": "=Re: {{ $('Gmail Trigger (New Emails)').item.json.subject || $('Gmail Trigger (New Emails)').item.json.snippet }}",
+        "message": "=Hello,\n\nThank you for reaching out with your request. We have created an internal draft document for our team to review before sending a final response.\n\nInternal Reference Document: https://docs.google.com/document/d/{{ $json.documentId }}/edit\n\nWe will follow up shortly.\n\nBest,\nProject NoeMI Team",
+        "toEmail": "={{ $('Gmail Trigger (New Emails)').item.json.from }}",
+        "options": {
+          "threadId": "={{ $('Gmail Trigger (New Emails)').item.json.threadId }}"
+        }
       },
-      "id": "5",
-      "name": "Draft Gmail Reply",
       "type": "n8n-nodes-base.gmail",
-      "typeVersion": 2,
+      "typeVersion": 2.2,
       "position": [
-        1050,
-        150
-      ]
+        1080,
+        120
+      ],
+      "id": "0c2e71d7-3a0a-48a3-bdb6-5ca5703561b7",
+      "name": "Draft Gmail Reply",
+      "credentials": {
+        "gmailOAuth2": {
+          "id": "REPLACE_WITH_YOUR_GMAIL_CREDENTIAL_ID",
+          "name": "Gmail account"
+        }
+      }
     },
     {
       "parameters": {},
-      "id": "6",
-      "name": "Ignore Non-RFPs",
       "type": "n8n-nodes-base.noOp",
       "typeVersion": 1,
       "position": [
-        850,
-        450
-      ]
+        840,
+        360
+      ],
+      "id": "9355548b-8f79-4865-b09f-baad7d25e2e7",
+      "name": "Ignore Non-RFPs"
     }
   ],
+  "pinData": {},
   "connections": {
     "Gmail Trigger (New Emails)": {
       "main": [
@@ -164,5 +209,17 @@
         ]
       ]
     }
-  }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "availableInMCP": false
+  },
+  "meta": {
+    "templateCredsSetupCompleted": false,
+    "instanceId": "REPLACE_WITH_YOUR_INSTANCE_ID"
+  },
+  "versionId": "cbf654e6-5ad2-45cf-9430-868a72b958d6",
+  "id": "rfpResponderTemplate",
+  "tags": []
 }

--- a/mcp-protocols/n8n.md
+++ b/mcp-protocols/n8n.md
@@ -5,7 +5,19 @@ This file contains specific capabilities, protocols, and workflows when interact
 Execute n8n operations silently. Call tools in parallel and report back only upon completion.
 
 #### 2. Multi-Level Validation
-When configuring nodes, use minimal validation first, then comprehensive runtime validation before building workflows.
+When configuring nodes, validate in layers:
+
+- credentials
+- node parameters
+- expressions
+- branch routing
+- workflow runtime behavior
 
 #### 3. Never Trust Defaults
 Always explicitly define configurations when interacting with nodes rather than relying on default parameters which often fail at runtime.
+
+#### 4. Do Not Assume Hidden Helper Tools
+Do not invent template catalogs, node validators, or workflow helper methods unless the orchestrator explicitly provides them. If the runtime only exposes JSON files or the n8n API, work within that real surface.
+
+#### 5. Prefer Current Node Types
+Use current built-in node types and explicit `typeVersion` values. Treat older workflow JSON as illustrative until verified against the target n8n release.

--- a/operating-profiles/PROFILE_TEMPLATE.md
+++ b/operating-profiles/PROFILE_TEMPLATE.md
@@ -1,0 +1,94 @@
+# {Locale Or Audience} Operating Profile
+
+## Profile Metadata
+
+- **Language:** `{language}`
+- **Locale:** `{locale}`
+- **Subregion:** `{subregion or n/a}`
+- **Sector:** `{sector or n/a}`
+- **Audience:** `{audience or n/a}`
+- **Inherits:** `{parent profiles}`
+- **Validated By:** `{human reviewer}`
+- **Last Validated On:** `{yyyy-mm-dd}`
+- **Evidence Sources:** `{interviews, customer observations, style guide, regulatory source}`
+
+## Purpose
+
+Describe how agent work should be adapted for this context beyond simple translation.
+
+## Language And Register
+
+- preferred language form
+- register and formality level
+- preferred level of directness
+- words or constructions to prefer
+- words or constructions to avoid
+
+## Workstyle Expectations
+
+- expected initiative before escalation
+- expected response pace
+- preferred handoff style
+- documentation depth normally expected
+- review or approval expectations
+
+## Trust Signals
+
+- what creates confidence locally
+- what phrasing or evidence helps
+- what comes across as careless, rude, or weak
+
+## Meetings And Scheduling
+
+- local norms for scheduling
+- punctuality expectations
+- meeting-prep expectations
+- follow-up expectations
+
+## Escalation And Decision-Making
+
+- when to escalate
+- how explicit the escalation should be
+- who is usually expected to decide
+- what consensus or approval pattern is normal
+
+## Compliance Or Formal Requirements
+
+- legal or regulatory notes that affect execution
+- record-keeping requirements
+- mandatory phrasing or disclosures if applicable
+
+## Audience-Specific Adjustments
+
+Only include identity-aware or audience-specific adjustments when they are explicit, locally validated, and necessary.
+
+- required inclusion or accessibility choices
+- specific audience expectations
+- opt-in communication constraints
+
+## Do Not Assume
+
+- list stereotypes or shortcuts the agent must avoid
+- list tempting but unsupported assumptions
+
+## Example Task Adaptations
+
+### Example 1
+
+- **Task:** `{task}`
+- **Default Behavior:** `{default approach}`
+- **Localized Behavior:** `{localized approach}`
+- **Why:** `{reason}`
+
+### Example 2
+
+- **Task:** `{task}`
+- **Default Behavior:** `{default approach}`
+- **Localized Behavior:** `{localized approach}`
+- **Why:** `{reason}`
+
+## Audit Notes
+
+- what is strongly evidenced
+- what is provisional
+- what still needs local validation

--- a/operating-profiles/README.md
+++ b/operating-profiles/README.md
@@ -1,0 +1,71 @@
+# Operating Profiles
+
+Operating Profiles are the Project NoeMI layer for culturally grounded execution.
+
+They are **not** simple translation files.
+
+They tell an agent how to adapt its work for a local context such as:
+
+- language
+- country
+- subregion
+- sector
+- audience
+
+## Design Goal
+
+Keep the core persona stable while varying the execution style responsibly.
+
+An agent answers:
+
+- what role am I playing?
+
+An operating profile answers:
+
+- how should this work be carried out here?
+
+## Directory Pattern
+
+Recommended layout:
+
+```text
+operating-profiles/
+├── PROFILE_TEMPLATE.md
+├── fr/
+│   └── fr-fr/
+│       ├── core.md
+│       ├── north.md
+│       └── south.md
+└── en/
+    └── en-us/
+        └── core.md
+```
+
+## Authoring Rules
+
+- use evidence, not stereotypes
+- keep subregional overlays small and explicit
+- separate hard requirements from local preference
+- require human validation for any locally specific claim
+- do not create hidden gender defaults
+
+## Safe Identity Handling
+
+If a profile must adapt for identity-related communications needs, handle that as an explicit, opt-in audience overlay with human review.
+
+Do not infer gender or rewrite work style based on assumed identity.
+
+## Start Small
+
+The first useful rollout is:
+
+1. one base language profile
+2. one country profile
+3. one subregional overlay
+4. one audience overlay
+
+That is enough to prove the system before adding more profile depth.
+
+## Template
+
+Use [`PROFILE_TEMPLATE.md`](PROFILE_TEMPLATE.md) as the canonical shape.

--- a/operating-profiles/README.md
+++ b/operating-profiles/README.md
@@ -24,6 +24,8 @@ An operating profile answers:
 
 - how should this work be carried out here?
 
+If you need to define what counts as success, what tradeoffs are acceptable, or whose benefit is being prioritized, use the separate Value Lens layer instead of putting that logic in an operating profile.
+
 ## Directory Pattern
 
 Recommended layout:
@@ -69,3 +71,5 @@ That is enough to prove the system before adding more profile depth.
 ## Template
 
 Use [`PROFILE_TEMPLATE.md`](PROFILE_TEMPLATE.md) as the canonical shape.
+
+For the companion framework, see [`../docs/frameworks/value-lenses.md`](../docs/frameworks/value-lenses.md).

--- a/tests/contracts.test.js
+++ b/tests/contracts.test.js
@@ -56,6 +56,16 @@ test('builder-facing docs point to the Docker Agent Home path', () => {
     assert.match(readme, /npm run validate/);
 });
 
+test('builder-facing docs expose the split Google Workspace implementation paths', () => {
+    const readme = read('README.md');
+    const mcpSetupIndex = read('docs/mcp-setup/README.md');
+
+    assert.match(readme, /docs\/tool-usages\/gemini-workspace-quickstart\.md/);
+    assert.match(readme, /docs\/examples\/n8n-google-workspace-quickstart\.md/);
+    assert.match(readme, /docs\/mcp-setup\/google-n8n-credential-matrix\.md/);
+    assert.match(mcpSetupIndex, /google-n8n-credential-matrix\.md/);
+});
+
 test('contributor guide documents the canonical validation and security flow', () => {
     const contributing = read('CONTRIBUTING.md');
     assert.match(contributing, /npm run validate/);

--- a/tests/contracts.test.js
+++ b/tests/contracts.test.js
@@ -66,6 +66,32 @@ test('builder-facing docs expose the split Google Workspace implementation paths
     assert.match(mcpSetupIndex, /google-n8n-credential-matrix\.md/);
 });
 
+test('builder-facing docs expose the local workspace comparison and client integration guides', () => {
+    const readme = read('README.md');
+    const mcpSetupIndex = read('docs/mcp-setup/README.md');
+
+    assert.match(readme, /docs\/tool-usages\/agentic-local-workspaces\.md/);
+    assert.match(readme, /docs\/tool-usages\/google-local-workspace\.md/);
+    assert.match(readme, /docs\/tool-usages\/claude-code-local-workspace\.md/);
+    assert.match(readme, /docs\/tool-usages\/openai-codex-local-workspace\.md/);
+    assert.match(readme, /docs\/mcp-setup\/google-workspace-agentic-clients\.md/);
+    assert.match(readme, /docs\/mcp-setup\/microsoft-365-agentic-clients\.md/);
+    assert.match(mcpSetupIndex, /google-workspace-agentic-clients\.md/);
+    assert.match(mcpSetupIndex, /microsoft-365-agentic-clients\.md/);
+});
+
+test('repo exposes the localized operating profile framework and template', () => {
+    const readme = read('README.md');
+    const framework = read('docs/frameworks/localized-operating-profiles.md');
+    const template = read('operating-profiles/PROFILE_TEMPLATE.md');
+
+    assert.match(readme, /operating-profiles\//);
+    assert.match(framework, /simple translation/i);
+    assert.match(framework, /inferred gender/i);
+    assert.match(template, /## Language And Register/);
+    assert.match(template, /## Do Not Assume/);
+});
+
 test('contributor guide documents the canonical validation and security flow', () => {
     const contributing = read('CONTRIBUTING.md');
     assert.match(contributing, /npm run validate/);

--- a/tests/contracts.test.js
+++ b/tests/contracts.test.js
@@ -92,6 +92,42 @@ test('repo exposes the localized operating profile framework and template', () =
     assert.match(template, /## Do Not Assume/);
 });
 
+test('repo exposes the value lens framework, starter lenses, and template', () => {
+    const readme = read('README.md');
+    const framework = read('docs/frameworks/value-lenses.md');
+    const template = read('value-lenses/LENS_TEMPLATE.md');
+    const performance = read('value-lenses/performance-efficiency.md');
+    const care = read('value-lenses/care-continuity.md');
+    const balanced = read('value-lenses/balanced-enterprise.md');
+
+    assert.match(readme, /value-lenses\//);
+    assert.match(framework, /neutral operational names/i);
+    assert.match(framework, /comparison mode/i);
+    assert.match(template, /## Core Success Question/);
+    assert.match(template, /## Failure Modes/);
+    assert.match(performance, /Lens ID:\*\* `performance-efficiency`/);
+    assert.match(care, /Lens ID:\*\* `care-continuity`/);
+    assert.match(balanced, /Lens ID:\*\* `balanced-enterprise`/);
+});
+
+test('repo exposes the visual guides and links them from the main entry docs', () => {
+    const readme = read('README.md');
+    const projectReference = read('docs/PROJECT_REFERENCE.md');
+    const visualsIndex = read('docs/visuals/README.md');
+    const systemMap = read('docs/visuals/noemi-system-map.md');
+    const audienceMap = read('docs/visuals/noemi-audience-entry-map.md');
+    const runtimeFlow = read('docs/visuals/noemi-runtime-flow.md');
+    const mindMap = read('docs/visuals/noemi-workshop-mind-map.md');
+
+    assert.match(readme, /docs\/visuals\/README\.md/);
+    assert.match(projectReference, /docs\/visuals\//);
+    assert.match(visualsIndex, /noemi-system-map\.md/);
+    assert.match(systemMap, /```mermaid/);
+    assert.match(audienceMap, /```mermaid/);
+    assert.match(runtimeFlow, /```mermaid/);
+    assert.match(mindMap, /```mermaid/);
+});
+
 test('contributor guide documents the canonical validation and security flow', () => {
     const contributing = read('CONTRIBUTING.md');
     assert.match(contributing, /npm run validate/);

--- a/tests/examples-smoke.test.js
+++ b/tests/examples-smoke.test.js
@@ -78,6 +78,44 @@ test('Google Workspace docs separate Gemini CLI, generic MCP, and n8n setup path
     assert.match(matrix, /n8n Gmail \/ Docs \/ Drive \/ Sheets nodes/);
 });
 
+test('local workspace docs explain CLI-first builder habits across Gemini, Claude, and Codex', () => {
+    const overview = read('docs/tool-usages/agentic-local-workspaces.md');
+    const google = read('docs/tool-usages/google-local-workspace.md');
+    const claude = read('docs/tool-usages/claude-code-local-workspace.md');
+    const codex = read('docs/tool-usages/openai-codex-local-workspace.md');
+    const googleClients = read('docs/mcp-setup/google-workspace-agentic-clients.md');
+    const microsoftClients = read('docs/mcp-setup/microsoft-365-agentic-clients.md');
+
+    assert.match(overview, /Builders \/ Practitioners/i);
+    assert.match(overview, /Accelerators/i);
+    assert.match(overview, /CLI is usually the most durable source of truth/i);
+    assert.match(google, /Antigravity/i);
+    assert.match(google, /gemini mcp add/);
+    assert.match(claude, /claude mcp add/);
+    assert.match(codex, /codex mcp add/);
+    assert.match(googleClients, /Gemini CLI/);
+    assert.match(googleClients, /Antigravity/);
+    assert.match(googleClients, /OpenAI Codex/);
+    assert.match(googleClients, /Claude Code app/);
+    assert.match(googleClients, /Claude Code CLI/);
+    assert.match(microsoftClients, /Microsoft 365, also commonly called Office 365/i);
+    assert.match(microsoftClients, /gemini mcp add microsoft365/);
+    assert.match(microsoftClients, /codex mcp add microsoft365/);
+    assert.match(microsoftClients, /claude mcp add microsoft365/);
+});
+
+test('localized operating profile docs separate culture from translation and guard against stereotypes', () => {
+    const framework = read('docs/frameworks/localized-operating-profiles.md');
+    const profilesReadme = read('operating-profiles/README.md');
+
+    assert.match(framework, /without collapsing everything into simple translation/i);
+    assert.match(framework, /language family/i);
+    assert.match(framework, /subregion or city cluster/i);
+    assert.match(framework, /inferred gender/i);
+    assert.match(profilesReadme, /culturally grounded execution/i);
+    assert.match(profilesReadme, /assumed identity/i);
+});
+
 test('n8n guidance avoids invented helper APIs and documents the real runtime surface', () => {
     const persona = read('docs/tool-usages/n8n-expert-persona.md');
     const protocol = read('mcp-protocols/n8n.md');

--- a/tests/examples-smoke.test.js
+++ b/tests/examples-smoke.test.js
@@ -116,6 +116,46 @@ test('localized operating profile docs separate culture from translation and gua
     assert.match(profilesReadme, /assumed identity/i);
 });
 
+test('value lens docs separate success logic from identity and define starter comparison lenses', () => {
+    const framework = read('docs/frameworks/value-lenses.md');
+    const lensesReadme = read('value-lenses/README.md');
+    const performance = read('value-lenses/performance-efficiency.md');
+    const care = read('value-lenses/care-continuity.md');
+    const balanced = read('value-lenses/balanced-enterprise.md');
+
+    assert.match(framework, /what counts as success here/i);
+    assert.match(framework, /should use \*\*neutral operational names\*\*/i);
+    assert.match(framework, /should never be silently inferred from gender or identity/i);
+    assert.match(lensesReadme, /explicit success criteria and tradeoff logic/i);
+    assert.match(performance, /speed/i);
+    assert.match(performance, /throughput/i);
+    assert.match(care, /continuity/i);
+    assert.match(care, /habitability/i);
+    assert.match(balanced, /business performance/i);
+    assert.match(balanced, /human sustainability/i);
+});
+
+test('visual guides provide distinct views for structure, navigation, execution, and workshop exploration', () => {
+    const visualsIndex = read('docs/visuals/README.md');
+    const systemMap = read('docs/visuals/noemi-system-map.md');
+    const audienceMap = read('docs/visuals/noemi-audience-entry-map.md');
+    const runtimeFlow = read('docs/visuals/noemi-runtime-flow.md');
+    const mindMap = read('docs/visuals/noemi-workshop-mind-map.md');
+
+    assert.match(visualsIndex, /system map/i);
+    assert.match(visualsIndex, /audience entry map/i);
+    assert.match(visualsIndex, /runtime flow/i);
+    assert.match(visualsIndex, /mind map/i);
+    assert.match(systemMap, /Phase 0 Security/i);
+    assert.match(systemMap, /Value Lenses/i);
+    assert.match(audienceMap, /Client \/ Buyer/i);
+    assert.match(audienceMap, /Builder \/ Accelerator/i);
+    assert.match(runtimeFlow, /Guardian and Governance/i);
+    assert.match(runtimeFlow, /Audit and ROI/i);
+    assert.match(mindMap, /mindmap/);
+    assert.match(mindMap, /Virtual Workforce/i);
+});
+
 test('n8n guidance avoids invented helper APIs and documents the real runtime surface', () => {
     const persona = read('docs/tool-usages/n8n-expert-persona.md');
     const protocol = read('mcp-protocols/n8n.md');

--- a/tests/examples-smoke.test.js
+++ b/tests/examples-smoke.test.js
@@ -61,3 +61,40 @@ test('Docker Agent Home guide connects the current example topologies', () => {
     assert.match(guide, /examples\/gatekeeper-deployment/);
     assert.match(guide, /not a runtime or execution engine/i);
 });
+
+test('Google Workspace docs separate Gemini CLI, generic MCP, and n8n setup paths', () => {
+    const geminiQuickstart = read('docs/tool-usages/gemini-workspace-quickstart.md');
+    const n8nQuickstart = read('docs/examples/n8n-google-workspace-quickstart.md');
+    const genericGoogleSetup = read('docs/mcp-setup/google-workspace.md');
+    const matrix = read('docs/mcp-setup/google-n8n-credential-matrix.md');
+
+    assert.match(geminiQuickstart, /gemini extensions install https:\/\/github\.com\/gemini-cli-extensions\/workspace/);
+    assert.match(geminiQuickstart, /does \*\*not\*\* use the generic `GOOGLE_CLIENT_ID`/);
+    assert.match(n8nQuickstart, /uses \*\*n8n credentials\*\*, not the Gemini CLI Workspace extension/i);
+    assert.match(genericGoogleSetup, /generic Google Workspace MCP server pattern/i);
+    assert.match(genericGoogleSetup, /Gemini CLI with the official Workspace extension/i);
+    assert.match(genericGoogleSetup, /n8n Google Workspace nodes/i);
+    assert.match(matrix, /Gemini CLI \+ Workspace extension/);
+    assert.match(matrix, /n8n Gmail \/ Docs \/ Drive \/ Sheets nodes/);
+});
+
+test('n8n guidance avoids invented helper APIs and documents the real runtime surface', () => {
+    const persona = read('docs/tool-usages/n8n-expert-persona.md');
+    const protocol = read('mcp-protocols/n8n.md');
+
+    assert.doesNotMatch(persona, /tools_documentation\(\)|validate_node\(|validate_workflow/);
+    assert.match(persona, /n8n editor or API/i);
+    assert.match(protocol, /Do Not Assume Hidden Helper Tools/);
+});
+
+test('RFP responder workflow uses the current Google Gemini node path', () => {
+    const workflow = JSON.parse(read('examples/workflows/rfp-responder.json'));
+    const workflowText = read('examples/workflows/rfp-responder.json');
+    const geminiNode = workflow.nodes.find((node) => node.name === 'Analyze Request (Gemini)');
+
+    assert.ok(geminiNode, 'Expected Analyze Request (Gemini) node to exist');
+    assert.equal(geminiNode.type, '@n8n/n8n-nodes-langchain.googleGemini');
+    assert.match(workflowText, /models\/gemini-2\.5-flash/);
+    assert.match(workflowText, /REPLACE_WITH_YOUR_GEMINI_API_CREDENTIAL_ID/);
+    assert.doesNotMatch(workflowText, /@n8n\/n8n-nodes-langchain\.chainLlm/);
+});

--- a/tests/fixtures/generated/active-mcps.md
+++ b/tests/fixtures/generated/active-mcps.md
@@ -11,10 +11,22 @@ This file contains specific capabilities, protocols, and workflows when interact
 Execute n8n operations silently. Call tools in parallel and report back only upon completion.
 
 #### 2. Multi-Level Validation
-When configuring nodes, use minimal validation first, then comprehensive runtime validation before building workflows.
+When configuring nodes, validate in layers:
+
+- credentials
+- node parameters
+- expressions
+- branch routing
+- workflow runtime behavior
 
 #### 3. Never Trust Defaults
 Always explicitly define configurations when interacting with nodes rather than relying on default parameters which often fail at runtime.
+
+#### 4. Do Not Assume Hidden Helper Tools
+Do not invent template catalogs, node validators, or workflow helper methods unless the orchestrator explicitly provides them. If the runtime only exposes JSON files or the n8n API, work within that real surface.
+
+#### 5. Prefer Current Node Types
+Use current built-in node types and explicit `typeVersion` values. Treat older workflow JSON as illustrative until verified against the target n8n release.
 
 ### Slack Protocol
 

--- a/value-lenses/LENS_TEMPLATE.md
+++ b/value-lenses/LENS_TEMPLATE.md
@@ -1,0 +1,84 @@
+# {Lens Name} Value Lens
+
+## Lens Metadata
+
+- **Lens ID:** `{slug}`
+- **Owner:** `{human owner}`
+- **Status:** `{draft or active}`
+- **Last Validated On:** `{yyyy-mm-dd}`
+- **Evidence Sources:** `{policy, interviews, operating practice, research}`
+
+## Purpose
+
+Describe what this lens optimizes for and how it evaluates success.
+
+## Core Success Question
+
+What is the first question this lens asks when judging a result?
+
+## Success Dimensions
+
+- `{dimension 1}`
+- `{dimension 2}`
+- `{dimension 3}`
+
+## Primary Stakeholders Counted
+
+- `{stakeholder group}`
+- `{stakeholder group}`
+
+## Time Horizon
+
+- immediate
+- short-cycle
+- medium-term
+- long-term
+
+Describe which horizon dominates this lens.
+
+## Preferred Evidence
+
+- metrics
+- user outcomes
+- continuity indicators
+- operational resilience
+- auditability
+
+## Acceptable Tradeoffs
+
+- what this lens is willing to sacrifice
+- what this lens is not willing to sacrifice
+
+## Common Blind Spots
+
+- what this lens may underweight
+- what another lens may see more clearly
+
+## Failure Modes
+
+- what "success" under this lens can accidentally damage
+- what misuse looks like
+
+## Comparison Guidance
+
+When this lens conflicts with another lens, how should the system explain the difference?
+
+## Example Evaluation
+
+### Example 1
+
+- **Task:** `{task}`
+- **What This Lens Rewards:** `{criteria}`
+- **What This Lens Penalizes:** `{criteria}`
+- **Likely Outcome:** `{summary}`
+
+### Example 2
+
+- **Task:** `{task}`
+- **What This Lens Rewards:** `{criteria}`
+- **What This Lens Penalizes:** `{criteria}`
+- **Likely Outcome:** `{summary}`
+
+## Audit Notes
+
+- what must be visible in the audit trail when this lens is active

--- a/value-lenses/README.md
+++ b/value-lenses/README.md
@@ -1,0 +1,54 @@
+# Value Lenses
+
+Value Lenses are the Project NoeMI layer for explicit success criteria and tradeoff logic.
+
+They are not:
+
+- personas
+- operating profiles
+- translations
+
+They answer a different question:
+
+- what does good look like here?
+
+## Design Goal
+
+Make the active value system explicit instead of leaving it hidden inside prompts, habits, or enterprise politics.
+
+## Directory Pattern
+
+Recommended layout:
+
+```text
+value-lenses/
+├── LENS_TEMPLATE.md
+├── performance-efficiency.md
+├── care-continuity.md
+└── balanced-enterprise.md
+```
+
+## Authoring Rules
+
+- use neutral operational language
+- define success dimensions clearly
+- define stakeholders and time horizon explicitly
+- document acceptable tradeoffs
+- document failure modes
+- do not use identity stereotypes as scoring logic
+
+## Safe Governance Rule
+
+If the active lens materially changes a recommendation, it should be visible in the audit trail or decision summary.
+
+## First Rollout
+
+The repository starts with three baseline lenses:
+
+1. `performance-efficiency`
+2. `care-continuity`
+3. `balanced-enterprise`
+
+## Template
+
+Use [`LENS_TEMPLATE.md`](LENS_TEMPLATE.md) as the canonical shape.

--- a/value-lenses/balanced-enterprise.md
+++ b/value-lenses/balanced-enterprise.md
@@ -1,0 +1,87 @@
+# Balanced-Enterprise Value Lens
+
+## Lens Metadata
+
+- **Lens ID:** `balanced-enterprise`
+- **Owner:** `TBD`
+- **Status:** `starter`
+- **Last Validated On:** `2026-04-03`
+- **Evidence Sources:** `enterprise governance, delivery management, sustainability and people operations`
+
+## Purpose
+
+Balance practical business performance with human sustainability, trust, and long-term enterprise viability.
+
+## Core Success Question
+
+Is this a decision the enterprise can defend both operationally and humanly over time?
+
+## Success Dimensions
+
+- viability
+- delivery effectiveness
+- sustainability
+- trustworthiness
+- maintainability
+
+## Primary Stakeholders Counted
+
+- business owners
+- operators
+- affected teams
+- end users or customers
+
+## Time Horizon
+
+This lens balances short-cycle performance with medium-term and long-term viability.
+
+## Preferred Evidence
+
+- delivery metrics
+- quality outcomes
+- maintenance burden
+- user trust indicators
+- operational resilience
+
+## Acceptable Tradeoffs
+
+- acceptable: moderate slowdown for material quality or trust gains
+- acceptable: controlled automation when escalation paths remain clear
+- not acceptable: a result that looks efficient now but weakens the enterprise later
+
+## Common Blind Spots
+
+- can become vague if tradeoffs are not made explicit
+- may default to compromise language without resolving the real tension
+
+## Failure Modes
+
+- splitting the difference without strategic clarity
+- hiding conflict under the word "balance"
+- becoming a default lens that nobody examines critically
+
+## Comparison Guidance
+
+When this lens conflicts with another lens, explain which side of the tradeoff it softens and which hard constraint it refuses to cross.
+
+## Example Evaluation
+
+### Example 1
+
+- **Task:** deploy a new automation workflow
+- **What This Lens Rewards:** measurable efficiency with safe review points and maintainable ownership
+- **What This Lens Penalizes:** either reckless speed or overly abstract caution
+- **Likely Outcome:** chooses staged rollout with clear metrics and human override
+
+### Example 2
+
+- **Task:** score an AI-assisted client onboarding flow
+- **What This Lens Rewards:** faster delivery, preserved client trust, sustainable team workload
+- **What This Lens Penalizes:** one-sided success definitions
+- **Likely Outcome:** favors implementation that is operationally useful without degrading the client relationship
+
+## Audit Notes
+
+- active lens id
+- competing priorities considered
+- why the chosen balance was accepted

--- a/value-lenses/care-continuity.md
+++ b/value-lenses/care-continuity.md
@@ -1,0 +1,87 @@
+# Care-Continuity Value Lens
+
+## Lens Metadata
+
+- **Lens ID:** `care-continuity`
+- **Owner:** `TBD`
+- **Status:** `starter`
+- **Last Validated On:** `2026-04-03`
+- **Evidence Sources:** `care ethics, sustainability practice, continuity-focused operating design`
+
+## Purpose
+
+Optimize for continuity, sustainability, trust, human impact, and the long-term livability of the system surrounding the work.
+
+## Core Success Question
+
+Does this result preserve or improve the human and organizational conditions that must continue living with it?
+
+## Success Dimensions
+
+- continuity
+- trust
+- sustainability
+- human impact
+- habitability
+
+## Primary Stakeholders Counted
+
+- people affected by the work over time
+- teams who must maintain the outcome
+- communities or relationships carrying the downstream impact
+
+## Time Horizon
+
+This lens emphasizes medium-term and long-term effects, while still checking near-term harm.
+
+## Preferred Evidence
+
+- downstream burden
+- trust retention
+- maintenance effort
+- human wellbeing indicators
+- resilience over time
+
+## Acceptable Tradeoffs
+
+- acceptable: slower rollout if it protects continuity and trust
+- acceptable: more handoff clarity if it reduces hidden burden
+- not acceptable: speed gains that externalize cost onto people or degrade livability
+
+## Common Blind Spots
+
+- underweighting urgent delivery needs
+- underweighting near-term efficiency
+- creating frustration if no practical execution path is preserved
+
+## Failure Modes
+
+- becoming so cautious that useful action stalls
+- overvaluing harmony at the expense of necessary decisions
+- protecting continuity without enough operational realism
+
+## Comparison Guidance
+
+When this lens conflicts with another lens, explain what downstream human or organizational cost is being avoided and what short-term speed or efficiency is being traded away.
+
+## Example Evaluation
+
+### Example 1
+
+- **Task:** automate customer support routing
+- **What This Lens Rewards:** reduced confusion, better handoffs, preserved trust, sustainable human oversight
+- **What This Lens Penalizes:** brittle automation that escalates frustration later
+- **Likely Outcome:** favors a slower rollout with clearer fallback paths and human review
+
+### Example 2
+
+- **Task:** redesign internal reporting
+- **What This Lens Rewards:** readability, shared understanding, maintainability, lower long-term burden
+- **What This Lens Penalizes:** dashboards that optimize vanity metrics while hiding care burden
+- **Likely Outcome:** favors a calmer but more durable reporting system
+
+## Audit Notes
+
+- active lens id
+- long-term stakeholders counted
+- continuity or trust risks flagged

--- a/value-lenses/performance-efficiency.md
+++ b/value-lenses/performance-efficiency.md
@@ -1,0 +1,87 @@
+# Performance-Efficiency Value Lens
+
+## Lens Metadata
+
+- **Lens ID:** `performance-efficiency`
+- **Owner:** `TBD`
+- **Status:** `starter`
+- **Last Validated On:** `2026-04-03`
+- **Evidence Sources:** `enterprise operations, throughput management, delivery governance`
+
+## Purpose
+
+Optimize for reliable output, speed, efficiency, and measurable operational performance.
+
+## Core Success Question
+
+Did this produce the required result quickly, clearly, and at an acceptable cost?
+
+## Success Dimensions
+
+- speed
+- throughput
+- predictability
+- measurable output
+- cost discipline
+
+## Primary Stakeholders Counted
+
+- operators responsible for delivery
+- business owners responsible for efficiency
+- customers waiting on completion
+
+## Time Horizon
+
+This lens emphasizes immediate and short-cycle performance.
+
+## Preferred Evidence
+
+- cycle time
+- completion rate
+- queue reduction
+- cost per task
+- error rate
+
+## Acceptable Tradeoffs
+
+- acceptable: less elegance in exchange for reliable delivery
+- acceptable: narrower scope if it improves execution speed
+- not acceptable: speed that creates hidden instability or harms trust materially
+
+## Common Blind Spots
+
+- underweighting relational damage
+- underweighting long-term sustainability
+- underweighting care burdens shifted onto humans later
+
+## Failure Modes
+
+- optimizing teams into burnout
+- winning on metrics while degrading trust
+- creating brittle systems that look productive in the short term
+
+## Comparison Guidance
+
+When this lens conflicts with another lens, explain what short-cycle gains are being purchased and what longer-term costs may be hidden.
+
+## Example Evaluation
+
+### Example 1
+
+- **Task:** triage inbound requests
+- **What This Lens Rewards:** quick classification, low backlog, clear routing
+- **What This Lens Penalizes:** delays, ambiguous ownership, excessive manual handling
+- **Likely Outcome:** chooses the fastest stable routing pattern with measurable queue relief
+
+### Example 2
+
+- **Task:** prepare weekly reporting
+- **What This Lens Rewards:** automated generation, consistency, low manual effort
+- **What This Lens Penalizes:** bespoke presentation work with little operational value
+- **Likely Outcome:** favors standardized reporting with strong repeatability
+
+## Audit Notes
+
+- active lens id
+- core metrics used
+- short-cycle tradeoffs accepted


### PR DESCRIPTION
## Summary
- split the Google Workspace implementation story into separate Gemini CLI, generic MCP, and n8n quickstarts
- modernize the n8n RFP responder workflow to use the current Google Gemini node path
- add regression tests so setup-path and workflow drift are caught by validation

## Validation
- npm run validate