### PR TITLE
docs(assessment): split security and AI readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Project NoéMI is the **public reference architecture** for NewPush's AI fluency and Virtual Workforce model, and the **agent specification library** that backs it. It defines AI agent personas, MCP (Model Context Protocol) integrations, governance frameworks, and Phase 0 security guidance as Markdown files. It is **not** a runtime or execution engine — external orchestrators like [Gemini CLI](https://github.com/google-gemini/gemini-cli), Claude Code, OpenAI Codex, [n8n](https://n8n.io/), or [LangChain](https://www.langchain.com/) consume these specifications to execute tasks.
 
+The goal of Project NoéMI is not to accelerate a replacement narrative around AI. The goal is to help businesses and enterprises raise the productivity of the active workforce by teaching people how to govern AI doing repeatable first-pass work, so organizations can increase output, improve consistency, and lower delivery cost **without** treating mass unemployment as the strategy. In NoéMI terms, this is the move from people doing every task themselves to people managing a governed **Virtual Workforce** of AI agents.
+
 > **New here?** Start with the [**Project Reference**](docs/PROJECT_REFERENCE.md) — the comprehensive public guide to NoéMI's philosophy, framework, curriculum, and technology stack.
 
 > **Need the fastest orientation?** Start with the [**Visual Guides**](docs/visuals/README.md) for the system map, audience path, runtime flow, and workshop mind map.

--- a/docs/PHASE_ZERO_SECURITY_BASELINE.md
+++ b/docs/PHASE_ZERO_SECURITY_BASELINE.md
@@ -4,6 +4,8 @@ Project NoéMI treats **Phase 0 Security** as the prerequisite for serious AI ad
 
 This guide is written from the **client's perspective**. It is meant to help leadership teams, IT managers, and operational owners ask better questions of their internal team, their MSP, or their MSSP before they fund an advanced AI initiative.
 
+This guide covers the **security half** of that conversation. The paired **AI readiness half** of the initial assessment lives in the [Phase 0 Assessment Kit](phase-zero-assessment/README.md), where security readiness and AI readiness are treated as separate executive questions.
+
 ## Why Phase 0 Comes First
 
 AI accelerates execution. That is useful when your environment is governed, and dangerous when it is not.
@@ -180,6 +182,10 @@ Phase 0 is complete when the organization can answer:
 If you already have an MSP or MSSP, use them. But ask them to behave like a diagnostic partner, not a product reseller.
 
 The reusable templates that support this conversation live in the [Phase 0 Assessment Kit](phase-zero-assessment/README.md).
+That kit now separates:
+
+- the **Security Assessment**: "Can we do this safely?"
+- the **AI Readiness Assessment**: "Can we do this in a way that creates measurable business value?"
 ### What to Ask For
 
 - A Phase 0 baseline or cyber risk assessment tied to the AI initiative you are considering

--- a/docs/PROJECT_REFERENCE.md
+++ b/docs/PROJECT_REFERENCE.md
@@ -6,6 +6,8 @@
 
 This document is the canonical public reference for Project NoéMI. It introduces the project's philosophy, framework, curriculum, and technology stack, and serves as a guide to the other documents in this repository.
 
+At the highest level, NoéMI exists to help organizations respond to AI by increasing the productivity of the active population, not by normalizing a story of mass unemployment. The program teaches businesses how to redesign work so AI handles governed, repeatable first-pass tasks while people move upward into review, exception handling, decision-making, and governance. The intended result is a surge in output, resilience, and economic usefulness through a **Virtual Workforce** model, not a simplistic replacement model.
+
 Readers who want the fastest structural overview should start with the visual set in [`docs/visuals/`](visuals/).
 
 ---
@@ -35,6 +37,8 @@ Readers who want the fastest structural overview should start with the visual se
 Project NoéMI is a **global AI fluency accelerator program** delivered by **NewPush** and academically credentialed by **George Mason University (GMU)**. It trains *organizations* — not individuals — to build, govern, and deploy a "Virtual Workforce" of AI agents securely and at scale.
 
 It is **not** a generic "prompt engineering" course. It is an enterprise AI transformation program that begins with cybersecurity (Phase 0 Security) and ends with certified, production-ready AI workflows governed by trained human leaders.
+
+Its strategic aim is to help enterprises convert AI from a labor-displacement fear into a productivity system. In practice, that means enabling teams to produce more with the same people, shift skilled staff away from repetitive execution, and build the managerial capability to supervise AI doing bounded operational work.
 
 **Key facts:**
 
@@ -375,7 +379,15 @@ Phase 0 is what distinguishes NoéMI from other AI training programs. It is the 
 
 ### Client-Side Phase 0 Baseline
 
-Organizations should complete a short, written **Phase 0 baseline assessment** before starting an advanced AI initiative. This should evaluate identity, endpoint hygiene, backups, logging, secrets management, SaaS and vendor exposure, data boundaries, and incident readiness, then produce a prioritized roadmap of what must be fixed before AI goes live.
+Organizations should complete a short, written **Phase 0 initial assessment** before starting an advanced AI initiative. In NoeMI, this should now be treated as two linked tracks:
+
+- a **Security Assessment** that evaluates identity, endpoint hygiene, backups, logging, secrets management, SaaS and vendor exposure, data boundaries, and incident readiness
+- an **AI Readiness Assessment** that evaluates business use-case clarity, process stability, approval boundaries, role uplift, and measurement readiness
+
+Together, these two tracks answer both executive questions:
+
+- can we do this safely?
+- can we do this in a way that creates real business value?
 
 For a client-oriented guide on what to assess, how to work with an MSP or MSSP, and how to request a grounded baseline without turning the conversation into a product pitch, see [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](PHASE_ZERO_SECURITY_BASELINE.md).
 For reusable assessment assets, see [`docs/phase-zero-assessment/`](phase-zero-assessment/).

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -22,10 +22,11 @@ It is not a runtime or execution engine. External orchestrators such as Gemini C
 - The repository must present **Phase 0 security** as the prerequisite for serious AI adoption.
 - Client and buyer navigation must reach [`PHASE_ZERO_SECURITY_BASELINE.md`](PHASE_ZERO_SECURITY_BASELINE.md) directly from the top-level experience.
 - The public documentation must include a reusable **Phase 0 Assessment Kit** with:
+  - separate security and AI readiness assessment guides
   - consent template
   - report-of-findings template
   - 30/60/90-day roadmap template
-  - readiness rubric (`ready now`, `ready with guardrails`, `not ready yet`)
+  - readiness rubric covering security readiness, AI readiness, and the overall recommendation
 
 ### 2. Persona Contract Is Mandatory
 

--- a/docs/examples/msp-deployment.md
+++ b/docs/examples/msp-deployment.md
@@ -11,7 +11,12 @@ NoéMI is a specification library — not a runtime. This makes it well-suited f
 - **Orchestration is external** — the MSP chooses the execution engine (Gemini CLI, n8n, LangChain) per client need
 - **Governance is built in** — AI TRiSM, red team gauntlets, and the 4D Framework apply uniformly across tenants
 
-Before onboarding a client into an AI workflow, establish their Phase 0 baseline first. Use the client-side guide at [`../PHASE_ZERO_SECURITY_BASELINE.md`](../PHASE_ZERO_SECURITY_BASELINE.md) and the reusable templates in [`../phase-zero-assessment/`](../phase-zero-assessment/) to document the minimum security posture, readiness gates, and remediation plan.
+Before onboarding a client into an AI workflow, establish their Phase 0 initial assessment first. Use the client-side guide at [`../PHASE_ZERO_SECURITY_BASELINE.md`](../PHASE_ZERO_SECURITY_BASELINE.md) and the reusable templates in [`../phase-zero-assessment/`](../phase-zero-assessment/) to document both:
+
+- the minimum **security posture** required to begin safely
+- the minimum **AI readiness** required to produce real business value
+
+That gives the MSP a grounded basis for readiness gates, first-pilot selection, and remediation planning.
 When you operationalize tenants, pair this guide with the orchestrator runtime expectations in [`../tool-usages/orchestrator-runtime-contract.md`](../tool-usages/orchestrator-runtime-contract.md) so identity, approval boundaries, logging, and retry handling remain consistent across clients.
 
 ## Architecture
@@ -155,7 +160,7 @@ The Fleet Dashboard aggregates reports across all client tenants. Use the three-
 
 ## Getting Started
 
-1. **Baseline the client** — Complete the Phase 0 baseline and document whether the client is `ready now`, `ready with guardrails`, or `not ready yet`
+1. **Assess the client** — Complete the two-track Phase 0 initial assessment and document security readiness, AI readiness, and the overall recommendation
 2. **Fork client configs** — Create `clients/{client-id}/mcp.config.json` from the base config
 3. **Provision vault** — Set up the client's vault compartment with required credentials
 4. **Select tier** — Enable the appropriate agents and MCPs

--- a/docs/phase-zero-assessment/README.md
+++ b/docs/phase-zero-assessment/README.md
@@ -1,23 +1,87 @@
 # Phase 0 Assessment Kit
 
-This kit is the reusable operational bundle for a **Phase 0 baseline assessment**. It is designed for clients, MSPs, MSSPs, and Accelerators who need a structured way to baseline cybersecurity before launching an advanced AI initiative.
+This kit is the reusable operational bundle for a **Phase 0 initial assessment**. It is designed for clients, MSPs, MSSPs, and Accelerators who need a structured way to answer two separate questions before launching an advanced AI initiative:
 
-The kit is intentionally diagnostic and non-salesy. Its purpose is to establish readiness, document risk, and produce a practical remediation path. It is not a penetration test, a compliance certification, or a disguised procurement script.
+1. **Can we do this safely?**
+2. **Can we do this in a way that creates real business value?**
+
+That is why the kit is now explicitly split into:
+
+- a **Security Assessment**
+- an **AI Readiness Assessment**
+
+The kit is intentionally diagnostic and non-salesy. Its purpose is to establish readiness, document risk, identify the first worthwhile pilot, and produce a practical remediation path. It is not a penetration test, a compliance certification, or a disguised procurement script.
+
+## The Two Assessment Tracks
+
+### Security Assessment
+
+See [security-assessment.md](security-assessment.md).
+
+This track evaluates:
+
+- identity and privilege
+- data boundaries
+- endpoint and SaaS hygiene
+- backups and incident readiness
+- logging and monitoring
+- secrets, APIs, and machine identities
+- third-party exposure
+
+It answers:
+
+> Are we grounded enough to begin AI safely?
+
+### AI Readiness Assessment
+
+See [ai-readiness-assessment.md](ai-readiness-assessment.md).
+
+This track evaluates:
+
+- use-case clarity
+- process stability
+- data and knowledge readiness
+- human approval boundaries
+- role redesign and workforce uplift
+- integration practicality
+- sponsorship and change readiness
+- value measurement and ROI baseline
+
+It answers:
+
+> Are we organized enough to turn AI into governed productivity, more output, and lower unit cost?
 
 ## What This Kit Contains
 
-- [consent-template.md](consent-template.md) — language for authorizing a non-invasive baseline review
-- [report-template.md](report-template.md) — the structure for a written report of findings
+- [security-assessment.md](security-assessment.md) — the cybersecurity half of the initial assessment
+- [ai-readiness-assessment.md](ai-readiness-assessment.md) — the business and operating-model half of the initial assessment
+- [consent-template.md](consent-template.md) — language for authorizing a non-invasive two-track review
+- [report-template.md](report-template.md) — the structure for a written report of findings across both tracks
 - [roadmap-template.md](roadmap-template.md) — a 30/60/90-day remediation and enablement plan
-- [readiness-rubric.md](readiness-rubric.md) — the gate used to classify an organization as `ready now`, `ready with guardrails`, or `not ready yet`
+- [readiness-rubric.md](readiness-rubric.md) — the gate used to classify security readiness, AI readiness, and the overall recommendation
 
 ## Recommended Use
 
-1. Confirm the client use case and the systems the AI initiative will touch.
+1. Confirm the business problem, target workflow, and systems the AI initiative will touch.
 2. Use the consent template to document scope and expectations.
-3. Perform the baseline using the areas defined in [../PHASE_ZERO_SECURITY_BASELINE.md](../PHASE_ZERO_SECURITY_BASELINE.md).
-4. Deliver the report of findings in plain language.
-5. End with the roadmap and readiness rubric so the client knows whether to proceed, proceed with guardrails, or pause.
+3. Perform the **security assessment** using [../PHASE_ZERO_SECURITY_BASELINE.md](../PHASE_ZERO_SECURITY_BASELINE.md) and [security-assessment.md](security-assessment.md).
+4. Perform the **AI readiness assessment** using [ai-readiness-assessment.md](ai-readiness-assessment.md).
+5. Deliver one combined report in plain language for the business owner and technical leads.
+6. End with the roadmap and readiness rubric so the client knows whether to proceed, proceed with guardrails, or pause.
+
+## Why This Matters For NoeMI Participants
+
+This split helps NoeMI participants speak to business owners at a higher level.
+
+Instead of saying:
+
+> I can do this task with AI.
+
+they can say:
+
+> We can assess whether this workflow is safe, whether it is worth automating, what human role should remain in control, and how the business can increase output without increasing headcount at the same rate.
+
+That is the real shift from tool use to governance and value creation.
 
 ## Ground Rules
 

--- a/docs/phase-zero-assessment/ai-readiness-assessment.md
+++ b/docs/phase-zero-assessment/ai-readiness-assessment.md
@@ -1,0 +1,166 @@
+# AI Readiness Assessment
+
+This assessment answers the second executive question:
+
+**"If this is safe enough to begin, are we ready to get real business value from AI?"**
+
+It is the operational and business half of the Project NoeMI initial assessment. Its purpose is to determine whether the organization has the workflow clarity, ownership, measurement, and human operating model needed to turn AI into measurable productivity, higher output, and lower unit cost.
+
+## What This Assessment Is For
+
+Use this assessment when a business or enterprise wants to move from:
+
+- curiosity to a real pilot
+- one-off prompting to repeatable workflows
+- individual task execution to human management of AI doing the task
+
+This assessment does **not** replace the security assessment. It assumes the organization must be both **safe enough** and **ready enough**.
+
+## The Questions It Answers
+
+- Is there a business use case with a real owner, real volume, and real pain?
+- Is the workflow stable enough to automate or augment?
+- Can success be measured in speed, output, quality, capacity, or cost?
+- Which human roles should stay responsible for approval, correction, and exception handling?
+- Can staff move from doing every step manually to managing AI performing first-pass work?
+- Which first pilot is likely to create visible value without creating unnecessary risk?
+
+## Core Assessment Areas
+
+### 1. Business Use-Case Clarity
+
+- named sponsor
+- named process owner
+- specific workflow to improve
+- reason the workflow matters now
+- known pain points such as delay, backlog, inconsistency, or labor intensity
+
+### 2. Process Stability and Repeatability
+
+- repeatable steps
+- clear inputs and outputs
+- known handoffs
+- low enough process chaos that AI is not being pointed at a moving target
+
+### 3. Data and Knowledge Readiness
+
+- source documents and systems are known
+- inputs are accessible and understandable
+- critical reference materials exist
+- exceptions can be recognized and escalated
+
+### 4. Human Approval and Decision Rights
+
+- final human approver is known
+- escalation path exists
+- risky or customer-facing actions stay behind review gates
+- the business knows which steps AI may perform and which remain human-only
+
+### 5. Workforce Uplift and Role Design
+
+- identify who currently performs the task
+- identify which parts should shift to AI first-pass work
+- define the human role after AI enters the loop
+- move people from repetitive execution toward supervision, quality control, exception handling, and process improvement
+
+This is where NoeMI creates its biggest practical shift: the team is not just learning to perform the task with AI. It is learning to **manage AI doing the task**.
+
+### 6. Tooling and Integration Practicality
+
+- required systems are known
+- integration path is realistic
+- pilot can begin with a constrained toolset
+- human-led local path, n8n workflow, or governed runtime path is chosen intentionally
+
+### 7. Change Readiness and Sponsorship
+
+- leadership sponsor is engaged
+- participants have time and authority to test
+- owners will review results and approve corrections
+- staff understand that AI changes the shape of work, not only the speed of work
+
+### 8. Value Measurement and ROI Baseline
+
+- current time spent is known or estimable
+- current volume is known
+- current rework or quality pain is known
+- future success metrics are defined before the pilot starts
+
+Typical measures include:
+
+- turnaround time
+- throughput
+- backlog reduction
+- draft quality consistency
+- human hours redirected
+- lower unit cost per completed item
+
+## How To Explain The Value To A Business Owner
+
+The AI readiness assessment helps a NoeMI participant talk like an operator, not just a tool user.
+
+The core value statement is:
+
+> We are not just helping your team do the task faster. We are helping your team redesign the workflow so AI handles repeatable first-pass work while your people manage approvals, exceptions, and quality.
+
+That matters because the business outcome is bigger than convenience:
+
+- more output with the same team
+- faster turnaround on repetitive work
+- more consistent first drafts or first-pass decisions
+- less skilled human time spent on low-leverage repetition
+- clearer path to measurable ROI
+
+## The Role-Uplift Narrative
+
+This is the shift NoeMI participants should be able to explain clearly:
+
+- **Before AI:** skilled people spend valuable time doing every repetitive step themselves
+- **With governed AI:** AI handles the first-pass work inside defined boundaries
+- **After uplift:** people spend more time reviewing, improving, deciding, and governing
+
+This is how the organization moves from labor substitution thinking to **Virtual Workforce** thinking.
+
+## Recommended Output
+
+The client should leave with:
+
+- one or two high-confidence pilot candidates
+- a clear statement of what success looks like
+- the baseline metrics needed for later ROI tracking
+- the approval boundary for the first pilot
+- a role-uplift explanation leadership can support
+- an AI readiness classification:
+  `ready now`, `ready with guardrails`, or `not ready yet`
+
+## What Good First Pilots Look Like
+
+Strong first pilots are usually:
+
+- high-volume
+- repetitive
+- low-to-medium risk
+- easy to review by a human
+- painful enough that the business owner already wants relief
+
+Examples:
+
+- inbound request triage
+- draft creation
+- document summarization
+- action-item extraction
+- internal knowledge retrieval
+
+## What To Avoid In The First Pilot
+
+- unstable processes with no clear owner
+- emotionally sensitive or high-liability tasks with no review gate
+- enterprise-wide rollouts before one team proves value
+- pilots with no baseline metrics
+- work where nobody agrees what "good" looks like
+
+## Deliverable Sentence
+
+When presenting this assessment, the simplest executive summary is:
+
+> The AI readiness assessment tells us whether this organization can turn AI into governed output, measurable productivity, and lower delivery cost without confusing experimentation for transformation.

--- a/docs/phase-zero-assessment/consent-template.md
+++ b/docs/phase-zero-assessment/consent-template.md
@@ -1,13 +1,19 @@
-# Phase 0 Assessment Consent Template
+# Phase 0 Initial Assessment Consent Template
 
 ## Purpose
 
-This assessment is a **non-invasive Phase 0 baseline review** intended to identify cybersecurity gaps that could materially affect a planned AI initiative. Its purpose is to help the client understand readiness, risk, and remediation priorities before advanced AI workflows go live.
+This assessment is a **non-invasive Phase 0 initial review** intended to establish whether a planned AI initiative is both:
+
+- secure enough to begin
+- operationally ready enough to create measurable business value
+
+Its purpose is to help the client understand readiness, risk, workflow suitability, and remediation priorities before advanced AI workflows go live.
 
 ## Scope
 
-- Review of the target AI use case, connected systems, and data classes
+- Review of the target AI use case, connected systems, data classes, and business owner goals
 - Review of existing policies, incident response, backup, identity, and logging practices
+- Review of process stability, approval boundaries, workforce roles, and measurement approach for the proposed AI workflow
 - Limited technical validation such as posture review, configuration review, or external exposure checks
 - No remediation or production changes during the assessment unless explicitly authorized in writing
 
@@ -15,6 +21,7 @@ This assessment is a **non-invasive Phase 0 baseline review** intended to identi
 
 - This is not a penetration test unless separately agreed
 - This is not a formal compliance certification
+- This is not a guarantee of ROI or production success
 - This is not an authorization to alter, delete, or reconfigure client systems
 - Findings are provided for diagnostic and planning purposes
 
@@ -25,14 +32,20 @@ All information gathered during the assessment is treated as confidential and us
 ## Expected Outputs
 
 - Executive summary
-- Risk findings with evidence and business impact
+- Security findings with evidence and business impact
+- AI readiness findings covering workflow suitability, ownership, role uplift, and measurement readiness
+- Initial pilot recommendation and approval boundary
 - Recommended 30/60/90-day roadmap
-- Readiness classification: `ready now`, `ready with guardrails`, or `not ready yet`
+- Readiness classification:
+  - security readiness: `ready now`, `ready with guardrails`, or `not ready yet`
+  - AI readiness: `ready now`, `ready with guardrails`, or `not ready yet`
+  - overall recommendation: proceed, proceed with guardrails, or pause for remediation
 
 ## Authorization
 
 - **Client organization:**
 - **Primary sponsor:**
+- **Business owner for the target workflow:**
 - **Authorized approver:**
 - **Date:**
 - **Assessment window:**

--- a/docs/phase-zero-assessment/readiness-rubric.md
+++ b/docs/phase-zero-assessment/readiness-rubric.md
@@ -2,11 +2,18 @@
 
 Use this rubric to classify whether an organization is ready to begin an advanced AI initiative.
 
-## Ready Now
+The key rule is simple:
+
+- **security readiness** tells you whether the environment is safe enough
+- **AI readiness** tells you whether the business and workflow are ready enough
+- the **overall recommendation** should reflect both
+
+## 1. Security Readiness
+
+### Ready Now
 
 Use when all of the following are true:
 
-- the business use case is defined and owned
 - MFA and privileged access are under control
 - backup and recovery are verified for the systems in scope
 - secrets will be handled through a vault-backed runtime path
@@ -14,7 +21,7 @@ Use when all of the following are true:
 - data classes and refusal boundaries are documented
 - no critical blockers remain for the target workflow
 
-## Ready With Guardrails
+### Ready With Guardrails
 
 Use when the organization can move forward with a constrained pilot, but only if specific controls are added or enforced first:
 
@@ -23,9 +30,9 @@ Use when the organization can move forward with a constrained pilot, but only if
 - human approval points are added for sensitive operations
 - remediation items are already scheduled in the 30/60/90-day roadmap
 
-## Not Ready Yet
+### Not Ready Yet
 
-Use when the current environment would make the AI initiative materially unsafe or misleading to launch:
+Use when the current environment would make the AI initiative materially unsafe to launch:
 
 - MFA, privileged access, or service-account governance is weak
 - backup recoverability is unknown or untested
@@ -34,8 +41,72 @@ Use when the current environment would make the AI initiative materially unsafe 
 - logging is insufficient to investigate misuse or failure
 - critical vendor or compliance issues remain unresolved
 
-## Output Line
+## 2. AI Readiness
 
-Every assessment should end with a one-line classification:
+### Ready Now
 
-`Phase 0 readiness: ready now | ready with guardrails | not ready yet`
+Use when all of the following are true:
+
+- the business use case is defined and owned
+- the workflow is stable enough to pilot
+- the human approval boundary is clear
+- the team knows what success looks like
+- baseline metrics exist or can be captured immediately
+- leadership sponsor and process owner are engaged
+
+### Ready With Guardrails
+
+Use when the organization can run a constrained pilot, but only if the first rollout stays narrow:
+
+- the use case is promising but the workflow still needs tightening
+- approval gates must remain strong
+- only one team, one document class, or one low-risk action should be in scope at first
+- measurement must be formalized before broader rollout
+
+### Not Ready Yet
+
+Use when the organization is still too ambiguous or unstable to expect meaningful value:
+
+- the use case is vague or has no real owner
+- the workflow changes too often to automate reliably
+- nobody agrees what good output looks like
+- no baseline metrics exist and no one owns measurement
+- the organization is treating experimentation as transformation
+
+## 3. Overall Recommendation
+
+### Proceed
+
+Use when:
+
+- security readiness is `ready now` or a very light `ready with guardrails`
+- AI readiness is `ready now`
+- the first pilot can be launched with clear ownership and measurement
+
+### Proceed With Guardrails
+
+Use when:
+
+- one or both tracks are `ready with guardrails`
+- the initial pilot can be safely constrained
+- remediation items are named, owned, and time-bound
+
+### Pause For Remediation
+
+Use when:
+
+- security readiness is `not ready yet`
+- or AI readiness is `not ready yet`
+- or the organization cannot yet name a safe, worthwhile first pilot
+
+## 4. Output Lines
+
+Every assessment should end with four short lines:
+
+`Security readiness: ready now | ready with guardrails | not ready yet`
+
+`AI readiness: ready now | ready with guardrails | not ready yet`
+
+`Overall recommendation: proceed | proceed with guardrails | pause for remediation`
+
+`First pilot recommendation: <named workflow or "not recommended yet">`

--- a/docs/phase-zero-assessment/report-template.md
+++ b/docs/phase-zero-assessment/report-template.md
@@ -1,23 +1,43 @@
-# Phase 0 Report of Findings Template
+# Phase 0 Initial Assessment Report Template
 
 ## 1. Executive Summary
 
 - **Client:**
 - **Assessment date:**
 - **Planned AI initiative:**
-- **Overall readiness:** `ready now` | `ready with guardrails` | `not ready yet`
-- **Top risks:**
+- **Security readiness:** `ready now` | `ready with guardrails` | `not ready yet`
+- **AI readiness:** `ready now` | `ready with guardrails` | `not ready yet`
+- **Overall recommendation:** proceed | proceed with guardrails | pause for remediation
+- **Top security risks:**
+- **Top AI-readiness gaps:**
 - **Immediate recommendation:**
 
-## 2. Scope and Evidence Sources
+## 2. Business Context And Value Thesis
 
-- Stakeholders interviewed
-- Documents reviewed
-- Systems and services reviewed
-- Validation methods used
-- Constraints or exclusions that may affect confidence
+- **Business owner:**
+- **Target workflow:**
+- **Why this workflow matters now:**
+- **Current manual pain:**
+- **Expected business gain if improved:**
+- **Likely first pilot candidate:**
 
-## 3. Findings
+### Baseline Metrics To Capture
+
+- current volume
+- current turnaround time
+- current human effort
+- current rework or error rate
+- current approval points
+
+## 3. Scope And Evidence Sources
+
+- stakeholders interviewed
+- documents reviewed
+- systems and services reviewed
+- validation methods used
+- constraints or exclusions that may affect confidence
+
+## 4. Security Assessment Findings
 
 For each finding:
 
@@ -30,7 +50,19 @@ For each finding:
 - **Recommended action**
 - **Owner**
 
-## 4. Readiness by Control Area
+## 5. AI Readiness Assessment Findings
+
+For each finding:
+
+- **Title**
+- **Severity:** High | Moderate | Low
+- **Observation**
+- **Business impact**
+- **Why it matters for value realization**
+- **Recommended action**
+- **Owner**
+
+## 6. Security Readiness By Control Area
 
 | Area | Status | Notes |
 |------|--------|-------|
@@ -44,12 +76,47 @@ For each finding:
 | Third-party / vendor risk | | |
 | Incident response and governance | | |
 
-## 5. Go / No-Go Guidance
+## 7. AI Readiness By Operating Area
 
-- **Safe to proceed now**
-- **Safe to proceed only with guardrails**
-- **Must be remediated before launch**
+| Area | Status | Notes |
+|------|--------|-------|
+| Use-case clarity and ownership | | |
+| Process stability and repeatability | | |
+| Data and knowledge readiness | | |
+| Human approval and escalation design | | |
+| Workforce uplift and role redesign | | |
+| Tooling and integration practicality | | |
+| Change readiness and sponsorship | | |
+| Metrics and ROI baseline | | |
 
-## 6. Next-Step Roadmap
+## 8. Role Uplift And Operating Model Recommendation
+
+- **Current human role shape:**
+- **Recommended AI role in the workflow:**
+- **Recommended human role after AI enters the loop:**
+- **Approval boundary:**
+- **Exception-handling owner:**
+
+Use this section to explain the NoeMI shift clearly:
+
+- what work remains human
+- what work AI should perform first
+- how the team moves from doing the work manually to managing AI doing the first-pass work
+
+## 9. Go / Pilot / No-Go Guidance
+
+### Safe To Proceed Now
+
+- |
+
+### Safe To Proceed Only With Guardrails
+
+- |
+
+### Must Be Remediated Before Launch
+
+- |
+
+## 10. Next-Step Roadmap
 
 Reference [roadmap-template.md](roadmap-template.md) and tailor it to the client.

--- a/docs/phase-zero-assessment/roadmap-template.md
+++ b/docs/phase-zero-assessment/roadmap-template.md
@@ -1,33 +1,68 @@
 # Phase 0 30/60/90-Day Roadmap Template
 
-## 0-30 Days: Stabilize the Baseline
+Use this roadmap to keep the two workstreams visible:
 
-- Confirm executive sponsor and technical owner
-- Document the AI use case, systems touched, and allowed data classes
-- Close urgent identity, MFA, or privileged-access gaps
-- Verify backup recoverability for critical systems
-- Establish approved secret-management path for machine identities and service credentials
-- Define the initial refusal boundary for data and tasks that must not touch AI
+- **Security track** — what must be stabilized or governed
+- **AI readiness track** — what must be clarified, measured, and piloted to produce value
 
-## 31-60 Days: Add Guardrails
+## 0-30 Days: Stabilize And Scope
 
-- Centralize logs for the systems involved in the AI workflow
-- Confirm alert ownership and incident escalation path
-- Review third-party AI and SaaS vendor exposure
-- Tighten access scopes for service accounts and connectors
-- Document human approval points for risky or mutating actions
-- Run a tabletop or dry run for failure handling
+### Security Track
 
-## 61-90 Days: Prepare for Governed Launch
+- confirm executive sponsor and technical owner
+- document the AI use case, systems touched, and allowed data classes
+- close urgent identity, MFA, or privileged-access gaps
+- verify backup recoverability for critical systems
+- establish approved secret-management path for machine identities and service credentials
+- define the initial refusal boundary for data and tasks that must not touch AI
 
-- Finalize monitoring and audit expectations
-- Validate the target workflow against the readiness rubric
-- Perform a Red Team or boundary review where warranted
-- Confirm rollback and correction procedures
-- Decide whether the AI initiative moves to pilot, guarded launch, or remediation hold
+### AI Readiness Track
 
-## Owners and Dependencies
+- confirm the business owner for the target workflow
+- document the current workflow, inputs, outputs, and approval steps
+- identify the first narrow pilot candidate
+- capture baseline metrics for volume, cycle time, and human effort
+- define what work AI may perform first and what remains human-only
 
-| Item | Owner | Dependency | Target Date |
-|------|-------|------------|-------------|
-| | | | |
+## 31-60 Days: Add Guardrails And Design The Pilot
+
+### Security Track
+
+- centralize logs for the systems involved in the AI workflow
+- confirm alert ownership and incident escalation path
+- review third-party AI and SaaS vendor exposure
+- tighten access scopes for service accounts and connectors
+- document human approval points for risky or mutating actions
+- run a tabletop or dry run for failure handling
+
+### AI Readiness Track
+
+- convert the workflow into a constrained pilot design
+- assign review, correction, and exception owners
+- define the target output and acceptance criteria clearly
+- train the participating team on the approval boundary
+- confirm how the business owner will review results and value
+
+## 61-90 Days: Prepare For Governed Launch
+
+### Security Track
+
+- finalize monitoring and audit expectations
+- validate the target workflow against the readiness rubric
+- perform a Red Team or boundary review where warranted
+- confirm rollback and correction procedures
+
+### AI Readiness Track
+
+- run the first governed pilot
+- compare pilot results to the baseline metrics
+- document where human roles shifted from execution to supervision or exception handling
+- decide whether to expand, constrain further, or pause
+- prepare the handoff into ongoing ROI tracking using the approved metrics
+
+## Owners And Dependencies
+
+| Track | Item | Owner | Dependency | Target Date |
+|-------|------|-------|------------|-------------|
+| Security | | | | |
+| AI Readiness | | | | |

--- a/docs/phase-zero-assessment/security-assessment.md
+++ b/docs/phase-zero-assessment/security-assessment.md
@@ -1,0 +1,119 @@
+# Phase 0 Security Assessment
+
+This assessment answers one executive question:
+
+**"Can we begin this AI initiative safely?"**
+
+It is the cybersecurity half of the Project NoeMI initial assessment. Its purpose is to identify the risks that would make an AI pilot unsafe, fragile, or non-governable before the organization connects AI to real systems, real data, or real customer interactions.
+
+## What This Assessment Is For
+
+Use this assessment when a business or enterprise wants to:
+
+- introduce copilots, agents, or workflow automation
+- connect AI to email, document systems, CRM, ERP, or line-of-business tools
+- move from informal experimentation to governed production use
+
+The security assessment does **not** tell the client whether the use case is commercially worthwhile. It tells them whether the environment is safe enough to begin.
+
+## The Questions It Answers
+
+- Are identity, access, and privilege boundaries strong enough for AI-connected workflows?
+- Are data classes, refusal boundaries, and sharing rules clear enough to prevent accidental leakage?
+- Are secrets, service accounts, and machine identities governed well enough for automation?
+- Can the organization detect, investigate, and contain misuse, failure, or breach?
+- Are there critical blockers that should stop the AI initiative until remediation is complete?
+
+## Core Assessment Areas
+
+### 1. Identity, MFA, and Privileged Access
+
+- centralized identity
+- MFA coverage
+- admin separation
+- service-account ownership
+- least-privilege scoping for connected systems
+
+### 2. Data Boundaries and Refusal Rules
+
+- data classification
+- systems holding regulated or confidential data
+- approved vs prohibited AI usage
+- human-only tasks and human-only data classes
+
+### 3. Endpoint, Server, and SaaS Hygiene
+
+- managed devices
+- patch cadence
+- EDR or MDR coverage
+- critical SaaS security settings
+- current asset inventory
+
+### 4. Backup, Recovery, and Incident Response
+
+- backup coverage
+- restore evidence
+- recovery ownership
+- incident escalation paths
+- breach and workflow-failure handling
+
+### 5. Logging, Monitoring, and Forensics
+
+- centralized log coverage
+- alert ownership
+- retention
+- traceability for AI-related service accounts or automation actions
+
+### 6. Secrets, APIs, and Machine Identity
+
+- vault-backed secret handling
+- rotation process
+- removal of plaintext `.env` habits
+- machine identities or equivalent non-human auth paths for headless automation
+
+### 7. Third-Party and Vendor Exposure
+
+- AI vendor review
+- connector exposure
+- SaaS risk
+- data-processing and contract concerns
+
+## What Good Output Looks Like
+
+The client should receive:
+
+- a clear written summary of the biggest risks
+- a distinction between blockers and non-blockers
+- evidence and business impact for each major finding
+- compensating controls where immediate remediation is not practical
+- a security readiness classification:
+  `ready now`, `ready with guardrails`, or `not ready yet`
+
+## How To Explain The Value To A Business Owner
+
+The security assessment is not "extra overhead." It protects the value of the AI initiative itself.
+
+The business value is:
+
+- fewer surprises after launch
+- lower chance of data leakage or uncontrolled Shadow AI behavior
+- less rework caused by rushed, unsafe implementations
+- clearer approval and accountability before the workflow touches sensitive systems
+- higher confidence that a future pilot can scale instead of being shut down by risk
+
+In business-owner language:
+
+> We are reducing the chance that your AI project creates new operational risk faster than it creates value.
+
+## What It Does Not Claim
+
+- it is not a penetration test unless separately scoped
+- it is not a compliance certification
+- it does not guarantee no future incident
+- it does not replace ongoing MSP or MSSP operations where continuous monitoring is needed
+
+## Deliverable Sentence
+
+When presenting this assessment, the simplest executive summary is:
+
+> The security assessment tells us whether the organization is grounded enough to start AI safely, what must be fixed first, and what controls must remain in place as the initiative grows.

--- a/tests/contracts.test.js
+++ b/tests/contracts.test.js
@@ -56,6 +56,8 @@ test('builder-facing docs point to the Docker Agent Home path', () => {
     assert.match(readme, /docs\/examples\/docker-agent-home\.md/);
     assert.match(readme, /npm run validate/);
     assert.match(readme, /verify-env\.sh --mode=builder/);
+    assert.match(readme, /productivity of the active workforce/i);
+    assert.match(readme, /mass unemployment as the strategy/i);
 });
 
 test('environment verification scripts expose path-aware beginner and docker modes', () => {

--- a/tests/examples-smoke.test.js
+++ b/tests/examples-smoke.test.js
@@ -88,6 +88,45 @@ test('secret management guide leads beginners through a local-first choice betwe
     assert.match(guide, /machine identities/i);
 });
 
+test('phase zero assessment kit separates security readiness from AI readiness and speaks in business-value terms', () => {
+    const kit = read('docs/phase-zero-assessment/README.md');
+    const security = read('docs/phase-zero-assessment/security-assessment.md');
+    const readiness = read('docs/phase-zero-assessment/ai-readiness-assessment.md');
+    const report = read('docs/phase-zero-assessment/report-template.md');
+    const rubric = read('docs/phase-zero-assessment/readiness-rubric.md');
+    const roadmap = read('docs/phase-zero-assessment/roadmap-template.md');
+
+    assert.match(kit, /Security Assessment/);
+    assert.match(kit, /AI Readiness Assessment/);
+    assert.match(kit, /can we do this safely/i);
+    assert.match(kit, /can we do this in a way that creates real business value/i);
+    assert.match(security, /Can we begin this AI initiative safely/i);
+    assert.match(security, /business owner/i);
+    assert.match(readiness, /real business value/i);
+    assert.match(readiness, /manage AI doing the task/i);
+    assert.match(readiness, /more output/i);
+    assert.match(readiness, /lower unit cost/i);
+    assert.match(report, /Security readiness:/);
+    assert.match(report, /AI readiness:/);
+    assert.match(report, /Role Uplift And Operating Model Recommendation/);
+    assert.match(rubric, /Overall recommendation:/);
+    assert.match(rubric, /First pilot recommendation:/);
+    assert.match(roadmap, /Security Track/);
+    assert.match(roadmap, /AI Readiness Track/);
+});
+
+test('front-door docs frame NoeMI as productivity uplift rather than labor replacement', () => {
+    const readme = read('README.md');
+    const projectReference = read('docs/PROJECT_REFERENCE.md');
+
+    assert.match(readme, /increase output/i);
+    assert.match(readme, /Virtual Workforce/i);
+    assert.match(readme, /mass unemployment/i);
+    assert.match(projectReference, /increasing the productivity of the active population/i);
+    assert.match(projectReference, /Virtual Workforce model/i);
+    assert.match(projectReference, /labor-displacement fear/i);
+});
+
 test('Google Workspace docs separate Gemini CLI, generic MCP, and n8n setup paths', () => {
     const geminiQuickstart = read('docs/tool-usages/gemini-workspace-quickstart.md');
     const n8nQuickstart = read('docs/examples/n8n-google-workspace-quickstart.md');


### PR DESCRIPTION
## Summary
- split the Phase 0 initial assessment into security and AI readiness tracks
- add business-facing framing about productivity uplift and governed AI work
- update the assessment templates, rubric, roadmap, and MSP/public reference docs

## Testing
- npm run validate