### PR TITLE
docs(frameworks): restore value lens public naming

### DIFF
--- a/docs/frameworks/value-lenses.md
+++ b/docs/frameworks/value-lenses.md
@@ -70,7 +70,9 @@ That means the implementation can preserve the conceptual distinction without sa
 
 ## Recommended Starter Lenses
 
-### 1. Competitiveness-Output Lens
+These are the public-facing lens names used throughout the repository because they are clearer and more marketable for broad audiences, while still carrying the deeper Demographic Mathésis framework underneath.
+
+### 1. Performance-Efficiency Lens
 
 Optimizes for:
 
@@ -84,7 +86,7 @@ Blind spot:
 
 - high risk of demographic debt and erosion of trust networks
 
-### 2. Care-Demographic-Vitality Lens
+### 2. Care-Continuity Lens
 
 Optimizes for:
 
@@ -98,7 +100,7 @@ Core question:
 
 - does this action support or deplete the human ecosystem over a 10-year horizon?
 
-### 3. Mathesis-Integrative Lens
+### 3. Balanced-Enterprise Lens
 
 Optimizes for:
 
@@ -137,9 +139,9 @@ Default rule:
 value-lenses/
 ├── README.md
 ├── LENS_TEMPLATE.md
-├── competitiveness-output.md
-├── care-demographic-vitality.md
-└── mathesis-integrative.md
+├── performance-efficiency.md
+├── care-continuity.md
+└── balanced-enterprise.md
 ```
 
 ## Activation Model
@@ -159,7 +161,7 @@ The value lens should refine the definition of success, not replace the role.
 - the lens should be human-selected for high-stakes work
 - the lens should never be silently inferred from gender or identity
 - if no lens is chosen, default to a documented enterprise baseline
-- the default baseline for this repository is `mathesis-integrative`
+- the default baseline for this repository is `balanced-enterprise`
 
 ## Comparison Mode
 

--- a/docs/visuals/noemi-system-map.md
+++ b/docs/visuals/noemi-system-map.md
@@ -13,7 +13,7 @@ flowchart TD
     mcps["MCP Protocols and Integrations\nGoogle Workspace, Microsoft 365, Slack, GitHub, n8n, web"]
     clients["Agentic Clients and Orchestrators\nGemini CLI, Antigravity, Claude Code, Codex, n8n"]
     profiles["Operating Profiles\nLocale, subregion, sector, audience"]
-    lenses["Value Lenses\nCompetitiveness-output, care-demographic-vitality, mathesis-integrative"]
+    lenses["Value Lenses\nPerformance-efficiency, care-continuity, balanced-enterprise"]
     runtime["Runtime Execution\nPrompts, approvals, retries, human review"]
     governance["Governance and Guardian Layer\nTRiSM, red teaming, diligence, refusal principle"]
     audit["Audit, ROI, and Observability\nLogs, dashboards, decision traces, ROI"]

--- a/tests/contracts.test.js
+++ b/tests/contracts.test.js
@@ -96,9 +96,9 @@ test('repo exposes the value lens framework, starter lenses, and template', () =
     const readme = read('README.md');
     const framework = read('docs/frameworks/value-lenses.md');
     const template = read('value-lenses/LENS_TEMPLATE.md');
-    const competitiveness = read('value-lenses/competitiveness-output.md');
-    const care = read('value-lenses/care-demographic-vitality.md');
-    const mathesis = read('value-lenses/mathesis-integrative.md');
+    const performance = read('value-lenses/performance-efficiency.md');
+    const care = read('value-lenses/care-continuity.md');
+    const balanced = read('value-lenses/balanced-enterprise.md');
 
     assert.match(readme, /value-lenses\//);
     assert.match(framework, /neutral operational names/i);
@@ -109,9 +109,9 @@ test('repo exposes the value lens framework, starter lenses, and template', () =
     assert.match(template, /## Care Capital/);
     assert.match(template, /## Demographic Footprint/);
     assert.match(template, /## Failure Modes/);
-    assert.match(competitiveness, /Lens ID:\*\* `competitiveness-output`/);
-    assert.match(care, /Lens ID:\*\* `care-demographic-vitality`/);
-    assert.match(mathesis, /Lens ID:\*\* `mathesis-integrative`/);
+    assert.match(performance, /Lens ID:\*\* `performance-efficiency`/);
+    assert.match(care, /Lens ID:\*\* `care-continuity`/);
+    assert.match(balanced, /Lens ID:\*\* `balanced-enterprise`/);
 });
 
 test('repo exposes the visual guides and links them from the main entry docs', () => {

--- a/tests/examples-smoke.test.js
+++ b/tests/examples-smoke.test.js
@@ -119,9 +119,9 @@ test('localized operating profile docs separate culture from translation and gua
 test('value lens docs separate success logic from identity and define starter comparison lenses', () => {
     const framework = read('docs/frameworks/value-lenses.md');
     const lensesReadme = read('value-lenses/README.md');
-    const competitiveness = read('value-lenses/competitiveness-output.md');
-    const care = read('value-lenses/care-demographic-vitality.md');
-    const mathesis = read('value-lenses/mathesis-integrative.md');
+    const performance = read('value-lenses/performance-efficiency.md');
+    const care = read('value-lenses/care-continuity.md');
+    const balanced = read('value-lenses/balanced-enterprise.md');
 
     assert.match(framework, /what counts as success here/i);
     assert.match(framework, /should use \*\*neutral operational names\*\*/i);
@@ -129,13 +129,13 @@ test('value lens docs separate success logic from identity and define starter co
     assert.match(framework, /Demographic Math[ée]sis/i);
     assert.match(lensesReadme, /explicit success criteria and tradeoff logic/i);
     assert.match(lensesReadme, /Comparison Mode/i);
-    assert.match(competitiveness, /ROI/i);
-    assert.match(competitiveness, /Demographic Debt/i);
+    assert.match(performance, /ROI/i);
+    assert.match(performance, /Demographic Debt/i);
     assert.match(care, /Care Capital/i);
     assert.match(care, /10-year horizon/i);
-    assert.match(mathesis, /default lens/i);
-    assert.match(mathesis, /Demographic Footprint/i);
-    assert.match(mathesis, /competitiveness and care/i);
+    assert.match(balanced, /default/i);
+    assert.match(balanced, /Demographic Footprint/i);
+    assert.match(balanced, /business viability/i);
 });
 
 test('visual guides provide distinct views for structure, navigation, execution, and workshop exploration', () => {

--- a/value-lenses/README.md
+++ b/value-lenses/README.md
@@ -28,6 +28,8 @@ Make the active value system explicit instead of leaving it hidden inside prompt
 
 This layer is where Project NoeMI integrates traditional business efficiency with the Demographic Mathésis view of long-term human sustainability.
 
+For public-facing docs, workshops, and onboarding, Project NoeMI uses the more intuitive lens names below because they are easier to explain quickly to a broad audience.
+
 ## Directory Pattern
 
 Recommended layout:
@@ -35,9 +37,9 @@ Recommended layout:
 ```text
 value-lenses/
 ├── LENS_TEMPLATE.md
-├── competitiveness-output.md
-├── care-demographic-vitality.md
-└── mathesis-integrative.md
+├── performance-efficiency.md
+├── care-continuity.md
+└── balanced-enterprise.md
 ```
 
 ## Authoring Rules
@@ -83,9 +85,9 @@ Comparison Mode should highlight:
 
 The repository starts with three baseline lenses:
 
-1. `competitiveness-output`
-2. `care-demographic-vitality`
-3. `mathesis-integrative`
+1. `performance-efficiency`
+2. `care-continuity`
+3. `balanced-enterprise`
 
 ## Template
 

--- a/value-lenses/balanced-enterprise.md
+++ b/value-lenses/balanced-enterprise.md
@@ -1,18 +1,18 @@
-# Mathesis-Integrative Value Lens
+# Balanced-Enterprise Value Lens
 
 ## Lens Metadata
 
-- **Lens ID:** `mathesis-integrative`
+- **Lens ID:** `balanced-enterprise`
 - **Owner:** `TBD`
 - **Status:** `default`
-- **Last Validated On:** `2026-04-03`
+- **Last Validated On:** `2026-04-04`
 - **Evidence Sources:** `enterprise governance, demographic Mathésis framing, operational sustainability practice`
 
 ## Purpose
 
-Optimize for the mathematical equilibrium between competitiveness and care.
+Optimize for practical business viability without degrading the human system that must sustain the result.
 
-This is the default lens for Project NoeMI. It seeks practical business viability without degrading the human system that must sustain the result.
+This is the public-facing default name for the integrative Mathésis logic inside the Value Lens framework.
 
 ## Core Success Question
 

--- a/value-lenses/care-continuity.md
+++ b/value-lenses/care-continuity.md
@@ -1,18 +1,18 @@
-# Care-Demographic-Vitality Value Lens
+# Care-Continuity Value Lens
 
 ## Lens Metadata
 
-- **Lens ID:** `care-demographic-vitality`
+- **Lens ID:** `care-continuity`
 - **Owner:** `TBD`
 - **Status:** `starter`
-- **Last Validated On:** `2026-04-03`
+- **Last Validated On:** `2026-04-04`
 - **Evidence Sources:** `care ethics, demographic sustainability research, continuity-focused operating design`
 
 ## Purpose
 
 Optimize for relational health, system habitability, and long-term human viability.
 
-This lens is designed to surface whether an apparently successful action actually supports or depletes the human ecosystem that must continue sustaining the organization.
+This is the public-facing name for the care-and-demographic-vitality logic inside the Value Lens framework.
 
 ## Core Success Question
 

--- a/value-lenses/performance-efficiency.md
+++ b/value-lenses/performance-efficiency.md
@@ -1,18 +1,18 @@
-# Competitiveness-Output Value Lens
+# Performance-Efficiency Value Lens
 
 ## Lens Metadata
 
-- **Lens ID:** `competitiveness-output`
+- **Lens ID:** `performance-efficiency`
 - **Owner:** `TBD`
 - **Status:** `starter`
-- **Last Validated On:** `2026-04-03`
+- **Last Validated On:** `2026-04-04`
 - **Evidence Sources:** `enterprise operations, delivery management, market-facing performance governance`
 
 ## Purpose
 
 Optimize for ROI, speed, throughput, and market predictability.
 
-This lens is useful when the organization must improve visible output quickly and can justify short-cycle optimization with clear commercial evidence.
+This is the public-facing name for the competitiveness-focused logic inside the Value Lens framework.
 
 ## Core Success Question
 


### PR DESCRIPTION
## Summary
- restore the more marketable public-facing value lens names
- keep the deeper Care Capital, Demographic Footprint, and Mathésis framework underneath
- update visuals and tests to match the restored naming

## Validation
- npm run validate