### PR TITLE
docs(onboarding): add beginner-first local path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ Project NoéMI is the **public reference architecture** for NewPush's AI fluency
 
 > **Need the fastest orientation?** Start with the [**Visual Guides**](docs/visuals/README.md) for the system map, audience path, runtime flow, and workshop mind map.
 
+> **New to AI and want one safe first win?** Start with [**Zero To First Agent**](docs/examples/zero-to-first-agent.md).
+
 **Audience paths:**
 - **Client / Buyer:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Phase 0 Security Baseline](docs/PHASE_ZERO_SECURITY_BASELINE.md) → [Phase 0 Assessment Kit](docs/phase-zero-assessment/README.md)
 - **MSP / MSSP:** [Project Reference](docs/PROJECT_REFERENCE.md) → [MSP Deployment Guide](docs/examples/msp-deployment.md) → [Fleet / governance docs](docs/agents/operations/)
-- **Builder / Accelerator:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Secure Secret Management](docs/tool-usages/secure-secret-management.md) → [Agentic Local Workspaces](docs/tool-usages/agentic-local-workspaces.md) → [Google Local Workspace](docs/tool-usages/google-local-workspace.md), [Claude Code Local Workspace](docs/tool-usages/claude-code-local-workspace.md), or [OpenAI Codex Local Workspace](docs/tool-usages/openai-codex-local-workspace.md) → [Google Workspace For Agentic Clients](docs/mcp-setup/google-workspace-agentic-clients.md) or [Microsoft 365 For Agentic Clients](docs/mcp-setup/microsoft-365-agentic-clients.md) → [Value Lenses](docs/frameworks/value-lenses.md) → [Gemini Workspace Quickstart](docs/tool-usages/gemini-workspace-quickstart.md) or [n8n Google Workspace Quickstart](docs/examples/n8n-google-workspace-quickstart.md) → [Builder First 30 Minutes](docs/examples/builder-first-30-minutes.md) → [Docker Agent Home](docs/examples/docker-agent-home.md) → [Orchestrator Runtime Contract](docs/tool-usages/orchestrator-runtime-contract.md)
+- **Builder / Accelerator:** [Zero To First Agent](docs/examples/zero-to-first-agent.md) → [Secure Secret Management](docs/tool-usages/secure-secret-management.md) → [Agentic Local Workspaces](docs/tool-usages/agentic-local-workspaces.md) → [Google Local Workspace](docs/tool-usages/google-local-workspace.md), [Claude Code Local Workspace](docs/tool-usages/claude-code-local-workspace.md), or [OpenAI Codex Local Workspace](docs/tool-usages/openai-codex-local-workspace.md) → [Google Workspace For Agentic Clients](docs/mcp-setup/google-workspace-agentic-clients.md) or [Microsoft 365 For Agentic Clients](docs/mcp-setup/microsoft-365-agentic-clients.md) → [Value Lenses](docs/frameworks/value-lenses.md) → [Gemini Workspace Quickstart](docs/tool-usages/gemini-workspace-quickstart.md) or [n8n Google Workspace Quickstart](docs/examples/n8n-google-workspace-quickstart.md) → [Builder First 30 Minutes](docs/examples/builder-first-30-minutes.md) → [Docker Agent Home](docs/examples/docker-agent-home.md) → [Orchestrator Runtime Contract](docs/tool-usages/orchestrator-runtime-contract.md)
 
 ## Table of Contents
 
@@ -32,15 +34,15 @@ Project NoéMI is the **public reference architecture** for NewPush's AI fluency
 
 ## Quick Start
 
-**Prerequisites:** [Node.js](https://nodejs.org/) (24.x LTS recommended; 25+ supported), [Docker](https://www.docker.com/), and a secret manager ([Infisical CLI](https://infisical.com/docs/cli/overview) or [1Password CLI](https://developer.1password.com/docs/cli/))
+**Prerequisites:** [Node.js](https://nodejs.org/) (24.x LTS recommended; 25+ supported), [Git](https://git-scm.com/), one supported local client ([Gemini CLI](https://github.com/google-gemini/gemini-cli), Claude Code, or OpenAI Codex), and a secret manager ([Infisical CLI](https://infisical.com/docs/cli/overview) or [1Password CLI](https://developer.1password.com/docs/cli/)) before you connect business systems. [Docker](https://www.docker.com/) becomes part of the path when you are ready to build a runtime home.
 
 ```bash
 # 1. Clone the repository
 git clone https://github.com/newpush/agents.git
 cd agents
 
-# 2. Verify your environment has the required tools
-bash scripts/verify-env.sh
+# 2. Verify the beginner local-first path
+bash scripts/verify-env.sh --mode=builder
 
 # 3. Configure which MCP integrations are active (edit as needed)
 cat mcp.config.json
@@ -51,16 +53,23 @@ node scripts/generate_all.js      # Generates both GEMINI.md and CLAUDE.md
 # 5. Run the fast validation gate
 npm run validate
 
-# 6. Run Docker smoke validation when Docker is available
+# 6. Prove one safe local task first
+# Example with Gemini CLI. If you chose Claude Code or Codex, use the same repo-local prompt there instead.
+gemini -p GEMINI.md "List the engineering agents in this repository and summarize what each one does in one sentence."
+
+# 7. Run Docker smoke validation when Docker is available
 npm run test:e2e
 
-# 7. Use the generated context with your orchestrator
-# Example with Gemini CLI:
-infisical run --env=dev -- gemini -p GEMINI.md "List all open PRs in our org"
+# 8. When you need secrets, wrap the client at launch time
+infisical run --env=dev -- gemini
+# or:
+op run --env-file=.env.template -- gemini
 # Claude Code reads CLAUDE.md automatically when opened in this repository
+# Codex can be launched through the same Fetch-on-Demand pattern
 ```
 
 The generated `GEMINI.md` and `CLAUDE.md` files contain your agent personas, security mandates, and MCP protocol definitions — everything an orchestrator needs to act as your agents.
+If you are completely new to AI implementation, follow [`docs/examples/zero-to-first-agent.md`](docs/examples/zero-to-first-agent.md) before the Docker-oriented builder path.
 
 The same validation gates are enforced in GitHub Actions on pushes and pull requests targeting `develop` and `main`, so local validation mirrors the repository's CI contract.
 When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-smoke/` or the uploaded `docker-smoke-diagnostics` artifact.
@@ -73,7 +82,7 @@ When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-
 |----------|------------|------------|
 | **Client / Buyer** | [`docs/PROJECT_REFERENCE.md`](docs/PROJECT_REFERENCE.md) | [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](docs/PHASE_ZERO_SECURITY_BASELINE.md), [`docs/phase-zero-assessment/README.md`](docs/phase-zero-assessment/README.md) |
 | **MSP / MSSP** | [`docs/PROJECT_REFERENCE.md`](docs/PROJECT_REFERENCE.md) | [`docs/examples/msp-deployment.md`](docs/examples/msp-deployment.md), [`docs/agents/operations/`](docs/agents/operations/) |
-| **Builder / Accelerator** | [`docs/tool-usages/secure-secret-management.md`](docs/tool-usages/secure-secret-management.md) | [`docs/tool-usages/agentic-local-workspaces.md`](docs/tool-usages/agentic-local-workspaces.md), [`docs/tool-usages/google-local-workspace.md`](docs/tool-usages/google-local-workspace.md), [`docs/tool-usages/claude-code-local-workspace.md`](docs/tool-usages/claude-code-local-workspace.md), [`docs/tool-usages/openai-codex-local-workspace.md`](docs/tool-usages/openai-codex-local-workspace.md), [`docs/mcp-setup/google-workspace-agentic-clients.md`](docs/mcp-setup/google-workspace-agentic-clients.md), [`docs/mcp-setup/microsoft-365-agentic-clients.md`](docs/mcp-setup/microsoft-365-agentic-clients.md), [`docs/tool-usages/gemini-workspace-quickstart.md`](docs/tool-usages/gemini-workspace-quickstart.md), [`docs/examples/n8n-google-workspace-quickstart.md`](docs/examples/n8n-google-workspace-quickstart.md), [`docs/mcp-setup/google-n8n-credential-matrix.md`](docs/mcp-setup/google-n8n-credential-matrix.md), [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md), [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md), [`docs/examples/docker-runtime-verification.md`](docs/examples/docker-runtime-verification.md), [`docs/tool-usages/orchestrator-runtime-contract.md`](docs/tool-usages/orchestrator-runtime-contract.md), [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md) |
+| **Builder / Accelerator** | [`docs/examples/zero-to-first-agent.md`](docs/examples/zero-to-first-agent.md) | [`docs/tool-usages/secure-secret-management.md`](docs/tool-usages/secure-secret-management.md), [`docs/tool-usages/agentic-local-workspaces.md`](docs/tool-usages/agentic-local-workspaces.md), [`docs/tool-usages/google-local-workspace.md`](docs/tool-usages/google-local-workspace.md), [`docs/tool-usages/claude-code-local-workspace.md`](docs/tool-usages/claude-code-local-workspace.md), [`docs/tool-usages/openai-codex-local-workspace.md`](docs/tool-usages/openai-codex-local-workspace.md), [`docs/mcp-setup/google-workspace-agentic-clients.md`](docs/mcp-setup/google-workspace-agentic-clients.md), [`docs/mcp-setup/microsoft-365-agentic-clients.md`](docs/mcp-setup/microsoft-365-agentic-clients.md), [`docs/tool-usages/gemini-workspace-quickstart.md`](docs/tool-usages/gemini-workspace-quickstart.md), [`docs/examples/n8n-google-workspace-quickstart.md`](docs/examples/n8n-google-workspace-quickstart.md), [`docs/mcp-setup/google-n8n-credential-matrix.md`](docs/mcp-setup/google-n8n-credential-matrix.md), [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md), [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md), [`docs/examples/docker-runtime-verification.md`](docs/examples/docker-runtime-verification.md), [`docs/tool-usages/orchestrator-runtime-contract.md`](docs/tool-usages/orchestrator-runtime-contract.md), [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md) |
 
 ---
 
@@ -157,7 +166,7 @@ When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-
 │   ├── generate_claude.js           # Builds CLAUDE.md from template + agent index + skills + MCPs
 │   ├── audit-repo.js               # Fails on persona/generator drift
 │   ├── retry-with-backoff.sh       # Reference retry helper for transient failures
-│   └── verify-env.sh               # Checks prerequisites (Docker, CLI tools)
+│   └── verify-env.sh               # Checks prerequisites by path (builder, client, Docker)
 │
 ├── tests/                          # Node built-in contract and smoke tests
 ├── package.json                    # Validation and generation entrypoints
@@ -301,7 +310,7 @@ Read `GEMINI.md`, `CLAUDE.md`, or individual agent specs from `agents/` as syste
 
 ## Deploying the Examples
 
-All examples use the **Fetch-on-Demand** security model: secrets are injected at runtime via vault CLI wrappers (`infisical run` or `op run`), never hardcoded. Start with the **Secure Secret Management** demo, then follow the [Builder First 30 Minutes guide](docs/examples/builder-first-30-minutes.md) and the [Docker Agent Home guide](docs/examples/docker-agent-home.md) before trying legacy Python examples. See [Security Model](#security-model) for details.
+All examples use the **Fetch-on-Demand** security model: secrets are injected at runtime via vault CLI wrappers (`infisical run` or `op run`), never hardcoded. If you are new, start with [Zero To First Agent](docs/examples/zero-to-first-agent.md), then move into the [Secure Secret Management guide](docs/tool-usages/secure-secret-management.md), the [Builder First 30 Minutes guide](docs/examples/builder-first-30-minutes.md), and the [Docker Agent Home guide](docs/examples/docker-agent-home.md) before trying legacy Python examples. See [Security Model](#security-model) for details.
 
 ### 1. Docker Sandbox (Historical Python Example)
 
@@ -502,6 +511,7 @@ All documentation lives in `docs/`. Here's where to find what:
 |----------------|-------|
 | Client-side Phase 0 guidance | [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](docs/PHASE_ZERO_SECURITY_BASELINE.md) |
 | Phase 0 assessment kit | [`docs/phase-zero-assessment/README.md`](docs/phase-zero-assessment/README.md) |
+| Beginner first-win guide | [`docs/examples/zero-to-first-agent.md`](docs/examples/zero-to-first-agent.md) |
 | Builder onboarding walkthrough | [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md) |
 | Builder-facing Docker home guide | [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md) |
 | Visual orientation maps | [`docs/visuals/README.md`](docs/visuals/README.md) |

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -109,15 +109,17 @@ Lifecycle docs, templates, and governance text must not reorder these dimensions
 
 ### 10. Docker Guidance Must Describe the Home, Not a Fake Runtime
 
+- The builder path must include a beginner-safe onboarding guide that gets a new user from clone to one harmless local success before Docker becomes mandatory.
 - The builder path must include a Docker-oriented guide that explains how to build a home around the repo's assets without misrepresenting the repository as a runtime product.
 - That guide must connect the current local, fleet, and specialist Docker examples into one coherent progression.
-- The builder path must also include a short onboarding walkthrough that chains environment verification, context generation, validation, and initial Docker launch.
+- The builder path must also include a short Docker onboarding walkthrough that chains environment verification, context generation, validation, and initial Docker launch after the first local success.
 
 ## Runtime and Tooling Requirements
 
 - Node.js is the primary runtime for repository utilities and generation scripts.
 - The built-in Node test runner is the primary validation framework for repository contracts and smoke tests.
-- Docker, Git, and Gemini CLI remain part of the documented local toolchain.
+- Git, Node.js, and at least one supported local AI client (Gemini CLI, Claude Code CLI, or OpenAI Codex) remain part of the documented beginner toolchain.
+- Docker becomes part of the documented toolchain when a builder moves into runtime homes or Docker verification.
 - Python examples may remain for historical context, but they are not the canonical implementation path for new work.
 
 ## Current Known Limitations

--- a/docs/examples/builder-first-30-minutes.md
+++ b/docs/examples/builder-first-30-minutes.md
@@ -1,6 +1,8 @@
 # Builder First 30 Minutes
 
-This walkthrough is the fastest safe path for a builder or accelerator who wants to move from clone to a working Docker-based agent home.
+This walkthrough is the fastest safe path from a **first local success** to a working Docker-based agent home.
+
+If you are completely new to AI implementation, start with [`zero-to-first-agent.md`](zero-to-first-agent.md) first. That guide gets you through the first harmless, read-only local task. This guide is the **phase-two Docker path**.
 
 It does not turn Project NoeMI into a runtime engine. It shows how to validate the reference architecture, generate the current agent context, and launch one local Docker home around those assets.
 
@@ -8,27 +10,26 @@ It does not turn Project NoeMI into a runtime engine. It shows how to validate t
 
 Read these guides first:
 
-1. [`../tool-usages/secure-secret-management.md`](../tool-usages/secure-secret-management.md)
-2. [`docker-agent-home.md`](docker-agent-home.md)
-3. [`../tool-usages/orchestrator-runtime-contract.md`](../tool-usages/orchestrator-runtime-contract.md)
-4. Read the local-workspace overview:
-   [`../tool-usages/agentic-local-workspaces.md`](../tool-usages/agentic-local-workspaces.md)
-5. Choose one implementation path:
+1. [`zero-to-first-agent.md`](zero-to-first-agent.md)
+2. [`../tool-usages/secure-secret-management.md`](../tool-usages/secure-secret-management.md)
+3. [`docker-agent-home.md`](docker-agent-home.md)
+4. [`../tool-usages/orchestrator-runtime-contract.md`](../tool-usages/orchestrator-runtime-contract.md)
+5. choose one implementation path:
    [`../tool-usages/gemini-workspace-quickstart.md`](../tool-usages/gemini-workspace-quickstart.md) for human-led Gemini CLI work or [`n8n-google-workspace-quickstart.md`](n8n-google-workspace-quickstart.md) for event-driven automation
 
 Those explain the security contract, the shape of the Docker home you are about to launch, and the runtime responsibilities your orchestrator must own.
 
-## Step 1: Verify the Local Toolchain
+## Step 1: Verify The Docker Toolchain
 
 From the repository root:
 
 ```bash
-bash scripts/verify-env.sh
+bash scripts/verify-env.sh --mode=docker
 ```
 
-This checks the core local prerequisites and reminds you that secrets must come from `op run` or `infisical run`, not local plaintext env files.
+This checks the Docker-oriented path without pretending Docker was required for the very first beginner task.
 
-## Step 2: Generate the Current Agent Context
+## Step 2: Generate The Current Agent Context
 
 ```bash
 node scripts/generate_all.js
@@ -47,7 +48,7 @@ Run this any time you change:
 - `mcp.config.json`
 - `AGENTS.md`
 
-## Step 3: Validate the Repository Contracts
+## Step 3: Validate The Repository Contracts
 
 ```bash
 npm run validate
@@ -67,7 +68,7 @@ If you intentionally changed generated sections, refresh the golden fixtures wit
 npm run test:update-fixtures
 ```
 
-## Step 4: Run Docker Smoke Validation When Docker Is Available
+## Step 4: Run Docker Smoke Validation
 
 ```bash
 npm run test:e2e
@@ -82,7 +83,7 @@ This is the slower runtime tier. It attempts to bring up the current Docker home
 If Docker is not installed in your environment, the e2e suite skips cleanly.
 If it fails on a Docker-capable host, inspect `test-artifacts/docker-smoke/` or follow the deeper playbook in [`docker-runtime-verification.md`](docker-runtime-verification.md).
 
-## Step 5: Launch the Local Builder Home
+## Step 5: Launch The Local Builder Home
 
 Start with the smallest Docker home:
 
@@ -92,13 +93,6 @@ cat .env.example
 op run --env-file=.env.example -- docker compose up -d --build
 ```
 
-Then enter the runtime container:
-
-```bash
-docker exec -it noemi-agent-runtime bash
-python agent.py
-```
-
 This gives you:
 
 - one runtime container
@@ -106,17 +100,32 @@ This gives you:
 - vault-injected secrets
 - a safe place to experiment without inventing your own topology first
 
-## Step 6: Try the Generated Context with an Orchestrator
-
-Back at the repository root:
+If you want to inspect the container directly:
 
 ```bash
-infisical run --env=dev -- gemini -p GEMINI.md "List the engineering agents in this repository"
+docker exec -it noemi-agent-runtime bash
 ```
 
-That confirms the generated context and orchestrator path are both usable.
+The historical Python sample inside this sandbox is optional and illustrative. The main goal here is to prove the home shape, secret injection, and container wiring.
 
-## Step 7: Choose the Next Home
+## Step 6: Try The Generated Context With An Orchestrator
+
+Back at the repository root, use a safe local task again:
+
+```bash
+gemini -p GEMINI.md "List the engineering agents in this repository and summarize what each one does in one sentence."
+```
+
+That confirms the generated context and orchestrator path are both usable after the Docker home is in place.
+If you are using Claude Code or Codex instead, reuse the same repo-local prompt there.
+
+If the task needs external credentials, switch to the Fetch-on-Demand wrapper:
+
+```bash
+infisical run --env=dev -- gemini
+```
+
+## Step 7: Choose The Next Home
 
 After the local builder home works:
 
@@ -125,10 +134,10 @@ After the local builder home works:
 
 ## Practical Working Rhythm
 
-The normal builder loop looks like this:
+The normal builder loop for Docker-facing work looks like this:
 
 ```bash
-bash scripts/verify-env.sh
+bash scripts/verify-env.sh --mode=docker
 node scripts/generate_all.js
 npm run validate
 npm run test:e2e
@@ -139,12 +148,12 @@ Then launch or relaunch the Docker home you are working on.
 ## If Something Fails
 
 - `verify-env.sh` fails:
-  install the missing tool or authenticate the SecretOps CLI first
+  install the missing tool for the Docker path first
 - `npm run validate` fails:
   fix the contract or generator drift before launching Docker
 - `npm run test:e2e` fails:
   inspect `test-artifacts/docker-smoke/` and the relevant compose stack before assuming the persona or docs are wrong
-- the container runs but the agent fails:
+- the container runs but the agent workflow fails:
   check whether the required vault-backed variables were actually injected at launch
 
 ## Outcome
@@ -153,6 +162,6 @@ By the end of this walkthrough you should have:
 
 - validated the repo
 - generated the current context
-- exercised the current Docker path
+- exercised the Docker path
 - launched one safe agent home
 - confirmed an orchestrator can consume the generated output

--- a/docs/examples/docker-agent-home.md
+++ b/docs/examples/docker-agent-home.md
@@ -4,7 +4,8 @@ This guide explains how to use Docker to build a **home for agents** around Proj
 
 Project NoeMI is **not a runtime or execution engine**. It provides the personas, governance, skills, MCP rules, and reference examples that a runtime consumes. A Docker-based "agent home" is the environment you build around those assets so agents can live somewhere consistent, observable, and secure.
 
-If you want the shortest guided path before you read the deeper topology discussion here, start with [`builder-first-30-minutes.md`](builder-first-30-minutes.md).
+If you are brand new to AI implementation, start with [`zero-to-first-agent.md`](zero-to-first-agent.md) first.
+If you already have a first local success and want the shortest guided Docker path, start with [`builder-first-30-minutes.md`](builder-first-30-minutes.md).
 For the runtime validation path that proves these homes actually boot on a Docker-capable host, see [`docker-runtime-verification.md`](docker-runtime-verification.md).
 
 ## What an Agent Home Includes
@@ -114,7 +115,7 @@ version: "3.8"
 
 services:
   agent-runtime:
-    image: node:20-alpine
+    image: node:24-alpine
     command: ["sh", "-lc", "sleep infinity"]
     environment:
       - GEMINI_API_KEY=${GEMINI_API_KEY}
@@ -149,11 +150,12 @@ If you are unsure, start with the secure secret pattern, then the local builder 
 
 ## Suggested Builder Path
 
-1. Read [`../tool-usages/secure-secret-management.md`](../tool-usages/secure-secret-management.md)
-2. Generate context with `node scripts/generate_all.js`
-3. Validate the repo with `npm run validate`
-4. Start with [`../../examples/docker/`](../../examples/docker/)
-5. Move to [`../../examples/fleet-deployment/`](../../examples/fleet-deployment/) when you need a real operator home
+1. Read [`zero-to-first-agent.md`](zero-to-first-agent.md)
+2. Read [`../tool-usages/secure-secret-management.md`](../tool-usages/secure-secret-management.md)
+3. Generate context with `node scripts/generate_all.js`
+4. Validate the repo with `npm run validate`
+5. Start with [`../../examples/docker/`](../../examples/docker/)
+6. Move to [`../../examples/fleet-deployment/`](../../examples/fleet-deployment/) when you need a real operator home
 
 If the runtime smoke tier fails on a real host, inspect `test-artifacts/docker-smoke/` locally or the `docker-smoke-diagnostics` artifact in GitHub Actions.
 

--- a/docs/examples/docker-runtime-verification.md
+++ b/docs/examples/docker-runtime-verification.md
@@ -31,7 +31,7 @@ You need:
 Before the runtime tier, run the fast gate:
 
 ```bash
-bash scripts/verify-env.sh
+bash scripts/verify-env.sh --mode=docker
 node scripts/generate_all.js
 npm run validate
 ```

--- a/docs/examples/docker-sandbox.md
+++ b/docs/examples/docker-sandbox.md
@@ -1,6 +1,6 @@
 # Docker AI Sandbox: Isolated Agent Environment
 
-> Historical example: this Python-based sandbox is retained as an illustrative legacy reference. For the recommended current entry path, start with [`../tool-usages/secure-secret-management.md`](../tool-usages/secure-secret-management.md), then read [`docker-agent-home.md`](docker-agent-home.md).
+> Historical example: this Python-based sandbox is retained as an illustrative legacy reference. For the recommended current entry path, start with [`zero-to-first-agent.md`](zero-to-first-agent.md), then [`../tool-usages/secure-secret-management.md`](../tool-usages/secure-secret-management.md), then [`docker-agent-home.md`](docker-agent-home.md).
 
 This guide walks you through setting up a containerized AI agent environment using **Docker**, **PostgreSQL with pgvector**, and the **Gemini API**.
 

--- a/docs/examples/zero-to-first-agent.md
+++ b/docs/examples/zero-to-first-agent.md
@@ -1,0 +1,174 @@
+# Zero To First Agent
+
+This is the safest beginner path in Project NoeMI.
+
+Use it when you are new to AI, comfortable around technology, and want one real success before you connect Google Workspace, Microsoft 365, GitHub, n8n, or Docker.
+
+By the end of this guide, you will:
+
+- verify the local tools you actually need
+- generate the current agent context from this repository
+- complete one harmless, read-only AI task against local repository content
+- understand when to bring in secret injection, business systems, and Docker later
+
+## What You Are Not Doing Yet
+
+In this first pass, do **not** start with:
+
+- production credentials
+- background automation
+- autonomous email sending
+- GitHub write access
+- Docker runtime homes
+
+The goal is to build confidence and secure habits before complexity.
+
+## Step 1: Choose One Local Client
+
+Pick the local AI client you want to learn first:
+
+- **Gemini CLI** if your team expects Google-heavy workflows or a clean terminal-first path
+- **Claude Code CLI / app** if you want a strong co-work experience around repositories and documents
+- **OpenAI Codex CLI / app** if you want a strong local execution and review workflow
+
+You only need **one** of these to get your first success.
+
+If you have not chosen yet, use the comparison guide in [`../tool-usages/agentic-local-workspaces.md`](../tool-usages/agentic-local-workspaces.md).
+
+## Step 2: Verify Only The Path You Need
+
+From the repository root, run the preflight mode that matches your first client:
+
+```bash
+bash scripts/verify-env.sh --mode=gemini
+```
+
+```bash
+bash scripts/verify-env.sh --mode=claude
+```
+
+```bash
+bash scripts/verify-env.sh --mode=codex
+```
+
+If you just want a general beginner check first, use:
+
+```bash
+bash scripts/verify-env.sh --mode=builder
+```
+
+This verifies Git, Node.js, and the local client you actually plan to use. It does **not** require Docker for the beginner path.
+
+## Step 3: Generate The Current Agent Context
+
+```bash
+node scripts/generate_all.js
+npm run validate
+```
+
+This gives you the latest:
+
+- `GEMINI.md`
+- `CLAUDE.md`
+
+and confirms the repo contracts are healthy before you ask the client to do anything with them.
+
+## Step 4: Get One Safe First Win
+
+Use a local, read-only task that does not touch external systems.
+
+Recommended first prompt:
+
+> List the engineering agents in this repository and summarize what each one does in one sentence. Then tell me which one would help first with PR review.
+
+### Gemini CLI
+
+```bash
+gemini -p GEMINI.md "List the engineering agents in this repository and summarize what each one does in one sentence. Then tell me which one would help first with PR review."
+```
+
+### Claude Code
+
+Open the repository in Claude Code and ask:
+
+> Read `CLAUDE.md`, inspect the engineering agents in this repository, and summarize what each one does in one sentence. Then tell me which one would help first with PR review.
+
+### OpenAI Codex
+
+Open the repository in Codex and ask:
+
+> Inspect this repository and summarize the engineering agents in one sentence each. Then tell me which one would help first with PR review.
+
+This is the right first success because it is:
+
+- useful
+- local
+- read-only
+- easy to verify with your own eyes
+
+## Step 5: Add Secure Muscle Memory Before Business Systems
+
+Once you move beyond local read-only work, bring in Phase 0 security immediately.
+
+Choose **one** supported SecretOps path:
+
+- **Infisical**
+- **1Password**
+
+Then authenticate locally:
+
+```bash
+infisical login
+```
+
+```bash
+op signin
+```
+
+When a task needs credentials, launch the client through the wrapper instead of hardcoding values:
+
+```bash
+infisical run --env=dev -- gemini
+op run --env-file=.env.template -- claude
+op run --env-file=.env.template -- codex
+```
+
+For the full local-first security flow, go next to [`../tool-usages/secure-secret-management.md`](../tool-usages/secure-secret-management.md).
+
+## Step 6: Turn The First Win Into A Safe Business Pilot
+
+Once the first local task works, choose one low-risk business use case:
+
+- summarize one internal document
+- classify inbound requests into simple buckets
+- draft, but do not send, a reply
+- extract action items from a meeting note
+
+Keep the initial pilot inside these boundaries:
+
+- read-heavy before write-heavy
+- human approval before external action
+- one department before the whole company
+- one clear success metric before broad rollout
+
+## What To Learn Next
+
+After this first win, follow this order:
+
+1. [`../tool-usages/secure-secret-management.md`](../tool-usages/secure-secret-management.md)
+2. [`../tool-usages/agentic-local-workspaces.md`](../tool-usages/agentic-local-workspaces.md)
+3. one product path:
+   [`../tool-usages/gemini-workspace-quickstart.md`](../tool-usages/gemini-workspace-quickstart.md) or [`n8n-google-workspace-quickstart.md`](n8n-google-workspace-quickstart.md)
+4. [`builder-first-30-minutes.md`](builder-first-30-minutes.md) when you want the Docker phase
+5. [`docker-agent-home.md`](docker-agent-home.md) when you are ready to build a governed runtime home
+
+## Outcome
+
+If this guide worked, you are no longer at the "AI is abstract" stage.
+
+You now have:
+
+- one working local client
+- one validated repository context
+- one successful AI task you can explain to a colleague
+- a secure next step for connecting business systems without skipping Phase 0

--- a/docs/tool-usages/secure-secret-management.md
+++ b/docs/tool-usages/secure-secret-management.md
@@ -3,109 +3,106 @@
 **Framework:** Gartner AI TRiSM (Security) | **Pedagogy:** Creation Diligence
 
 ## Overview
-When our Practitioners build applications with Virtual Coworkers, hardcoding credentials (API keys, database URLs) into source code or chat logs is a major security risk. This guide outlines a "Fetch-on-Demand" architecture:
 
-1. **Storage (The Vault):** Secrets live only in an encrypted SecretOps platform (Infisical).
-2. **Access (The Injector):** Agents use the Infisical CLI (`infisical run`) to inject secrets into the process memory at runtime.
-3. **Governance (The Guardian Layer):** Secrets are never written to disk, committed to Git, or exposed in the AI's context window.
+Project NoeMI uses a **Fetch-on-Demand** security model:
 
-For the client-side readiness conversation that should happen before these implementation details, see [`../PHASE_ZERO_SECURITY_BASELINE.md`](../PHASE_ZERO_SECURITY_BASELINE.md) and the reusable templates in [`../phase-zero-assessment/`](../phase-zero-assessment/).
-For the builder-facing Docker layout that should come after secret injection is understood, see [`../examples/docker-agent-home.md`](../examples/docker-agent-home.md).
+1. **Storage (The Vault):** secrets live only in a SecretOps platform
+2. **Access (The Injector):** the client or runtime receives secrets at launch time through a wrapper such as `infisical run` or `op run`
+3. **Governance (The Guardian Layer):** secrets are never written to disk, committed to Git, or pasted into chat
+
+For the client-side readiness conversation that should happen before implementation, see [`../PHASE_ZERO_SECURITY_BASELINE.md`](../PHASE_ZERO_SECURITY_BASELINE.md) and the reusable templates in [`../phase-zero-assessment/`](../phase-zero-assessment/).
+If you are brand new to this repo, start with [`../examples/zero-to-first-agent.md`](../examples/zero-to-first-agent.md) before you come back here.
+For the builder-facing Docker layout that comes later, see [`../examples/docker-agent-home.md`](../examples/docker-agent-home.md).
 For the runtime-side expectations that sit on top of secret injection, see [`orchestrator-runtime-contract.md`](orchestrator-runtime-contract.md).
 
-## The Tool Matrix for Project NoéMI
-To replace the 1Password `op run` workflow, we need tools that support an Environment Injection CLI—meaning the secrets exist only in the process memory during runtime and never on the hard drive.
+## Beginner Quick Path: Local First
 
-- **Infisical (The Top Open-Source Recommendation):** This is the perfect pedagogical fit for NoéMI. It is an open-source SecretOps platform that can be self-hosted within the NewPush Labs stack. Crucially, its CLI (`infisical run`) behaves exactly like 1Password’s `op run`, making it a seamless drop-in replacement for your curriculum.
-- **Google Secret Manager / AWS Secrets Manager (The Enterprise Cloud Path):** The gold standard if the cohort's "Walled Garden" is built on GCP or AWS. However, instead of a CLI wrapper, it relies on Identity and Access Management (IAM) and Workload Identity. The AI must be taught to write SDK-specific code to fetch secrets programmatically. It is highly secure but shifts the "vibe coding" dynamic slightly.
-- **Bitwarden Secrets Manager (BWS):** Another excellent open-source alternative with a CLI (`bws run`). Given NewPush's focus on SMBs, Bitwarden is a highly familiar tool for many participants.
+For Builders and Practitioners, the right first habit is simple:
 
-## Part 1: The Accelerator’s Role (Governance)
-Context: In the 1:50 Equilibrium, Accelerators govern the AI. Because autonomous agents run in headless environments (like cloud VMs or background workflows), they cannot use human SSO. Accelerators must provision "Machine Identities."
+1. choose **one** supported SecretOps path
+2. sign in locally with your human identity
+3. run the local client through the wrapper when the task needs credentials
+4. only then connect business systems such as Gmail, Drive, GitHub, or n8n
 
-**Create the Machine Identity:**
-1. Log in to the Infisical Dashboard.
-2. Navigate to Access Control > Machine Identities.
-3. Click Create Identity (e.g., name it `NoeMI-Agent-Crew`).
-4. **Crucial (TRiSM Policy):** Grant "Read-Only" access strictly to the specific environment your agent needs (e.g., `Dev-Secrets`). Never grant an AI agent access to production secrets during the build phase.
+You do **not** need machine identities for your first harmless local task.
 
-**Save the Token:**
-Generate an `INFISICAL_TOKEN`. You will need this to authorize the remote agents.
+## The Two Recommended SecretOps Paths
 
-## Part 2: Configuring Remote Agents (Jules / n8n)
-Context: Jules runs in a temporary, isolated Virtual Machine. The Practitioners must "teach" it how to access project secrets securely.
+Project NoeMI supports both of these beginner-friendly injector patterns:
 
-**Step 1: Inject the Service Token**
-You must bridge the gap between the Jules VM and the Secret Manager.
-1. Navigate to your Jules Dashboard (or Repository Settings).
-2. Find the Environment Variables section.
-3. Add a new variable:
-   - `Name`: `INFISICAL_TOKEN`
-   - `Value`: Your Machine Token from Part 1.
+- **Infisical:** open-source SecretOps with `infisical run`
+- **1Password CLI:** mature vault-backed wrapper with `op run`
 
-**Step 2: Install the CLI (Setup Script)**
-Add the CLI tool to your repository's environment setup script (`setup.sh`).
+Choose one for a given workflow and standardize on it within the team.
 
-```bash
-#!/bin/bash
-# Phase 0 Security: Install Infisical CLI
-curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | sudo -E bash
-sudo apt-get update && sudo apt-get install -y infisical
+### Why These Two Paths Fit NoeMI
 
-# Verify Auth (Useful for Loki/Grafana debugging logs)
-if infisical export > /dev/null 2>&1; then
-  echo "✅ Phase 0: Guardian Layer connection established."
-else
-  echo "❌ Phase 0 Error: Auth Failed. Check INFISICAL_TOKEN."
-fi
-```
+- they inject secrets into process memory at runtime
+- they support secure local builder habits
+- they avoid plaintext `.env` files
+- they map cleanly to the Phase 0 rules in [`../../AGENTS.md`](../../AGENTS.md)
 
-**Step 3: Instruct Jules (AGENTS.md)**
-To ensure the AI Agent understands our Description and Delegation principles, add this section explicitly telling it how to run code securely.
+## Step 1: Authenticate Locally
 
-```markdown
-# Phase 0 Security & Configuration
-This project uses Infisical for SecretOps. 
-- The CLI (`infisical`) is pre-installed.
-- **NEVER** ask the user for secrets in chat or hardcode them in files. This violates the Diligence protocol.
-- **ALWAYS** use `infisical run` to execute scripts that require credentials.
+### Infisical
 
-## Execution Pattern
-When running Python scripts or Node apps, wrap your execution:
-`infisical run --env=dev -- python agent_logic.py`
-*(Infisical will automatically inject all secrets from the 'dev' environment into the process).*
-```
-
-## Part 3: Configuring Local Agentic Workspaces
-Context: When a Practitioner is working locally, they can authenticate using their human user identity (SSO) rather than managing long-lived machine tokens.
-
-**Step 1: Authenticate Locally**
-Practitioners log in via their browser (often via Casdoor SSO in NewPush Labs).
 ```bash
 infisical login
 ```
 
-**Step 2: Running The Local Client Securely**
-To give a local client access to secrets, the Practitioner wraps the execution. Unlike 1Password, which requires a `.env.template` with reference strings, Infisical dynamically pulls the environment you specify.
+### 1Password CLI
 
-**Examples:**
 ```bash
-# This injects the 'dev' secrets into the shell where Gemini runs
+op signin
+```
+
+## Step 2: Launch The Local Client Securely
+
+When the task needs credentials, wrap the client launch instead of creating a local secret file.
+
+### Infisical examples
+
+```bash
 infisical run --env=dev -- gemini
-
-# Claude Code CLI
 infisical run --env=dev -- claude
-
-# OpenAI Codex CLI
 infisical run --env=dev -- codex
 ```
 
-**Pro Tip (Alias):**
-Add this to your `~/.zshrc` or `~/.bashrc` to build secure muscle memory:
+### 1Password examples
+
+```bash
+op run --env-file=.env.template -- gemini
+op run --env-file=.env.template -- claude
+op run --env-file=.env.template -- codex
+```
+
+Unlike a plaintext `.env`, `.env.template` in this repo is only a vault-reference manifest.
+
+## Step 3: Build Secure Muscle Memory
+
+The first useful rule for beginners is:
+
+- repo-only, read-only tasks can start without secrets
+- the moment a task touches external systems, wrap the launch with `infisical run` or `op run`
+
+That is how NoeMI keeps the transition from experimentation to business work secure without making beginners memorize infrastructure patterns on day one.
+
+## Suggested Local Aliases
+
+Once a builder chooses one secret path, create aliases so the secure path becomes the normal path:
+
 ```bash
 alias safe-gemini='infisical run --env=dev -- gemini'
 alias safe-claude='infisical run --env=dev -- claude'
 alias safe-codex='infisical run --env=dev -- codex'
+```
+
+or:
+
+```bash
+alias safe-gemini='op run --env-file=.env.template -- gemini'
+alias safe-claude='op run --env-file=.env.template -- claude'
+alias safe-codex='op run --env-file=.env.template -- codex'
 ```
 
 For the client-by-client comparison and the role of Google's Antigravity, Claude Code app, and Codex app on top of these CLI habits, see:
@@ -115,60 +112,122 @@ For the client-by-client comparison and the role of Google's Antigravity, Claude
 - [`claude-code-local-workspace.md`](claude-code-local-workspace.md)
 - [`openai-codex-local-workspace.md`](openai-codex-local-workspace.md)
 
-## Part 4: The "Agent Contract" (Prompting Guide)
-To ensure the agent writes secure code, Practitioners must master Process Description.
+## The Tool Matrix For Project NoéMI
 
-**1. The "Reference" Prompt**
-User (Practitioner): "Write a Python script to connect to the database. Assume the DATABASE_URL is securely injected into the environment at runtime via our SecretOps tool. Do not create a local `.env` file or ask me for the password."
+These are the main SecretOps patterns you may encounter as the work becomes more advanced:
 
-Agent (Correct Response):
+- **Infisical:** best open-source fit for local and self-hosted builder workflows
+- **1Password CLI:** strong local and SMB-friendly operational path
+- **Google Secret Manager / AWS Secrets Manager:** strong cloud-native path for workloads that rely on IAM and SDK-based secret retrieval rather than CLI injection
+- **Bitwarden Secrets Manager:** another strong option for teams that already standardize on Bitwarden
+
+The beginner path in this repo focuses on Infisical and 1Password because they most directly reinforce the Fetch-on-Demand habit.
+
+## The Agent Contract (Prompting Guide)
+
+To ensure the agent writes secure code, Practitioners should describe the security model explicitly.
+
+### The Reference Prompt
+
+User:
+
+> Write a Python script to connect to the database. Assume the `DATABASE_URL` is securely injected into the environment at runtime via our SecretOps tool. Do not create a local `.env` file or ask me for the password.
+
+Agent (correct pattern):
+
 ```python
 import os
 
-# Phase 0 Security: Agent assumes the variable exists in process memory
 db_url = os.getenv("DATABASE_URL")
 if not db_url:
-    raise ValueError("Missing DATABASE_URL. Phase 0 breach: Did you execute with `infisical run`?")
+    raise ValueError("Missing DATABASE_URL. Did you execute the script with `infisical run` or `op run`?")
 ```
-*(Note: If teaching Google Secret Manager, the prompt changes slightly: "Fetch the password dynamically using the google-cloud-secret-manager Python SDK.")*
 
-**2. The "Execution" Prompt**
-User (Practitioner): "Run the script you just wrote."
+### The Execution Prompt
 
-Agent (Correct Action):
-Because of the `AGENTS.md` instructions, the AI knows to execute:
+User:
+
+> Run the script you just wrote.
+
+Correct action:
+
 ```bash
 infisical run --env=dev -- python script.py
 ```
 
-## Part 5: Verifying Phase 0 Security (For Accelerators)
-To verify that your Guardian Layer is active, Accelerators can use these commands to audit the environment.
+or:
 
-**1. The Core Identity Check**
 ```bash
-# Returns information about the currently authenticated machine identity
+op run --env-file=.env.template -- python script.py
+```
+
+## Advanced Path: Accelerators And Headless Runtimes
+
+Once the team moves beyond local workstations into n8n, cloud VMs, or other background runtimes, Accelerators must provision **machine identities** or another non-human auth path.
+
+That is where the architecture becomes different:
+
+- local human sign-in is no longer enough
+- the runtime needs scoped, non-human access
+- environment access must be read-only and limited to the exact environment it needs
+
+## Configuring Machine Identity With Infisical
+
+1. Log in to the Infisical dashboard.
+2. Navigate to **Access Control > Machine Identities**.
+3. Create an identity such as `noemi-agent-crew`.
+4. Grant read-only access only to the specific environment needed for the runtime.
+
+Generate an `INFISICAL_TOKEN` for that machine identity and inject it into the remote environment rather than a human session.
+
+## Configuring Remote Agents (n8n / Headless Runtimes)
+
+1. Add the machine token to the remote environment as `INFISICAL_TOKEN`.
+2. Install the CLI in the runtime image or setup script.
+3. Make the launch command explicitly use `infisical run`.
+
+Example setup snippet:
+
+```bash
+#!/bin/bash
+curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | sudo -E bash
+sudo apt-get update && sudo apt-get install -y infisical
+
+if infisical export > /dev/null 2>&1; then
+  echo "✅ Phase 0: Guardian Layer connection established."
+else
+  echo "❌ Phase 0 Error: Auth failed. Check INFISICAL_TOKEN." >&2
+fi
+```
+
+## Verifying Phase 0 Security
+
+### Core identity check
+
+```bash
 infisical me
 ```
 
-**2. Test Secret Resolution**
-Perform a "dry run" to confirm the token has correct permissions without exposing secrets to the application.
+### Test secret resolution
+
 ```bash
-# Exports the environment variables safely to the terminal for verification
 infisical export --env=dev
 ```
 
-## 🛠 Troubleshooting Common Governance Errors
+For 1Password-based local verification, the practical equivalent is confirming the relevant vault references resolve during an `op run` launch instead of appearing in plaintext on disk.
+
+## Troubleshooting Common Governance Errors
 
 | Symptom | Likely Cause | Fix |
 |---|---|---|
-| Unauthorized access | Token is scoped to the wrong environment (e.g., prod instead of dev). | Accelerator must update the Machine Identity RBAC policy. |
-| `infisical: command not found` | The CLI is not in your system `$PATH`. | Verify installation in the `setup.sh` script. |
-| Agent hardcodes secrets | The `AGENTS.md` file is missing or ignored. | Correct the agent's behavior via Discernment and update the system prompt. |
+| Unauthorized access | Token or vault reference is scoped to the wrong environment. | Update RBAC or the vault reference to the correct environment. |
+| `infisical: command not found` or `op: command not found` | The CLI is not installed or not in the shell `$PATH`. | Install the CLI and rerun the preflight check. |
+| Agent hardcodes secrets | The security contract was not described clearly enough or the repo rules were ignored. | Restate the Fetch-on-Demand rule and correct the prompt or persona guidance. |
 
-## 🎓 The Pedagogical "Aha!" Moment
-To solidify this in Week 4 (Discernment & The Guardian Layer), you can introduce a "Red Team Gauntlet" Lab:
+## The Pedagogical "Aha!" Moment
 
-- **The Setup:** Instruct the Accelerators to intentionally try to prompt the AI agent to reveal the `OPENAI_API_KEY` that the Practitioner has been using to build their Virtual Coworker.
-- **The Result:** If the Practitioner used `infisical run` properly, the secret was injected purely into the memory of the Python process, not into the AI's chat context window. The agent cannot hallucinate or leak what it does not know.
+The beginner breakthrough is simple but important:
 
-When the Accelerators face the Feynman Requirement in Week 6, explaining how a Machine Token securely passes an API key to an LLM agent without human intervention is a masterclass in AI Governance. It perfectly justifies their George Mason University micro-credential.
+if the secret was never pasted into chat and never written to a local file, the model has much less chance to leak it.
+
+That is why Phase 0 matters so early in NoeMI. The team learns secure habits before the first business-facing workflow becomes powerful enough to do damage.

--- a/scripts/verify-env.ps1
+++ b/scripts/verify-env.ps1
@@ -1,25 +1,91 @@
-Write-Host "🚀 Starting Project NoéMI Pre-Flight Check..." -ForegroundColor Cyan
+param(
+    [ValidateSet("builder", "gemini", "claude", "codex", "docker", "n8n")]
+    [string]$Mode = "builder"
+)
 
-# Function to check dependencies
-function Check-Tool ($name, $command) {
-    if (Get-Command $command -ErrorAction SilentlyContinue) {
-        Write-Host "✅ $name is installed." -ForegroundColor Green
+Write-Host "🚀 Starting Project NoéMI Pre-Flight Check ($Mode mode)..." -ForegroundColor Cyan
+
+function Check-Tool($Name, $Command) {
+    if (Get-Command $Command -ErrorAction SilentlyContinue) {
+        Write-Host "✅ $Name is installed." -ForegroundColor Green
         return $true
+    }
+
+    Write-Host "❌ $Name is missing. Please install it." -ForegroundColor Red
+    return $false
+}
+
+function Note-Tool($Name, $Command) {
+    if (Get-Command $Command -ErrorAction SilentlyContinue) {
+        Write-Host "✅ $Name is installed." -ForegroundColor Green
     } else {
-        Write-Host "❌ $name is missing. Please install it." -ForegroundColor Red
-        return $false
+        Write-Host "ℹ️  $Name is not installed." -ForegroundColor Cyan
+    }
+}
+
+function Check-AnyLocalClient {
+    $clients = @()
+
+    if (Get-Command gemini -ErrorAction SilentlyContinue) { $clients += "gemini" }
+    if (Get-Command claude -ErrorAction SilentlyContinue) { $clients += "claude" }
+    if (Get-Command codex -ErrorAction SilentlyContinue) { $clients += "codex" }
+
+    if ($clients.Count -gt 0) {
+        Write-Host "✅ Found supported local AI client(s): $($clients -join ', ')." -ForegroundColor Green
+        return $true
+    }
+
+    Write-Host "❌ No supported local AI client found." -ForegroundColor Red
+    Write-Host "   Install at least one of: Gemini CLI, Claude Code CLI, or OpenAI Codex." -ForegroundColor Yellow
+    return $false
+}
+
+function Check-EnvVar($Name) {
+    if ([Environment]::GetEnvironmentVariable($Name)) {
+        Write-Host "✅ $Name is set in the current environment." -ForegroundColor Green
+    } else {
+        Write-Host "ℹ️  $Name is not set in the current environment." -ForegroundColor Cyan
     }
 }
 
 $allGood = $true
 if (-not (Check-Tool "Git" "git")) { $allGood = $false }
 if (-not (Check-Tool "Node.js" "node")) { $allGood = $false }
-if (-not (Check-Tool "Docker" "docker")) { $allGood = $false }
-if (-not (Check-Tool "Gemini CLI" "gemini")) { $allGood = $false }
+
+switch ($Mode) {
+    "builder" {
+        if (-not (Check-AnyLocalClient)) { $allGood = $false }
+        Note-Tool "Docker" "docker"
+    }
+    "gemini" {
+        if (-not (Check-Tool "Gemini CLI" "gemini")) { $allGood = $false }
+        Note-Tool "Docker" "docker"
+    }
+    "claude" {
+        if (-not (Check-Tool "Claude Code CLI" "claude")) { $allGood = $false }
+        Note-Tool "Docker" "docker"
+    }
+    "codex" {
+        if (-not (Check-Tool "OpenAI Codex CLI" "codex")) { $allGood = $false }
+        Note-Tool "Docker" "docker"
+    }
+    "docker" {
+        if (-not (Check-Tool "Docker" "docker")) { $allGood = $false }
+        Note-Tool "Gemini CLI" "gemini"
+        Note-Tool "Claude Code CLI" "claude"
+        Note-Tool "OpenAI Codex CLI" "codex"
+    }
+    "n8n" {
+        Note-Tool "Docker" "docker"
+        Note-Tool "Gemini CLI" "gemini"
+        Note-Tool "Claude Code CLI" "claude"
+        Note-Tool "OpenAI Codex CLI" "codex"
+    }
+}
 
 if (-not $allGood) {
-    Write-Host "`n⚠️ Please install the missing tools and run this script again." -ForegroundColor Yellow
-    exit
+    Write-Host "`n⚠️ Please install the missing tools for the selected path and run this script again." -ForegroundColor Yellow
+    exit 1
 }
 
 $nodeMajor = [int]((node --version) -replace '^v([0-9]+).*$','$1')
@@ -40,21 +106,37 @@ if (Get-Command infisical -ErrorAction SilentlyContinue) {
     $secretsCli = $true
 }
 if (-not $secretsCli) {
-    Write-Host "⚠️ No SecretOps CLI found. Install at least one:" -ForegroundColor Yellow
+    Write-Host "⚠️ No SecretOps CLI found. Install at least one before you connect business systems:" -ForegroundColor Yellow
     Write-Host "   - 1Password CLI: https://developer.1password.com/docs/cli/get-started/" -ForegroundColor Yellow
     Write-Host "   - Infisical CLI: https://infisical.com/docs/cli/overview" -ForegroundColor Yellow
-    Write-Host "   Secrets are injected at runtime via these tools (see AGENTS.md)." -ForegroundColor Yellow
+    Write-Host "   Local repo-only prompts can still work without secrets, but Gmail, GitHub, n8n, and Workspace flows should use Fetch-on-Demand wrappers." -ForegroundColor Yellow
 }
 
-Write-Host "`n🔑 Checking API Keys..." -ForegroundColor Cyan
-if ($env:GEMINI_API_KEY) {
-    Write-Host "✅ GEMINI_API_KEY is set in the environment." -ForegroundColor Green
-} else {
-    Write-Host "⚠️ GEMINI_API_KEY is not set." -ForegroundColor Yellow
-    Write-Host "   Use a secrets manager to inject credentials at runtime:" -ForegroundColor Yellow
-    Write-Host "     op run --env-file=.env.template -- <command>" -ForegroundColor Yellow
-    Write-Host "     infisical run --env=dev -- <command>" -ForegroundColor Yellow
-    Write-Host "   See AGENTS.md for the Fetch-on-Demand security policy." -ForegroundColor Yellow
+Write-Host "`n🔑 Checking common API key env vars in the current shell..." -ForegroundColor Cyan
+Check-EnvVar "GEMINI_API_KEY"
+Check-EnvVar "ANTHROPIC_API_KEY"
+Check-EnvVar "OPENAI_API_KEY"
+
+Write-Host "`n🧭 Recommended next step for $Mode mode:" -ForegroundColor Cyan
+switch ($Mode) {
+    "builder" {
+        Write-Host "   Read docs/examples/zero-to-first-agent.md and prove one safe local task first." -ForegroundColor White
+    }
+    "gemini" {
+        Write-Host "   Generate context with node scripts/generate_all.js and run one read-only local task first." -ForegroundColor White
+    }
+    "claude" {
+        Write-Host "   Generate context with node scripts/generate_all.js and run one read-only local task first." -ForegroundColor White
+    }
+    "codex" {
+        Write-Host "   Generate context with node scripts/generate_all.js and run one read-only local task first." -ForegroundColor White
+    }
+    "docker" {
+        Write-Host "   Generate context, run npm run validate, then npm run test:e2e on this Docker-capable host." -ForegroundColor White
+    }
+    "n8n" {
+        Write-Host "   Follow docs/examples/n8n-google-workspace-quickstart.md and keep human approval on the last mutating step." -ForegroundColor White
+    }
 }
 
-Write-Host "`n🎉 All Systems Go! You are ready to build agents." -ForegroundColor Green
+Write-Host "`n🎉 Pre-flight complete." -ForegroundColor Green

--- a/scripts/verify-env.sh
+++ b/scripts/verify-env.sh
@@ -1,8 +1,58 @@
 #!/bin/bash
 
-echo -e "\n🚀 Starting Project NoéMI Pre-Flight Check...\n"
+MODE="builder"
 
-# Function to check dependencies
+print_usage() {
+    cat <<'EOF'
+Usage: bash scripts/verify-env.sh [--mode builder|gemini|claude|codex|docker|n8n]
+
+Modes:
+  builder  Default beginner path. Requires Git, Node.js, and at least one supported local AI client.
+  gemini   Gemini CLI local path.
+  claude   Claude Code CLI local path.
+  codex    OpenAI Codex CLI local path.
+  docker   Docker home and runtime verification path.
+  n8n      n8n automation path without assuming a local AI client or Docker.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --mode)
+            MODE="$2"
+            shift 2
+            ;;
+        --mode=*)
+            MODE="${1#*=}"
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            MODE="$1"
+            shift
+            ;;
+    esac
+done
+
+MODE="$(printf '%s' "$MODE" | tr '[:upper:]' '[:lower:]')"
+
+case "$MODE" in
+    builder|gemini|claude|codex|docker|n8n)
+        ;;
+    *)
+        echo -e "❌ Unknown mode: $MODE"
+        print_usage
+        exit 1
+        ;;
+esac
+
+echo -e "\n🚀 Starting Project NoéMI Pre-Flight Check ($MODE mode)...\n"
+
+ALL_GOOD=true
+
 check_tool() {
     if command -v "$2" >/dev/null 2>&1; then
         echo -e "✅ $1 is installed."
@@ -13,14 +63,69 @@ check_tool() {
     fi
 }
 
-ALL_GOOD=true
+note_tool() {
+    if command -v "$2" >/dev/null 2>&1; then
+        echo -e "✅ $1 is installed."
+    else
+        echo -e "ℹ️  $1 is not installed."
+    fi
+}
+
+check_any_local_client() {
+    local found_clients=()
+
+    for tool in gemini claude codex; do
+        if command -v "$tool" >/dev/null 2>&1; then
+            found_clients+=("$tool")
+        fi
+    done
+
+    if [ "${#found_clients[@]}" -gt 0 ]; then
+        echo -e "✅ Found supported local AI client(s): ${found_clients[*]}."
+        return 0
+    fi
+
+    echo -e "❌ No supported local AI client found."
+    echo -e "   Install at least one of: Gemini CLI, Claude Code CLI, or OpenAI Codex."
+    return 1
+}
+
 check_tool "Git" "git" || ALL_GOOD=false
 check_tool "Node.js" "node" || ALL_GOOD=false
-check_tool "Docker" "docker" || ALL_GOOD=false
-check_tool "Gemini CLI" "gemini" || ALL_GOOD=false
+
+case "$MODE" in
+    builder)
+        check_any_local_client || ALL_GOOD=false
+        note_tool "Docker" "docker"
+        ;;
+    gemini)
+        check_tool "Gemini CLI" "gemini" || ALL_GOOD=false
+        note_tool "Docker" "docker"
+        ;;
+    claude)
+        check_tool "Claude Code CLI" "claude" || ALL_GOOD=false
+        note_tool "Docker" "docker"
+        ;;
+    codex)
+        check_tool "OpenAI Codex CLI" "codex" || ALL_GOOD=false
+        note_tool "Docker" "docker"
+        ;;
+    docker)
+        check_tool "Docker" "docker" || ALL_GOOD=false
+        note_tool "Gemini CLI" "gemini"
+        note_tool "Claude Code CLI" "claude"
+        note_tool "OpenAI Codex CLI" "codex"
+        ;;
+    n8n)
+        note_tool "Docker" "docker"
+        note_tool "Gemini CLI" "gemini"
+        note_tool "Claude Code CLI" "claude"
+        note_tool "OpenAI Codex CLI" "codex"
+        ;;
+esac
 
 if [ "$ALL_GOOD" = false ]; then
-    echo -e "\n⚠️ Please install the missing tools and run this script again.\n"
+    echo -e "\n⚠️ Please install the missing tools for the selected path and run this script again.\n"
     exit 1
 fi
 
@@ -42,20 +147,39 @@ if command -v infisical >/dev/null 2>&1; then
     SECRETS_CLI=true
 fi
 if [ "$SECRETS_CLI" = false ]; then
-    echo -e "⚠️ No SecretOps CLI found. Install at least one:"
+    echo -e "⚠️ No SecretOps CLI found. Install at least one before you connect business systems:"
     echo -e "   - 1Password CLI: https://developer.1password.com/docs/cli/get-started/"
     echo -e "   - Infisical CLI: https://infisical.com/docs/cli/overview"
-    echo -e "   Secrets are injected at runtime via these tools (see AGENTS.md)."
+    echo -e "   Local repo-only prompts can still work without secrets, but Gmail, GitHub, n8n, and Workspace flows should use Fetch-on-Demand wrappers."
 fi
 
-echo -e "\n🔑 Checking API Keys..."
-if [ -n "$GEMINI_API_KEY" ]; then
-    echo -e "✅ GEMINI_API_KEY is set in the environment."
-else
-    echo -e "⚠️ GEMINI_API_KEY is not set."
-    echo -e "   Use a secrets manager to inject credentials at runtime:"
-    echo -e "     op run --env-file=.env.template -- <command>"
-    echo -e "     infisical run --env=dev -- <command>"
-fi
+echo -e "\n🔑 Checking common API key env vars in the current shell..."
+check_env_var() {
+    if [ -n "${!1}" ]; then
+        echo -e "✅ $1 is set in the current environment."
+    else
+        echo -e "ℹ️  $1 is not set in the current environment."
+    fi
+}
 
-echo -e "\n🎉 All Systems Go! You are ready to build agents.\n"
+check_env_var "GEMINI_API_KEY"
+check_env_var "ANTHROPIC_API_KEY"
+check_env_var "OPENAI_API_KEY"
+
+echo -e "\n🧭 Recommended next step for $MODE mode:"
+case "$MODE" in
+    builder)
+        echo -e "   Read docs/examples/zero-to-first-agent.md and prove one safe local task first."
+        ;;
+    gemini|claude|codex)
+        echo -e "   Generate context with node scripts/generate_all.js and run one read-only local task first."
+        ;;
+    docker)
+        echo -e "   Generate context, run npm run validate, then npm run test:e2e on this Docker-capable host."
+        ;;
+    n8n)
+        echo -e "   Follow docs/examples/n8n-google-workspace-quickstart.md and keep human approval on the last mutating step."
+        ;;
+esac
+
+echo -e "\n🎉 Pre-flight complete.\n"

--- a/tests/contracts.test.js
+++ b/tests/contracts.test.js
@@ -52,8 +52,21 @@ test('context templates retain all required injection markers', () => {
 
 test('builder-facing docs point to the Docker Agent Home path', () => {
     const readme = read('README.md');
+    assert.match(readme, /docs\/examples\/zero-to-first-agent\.md/);
     assert.match(readme, /docs\/examples\/docker-agent-home\.md/);
     assert.match(readme, /npm run validate/);
+    assert.match(readme, /verify-env\.sh --mode=builder/);
+});
+
+test('environment verification scripts expose path-aware beginner and docker modes', () => {
+    const shellScript = read('scripts/verify-env.sh');
+    const powershellScript = read('scripts/verify-env.ps1');
+
+    assert.match(shellScript, /builder\|gemini\|claude\|codex\|docker\|n8n/);
+    assert.match(shellScript, /No supported local AI client found/);
+    assert.match(shellScript, /docs\/examples\/zero-to-first-agent\.md/);
+    assert.match(powershellScript, /ValidateSet\("builder", "gemini", "claude", "codex", "docker", "n8n"\)/);
+    assert.match(powershellScript, /No supported local AI client found/);
 });
 
 test('builder-facing docs expose the split Google Workspace implementation paths', () => {

--- a/tests/examples-smoke.test.js
+++ b/tests/examples-smoke.test.js
@@ -60,6 +60,32 @@ test('Docker Agent Home guide connects the current example topologies', () => {
     assert.match(guide, /examples\/fleet-deployment/);
     assert.match(guide, /examples\/gatekeeper-deployment/);
     assert.match(guide, /not a runtime or execution engine/i);
+    assert.match(guide, /zero-to-first-agent\.md/);
+    assert.match(guide, /node:24-alpine/);
+});
+
+test('beginner builder docs start with a safe local success before Docker', () => {
+    const beginnerGuide = read('docs/examples/zero-to-first-agent.md');
+    const builderGuide = read('docs/examples/builder-first-30-minutes.md');
+    const readme = read('README.md');
+
+    assert.match(beginnerGuide, /read-only AI task against local repository content/i);
+    assert.match(beginnerGuide, /does \*\*not\*\* require Docker/i);
+    assert.match(beginnerGuide, /engineering agents in this repository/i);
+    assert.match(beginnerGuide, /human approval before external action/i);
+    assert.match(builderGuide, /phase-two Docker path/i);
+    assert.match(builderGuide, /verify-env\.sh --mode=docker/);
+    assert.doesNotMatch(readme, /List all open PRs in our org/);
+});
+
+test('secret management guide leads beginners through a local-first choice between Infisical and 1Password', () => {
+    const guide = read('docs/tool-usages/secure-secret-management.md');
+
+    assert.match(guide, /Beginner Quick Path: Local First/);
+    assert.match(guide, /Infisical/);
+    assert.match(guide, /1Password CLI/);
+    assert.match(guide, /repo-only, read-only tasks can start without secrets/i);
+    assert.match(guide, /machine identities/i);
 });
 
 test('Google Workspace docs separate Gemini CLI, generic MCP, and n8n setup paths', () => {


### PR DESCRIPTION
## Summary
- add a zero-to-first-agent guide for complete beginners
- make environment verification path-aware for builder, client, Docker, and n8n flows
- resequence security and Docker docs around a local-safe-first path

## Testing
- bash -n scripts/verify-env.sh
- npm run validate
- npm run test:e2e