### PR TITLE
docs(onboarding): add windows and chromeos kickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ In plain business terms, NoéMI is useful because it helps an organization move 
 
 > **New to AI and want one safe first win?** Start with [**Zero To First Agent**](docs/examples/zero-to-first-agent.md).
 
+> **On Windows or ChromeOS?** Use the dedicated [**Windows Kickstart**](docs/examples/windows-kickstart.md) or [**ChromeOS Kickstart**](docs/examples/chromeos-kickstart.md) so you begin in the right shell and runtime.
+
 **Audience paths:**
 - **Client / Buyer:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Phase 0 Security Baseline](docs/PHASE_ZERO_SECURITY_BASELINE.md) → [Phase 0 Assessment Kit](docs/phase-zero-assessment/README.md)
 - **MSP / MSSP:** [Project Reference](docs/PROJECT_REFERENCE.md) → [MSP Deployment Guide](docs/examples/msp-deployment.md) → [Fleet / governance docs](docs/agents/operations/)
-- **Builder / Accelerator:** [Zero To First Agent](docs/examples/zero-to-first-agent.md) → [Secure Secret Management](docs/tool-usages/secure-secret-management.md) → [Agentic Local Workspaces](docs/tool-usages/agentic-local-workspaces.md) → [Google Local Workspace](docs/tool-usages/google-local-workspace.md), [Claude Code Local Workspace](docs/tool-usages/claude-code-local-workspace.md), or [OpenAI Codex Local Workspace](docs/tool-usages/openai-codex-local-workspace.md) → [GWS CLI Machine Setup](docs/mcp-setup/gws-cli-machine-setup.md) → [Google Workspace For Agentic Clients](docs/mcp-setup/google-workspace-agentic-clients.md) or [Microsoft 365 For Agentic Clients](docs/mcp-setup/microsoft-365-agentic-clients.md) → [Value Lenses](docs/frameworks/value-lenses.md) → [Gemini Workspace Quickstart](docs/tool-usages/gemini-workspace-quickstart.md) or [n8n Google Workspace Quickstart](docs/examples/n8n-google-workspace-quickstart.md) → [Builder First 30 Minutes](docs/examples/builder-first-30-minutes.md) → [Docker Agent Home](docs/examples/docker-agent-home.md) → [Orchestrator Runtime Contract](docs/tool-usages/orchestrator-runtime-contract.md)
+- **Builder / Accelerator:** [Zero To First Agent](docs/examples/zero-to-first-agent.md) → [Windows Kickstart](docs/examples/windows-kickstart.md) or [ChromeOS Kickstart](docs/examples/chromeos-kickstart.md) when needed → [Secure Secret Management](docs/tool-usages/secure-secret-management.md) → [Agentic Local Workspaces](docs/tool-usages/agentic-local-workspaces.md) → [Google Local Workspace](docs/tool-usages/google-local-workspace.md), [Claude Code Local Workspace](docs/tool-usages/claude-code-local-workspace.md), or [OpenAI Codex Local Workspace](docs/tool-usages/openai-codex-local-workspace.md) → [GWS CLI Machine Setup](docs/mcp-setup/gws-cli-machine-setup.md) → [Google Workspace For Agentic Clients](docs/mcp-setup/google-workspace-agentic-clients.md) or [Microsoft 365 For Agentic Clients](docs/mcp-setup/microsoft-365-agentic-clients.md) → [Value Lenses](docs/frameworks/value-lenses.md) → [Gemini Workspace Quickstart](docs/tool-usages/gemini-workspace-quickstart.md) or [n8n Google Workspace Quickstart](docs/examples/n8n-google-workspace-quickstart.md) → [Builder First 30 Minutes](docs/examples/builder-first-30-minutes.md) → [Docker Agent Home](docs/examples/docker-agent-home.md) → [Orchestrator Runtime Contract](docs/tool-usages/orchestrator-runtime-contract.md)
 
 ## Table of Contents
 
@@ -45,7 +47,9 @@ In plain business terms, NoéMI is useful because it helps an organization move 
 
 ## Quick Start
 
-**Prerequisites:** [Node.js](https://nodejs.org/) (24.x LTS recommended; 25+ supported), [Git](https://git-scm.com/), one supported local client ([Gemini CLI](https://github.com/google-gemini/gemini-cli), Claude Code, or OpenAI Codex), and a secret manager ([Infisical CLI](https://infisical.com/docs/cli/overview) or [1Password CLI](https://developer.1password.com/docs/cli/)) before you connect business systems. [Docker](https://www.docker.com/) becomes part of the path when you are ready to build a runtime home.
+**Prerequisites:** [Node.js](https://nodejs.org/) (24.x LTS recommended; 25+ supported), [Git](https://git-scm.com/), one supported local client ([Gemini CLI](https://github.com/google-gemini/gemini-cli), Claude Code, or OpenAI Codex), and a secret manager ([Infisical CLI](https://infisical.com/docs/cli/overview) or [1Password CLI](https://developer.1password.com/docs/cli/)) before you connect business systems. [Docker](https://www.docker.com/) becomes part of the path when you are ready to build a runtime home. On ChromeOS, use the Linux development environment terminal. On Windows, use the PowerShell path below.
+
+### macOS, Linux, or ChromeOS Linux Terminal
 
 ```bash
 # 1. Clone the repository
@@ -79,8 +83,31 @@ op run --env-file=.env.template -- gemini
 # Codex can be launched through the same Fetch-on-Demand pattern
 ```
 
+### Windows PowerShell
+
+```powershell
+# 1. Clone the repository
+git clone https://github.com/newpush/agents.git
+cd agents
+
+# 2. Verify the beginner local-first path
+powershell -ExecutionPolicy Bypass -File scripts/verify-env.ps1 -Mode builder
+
+# 3. Configure which MCP integrations are active (edit as needed)
+Get-Content mcp.config.json
+
+# 4. Generate context files consumed by orchestrators
+node scripts/generate_all.js
+
+# 5. Run the fast validation gate
+npm run validate
+
+# 6. Prove one safe local task first
+gemini -p GEMINI.md "List the engineering agents in this repository and summarize what each one does in one sentence."
+```
+
 The generated `GEMINI.md` and `CLAUDE.md` files contain your agent personas, security mandates, and MCP protocol definitions — everything an orchestrator needs to act as your agents.
-If you are completely new to AI implementation, follow [`docs/examples/zero-to-first-agent.md`](docs/examples/zero-to-first-agent.md) before the Docker-oriented builder path.
+If you are completely new to AI implementation, follow [`docs/examples/zero-to-first-agent.md`](docs/examples/zero-to-first-agent.md) before the Docker-oriented builder path. If you are on Windows or ChromeOS, start with [`docs/examples/windows-kickstart.md`](docs/examples/windows-kickstart.md) or [`docs/examples/chromeos-kickstart.md`](docs/examples/chromeos-kickstart.md) so the shell instructions match your machine.
 
 The same validation gates are enforced in GitHub Actions on pushes and pull requests targeting `develop` and `main`, so local validation mirrors the repository's CI contract.
 When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-smoke/` or the uploaded `docker-smoke-diagnostics` artifact.
@@ -93,7 +120,7 @@ When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-
 |----------|------------|------------|
 | **Client / Buyer** | [`docs/PROJECT_REFERENCE.md`](docs/PROJECT_REFERENCE.md) | [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](docs/PHASE_ZERO_SECURITY_BASELINE.md), [`docs/phase-zero-assessment/README.md`](docs/phase-zero-assessment/README.md) |
 | **MSP / MSSP** | [`docs/PROJECT_REFERENCE.md`](docs/PROJECT_REFERENCE.md) | [`docs/examples/msp-deployment.md`](docs/examples/msp-deployment.md), [`docs/agents/operations/`](docs/agents/operations/) |
-| **Builder / Accelerator** | [`docs/examples/zero-to-first-agent.md`](docs/examples/zero-to-first-agent.md) | [`docs/tool-usages/secure-secret-management.md`](docs/tool-usages/secure-secret-management.md), [`docs/tool-usages/agentic-local-workspaces.md`](docs/tool-usages/agentic-local-workspaces.md), [`docs/tool-usages/google-local-workspace.md`](docs/tool-usages/google-local-workspace.md), [`docs/tool-usages/claude-code-local-workspace.md`](docs/tool-usages/claude-code-local-workspace.md), [`docs/tool-usages/openai-codex-local-workspace.md`](docs/tool-usages/openai-codex-local-workspace.md), [`docs/mcp-setup/gws-cli-machine-setup.md`](docs/mcp-setup/gws-cli-machine-setup.md), [`docs/mcp-setup/google-workspace-agentic-clients.md`](docs/mcp-setup/google-workspace-agentic-clients.md), [`docs/mcp-setup/microsoft-365-agentic-clients.md`](docs/mcp-setup/microsoft-365-agentic-clients.md), [`docs/tool-usages/gemini-workspace-quickstart.md`](docs/tool-usages/gemini-workspace-quickstart.md), [`docs/examples/n8n-google-workspace-quickstart.md`](docs/examples/n8n-google-workspace-quickstart.md), [`docs/mcp-setup/google-n8n-credential-matrix.md`](docs/mcp-setup/google-n8n-credential-matrix.md), [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md), [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md), [`docs/examples/docker-runtime-verification.md`](docs/examples/docker-runtime-verification.md), [`docs/tool-usages/orchestrator-runtime-contract.md`](docs/tool-usages/orchestrator-runtime-contract.md), [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md) |
+| **Builder / Accelerator** | [`docs/examples/zero-to-first-agent.md`](docs/examples/zero-to-first-agent.md) | [`docs/examples/windows-kickstart.md`](docs/examples/windows-kickstart.md), [`docs/examples/chromeos-kickstart.md`](docs/examples/chromeos-kickstart.md), [`docs/tool-usages/secure-secret-management.md`](docs/tool-usages/secure-secret-management.md), [`docs/tool-usages/agentic-local-workspaces.md`](docs/tool-usages/agentic-local-workspaces.md), [`docs/tool-usages/google-local-workspace.md`](docs/tool-usages/google-local-workspace.md), [`docs/tool-usages/claude-code-local-workspace.md`](docs/tool-usages/claude-code-local-workspace.md), [`docs/tool-usages/openai-codex-local-workspace.md`](docs/tool-usages/openai-codex-local-workspace.md), [`docs/mcp-setup/gws-cli-machine-setup.md`](docs/mcp-setup/gws-cli-machine-setup.md), [`docs/mcp-setup/google-workspace-agentic-clients.md`](docs/mcp-setup/google-workspace-agentic-clients.md), [`docs/mcp-setup/microsoft-365-agentic-clients.md`](docs/mcp-setup/microsoft-365-agentic-clients.md), [`docs/tool-usages/gemini-workspace-quickstart.md`](docs/tool-usages/gemini-workspace-quickstart.md), [`docs/examples/n8n-google-workspace-quickstart.md`](docs/examples/n8n-google-workspace-quickstart.md), [`docs/mcp-setup/google-n8n-credential-matrix.md`](docs/mcp-setup/google-n8n-credential-matrix.md), [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md), [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md), [`docs/examples/docker-runtime-verification.md`](docs/examples/docker-runtime-verification.md), [`docs/tool-usages/orchestrator-runtime-contract.md`](docs/tool-usages/orchestrator-runtime-contract.md), [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md) |
 
 ---
 
@@ -523,6 +550,8 @@ All documentation lives in `docs/`. Here's where to find what:
 | Client-side Phase 0 guidance | [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](docs/PHASE_ZERO_SECURITY_BASELINE.md) |
 | Phase 0 assessment kit | [`docs/phase-zero-assessment/README.md`](docs/phase-zero-assessment/README.md) |
 | Beginner first-win guide | [`docs/examples/zero-to-first-agent.md`](docs/examples/zero-to-first-agent.md) |
+| Windows beginner guide | [`docs/examples/windows-kickstart.md`](docs/examples/windows-kickstart.md) |
+| ChromeOS beginner guide | [`docs/examples/chromeos-kickstart.md`](docs/examples/chromeos-kickstart.md) |
 | Google Workspace machine setup | [`docs/mcp-setup/gws-cli-machine-setup.md`](docs/mcp-setup/gws-cli-machine-setup.md) |
 | Builder onboarding walkthrough | [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md) |
 | Builder-facing Docker home guide | [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md) |

--- a/docs/examples/builder-first-30-minutes.md
+++ b/docs/examples/builder-first-30-minutes.md
@@ -19,12 +19,25 @@ Read these guides first:
 
 Those explain the security contract, the shape of the Docker home you are about to launch, and the runtime responsibilities your orchestrator must own.
 
+Platform note:
+
+- on Windows, use the PowerShell preflight script instead of the Bash script
+- on ChromeOS, finish the local-first path first and only continue here if your Linux environment or remote host is truly Docker-capable
+
 ## Step 1: Verify The Docker Toolchain
 
 From the repository root:
 
+macOS, Linux, or ChromeOS Linux terminal:
+
 ```bash
 bash scripts/verify-env.sh --mode=docker
+```
+
+Windows PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/verify-env.ps1 -Mode docker
 ```
 
 This checks the Docker-oriented path without pretending Docker was required for the very first beginner task.

--- a/docs/examples/chromeos-kickstart.md
+++ b/docs/examples/chromeos-kickstart.md
@@ -1,0 +1,108 @@
+# ChromeOS Kickstart
+
+Use this guide when your main machine is a Chromebook or ChromeOS device.
+
+The key idea is simple: on ChromeOS, Project NoeMI starts inside the **Linux development environment**. Once that terminal is available, the beginner path looks like the Linux path from this repository.
+
+## What You Need
+
+- a ChromeOS device with the Linux development environment enabled
+- Git
+- Node.js 24 or newer inside the Linux environment
+- one supported local AI client: Gemini CLI, Claude Code, or OpenAI Codex
+
+## Step 1: Turn On The Linux Development Environment
+
+In ChromeOS:
+
+1. Open **Settings**
+2. Go to **Developers**
+3. Turn on **Linux development environment**
+4. Open the Terminal window that ChromeOS creates
+
+If your Chromebook is managed and Linux is disabled, stop here and use another machine or a remote development host. The beginner path depends on that Linux terminal.
+
+## Step 2: Clone The Repository In The Linux Terminal
+
+```bash
+git clone https://github.com/newpush/agents.git
+cd agents
+```
+
+## Step 3: Run The Beginner Preflight
+
+```bash
+bash scripts/verify-env.sh --mode=builder
+```
+
+This checks:
+
+- Git
+- Node.js
+- at least one supported local AI client
+- whether Docker is present, without requiring it yet
+- whether Infisical CLI or 1Password CLI is available for later Fetch-on-Demand work
+
+If `node -v` is lower than 24, update Node inside the Linux environment before continuing.
+
+## Step 4: Generate The Current Agent Context
+
+```bash
+node scripts/generate_all.js
+npm run validate
+```
+
+## Step 5: Get One Safe First Win
+
+Use one read-only prompt against the local repository first.
+
+### Gemini CLI
+
+```bash
+gemini -p GEMINI.md "List the engineering agents in this repository and summarize what each one does in one sentence. Then tell me which one would help first with PR review."
+```
+
+### Claude Code
+
+Open the repository in Claude Code and ask:
+
+> Read `CLAUDE.md`, inspect the engineering agents in this repository, and summarize what each one does in one sentence. Then tell me which one would help first with PR review.
+
+### OpenAI Codex
+
+Open the repository in Codex and ask:
+
+> Inspect this repository and summarize the engineering agents in one sentence each. Then tell me which one would help first with PR review.
+
+## Step 6: Add Secret Injection Only When You Need Business Systems
+
+When you move beyond local read-only work, wrap the client at launch:
+
+```bash
+infisical run --env=dev -- gemini
+op run --env-file=.env.template -- gemini
+```
+
+The same pattern applies to Claude Code and Codex.
+
+## ChromeOS Notes
+
+- ChromeOS is excellent for the local-first builder path.
+- ChromeOS is often **not** the easiest place to start the Docker phase. Many users stop at the local client path on the Chromebook and move Docker runtime work to a stronger Linux, macOS, or Windows host later.
+- If your Chromebook is powerful and your Linux environment supports the tools you need, you can still continue into [`builder-first-30-minutes.md`](builder-first-30-minutes.md). Just do not treat Docker as part of the required first win.
+
+## What To Read Next
+
+1. [`zero-to-first-agent.md`](zero-to-first-agent.md)
+2. [`../tool-usages/secure-secret-management.md`](../tool-usages/secure-secret-management.md)
+3. [`../tool-usages/agentic-local-workspaces.md`](../tool-usages/agentic-local-workspaces.md)
+4. [`builder-first-30-minutes.md`](builder-first-30-minutes.md) when you are ready for the Docker phase
+
+## Outcome
+
+If this guide worked, you now have:
+
+- one Chromebook-safe verification path
+- one working local AI client inside the Linux terminal
+- one validated repository context
+- one first success before adding business-system credentials or Docker complexity

--- a/docs/examples/windows-kickstart.md
+++ b/docs/examples/windows-kickstart.md
@@ -1,0 +1,117 @@
+# Windows Kickstart
+
+Use this guide when your main machine is Windows and you want the safest beginner path into Project NoeMI.
+
+This is the right starting point if:
+
+- you are comfortable using Windows but not yet comfortable with Bash
+- you want one harmless, read-only AI success before Docker or business-system wiring
+- you want to use PowerShell instead of guessing which Linux-style command still applies on Windows
+
+## What You Need
+
+- Git
+- Node.js 24 or newer
+- one supported local AI client: Gemini CLI, Claude Code, or OpenAI Codex
+- PowerShell
+  - `powershell` works on stock Windows
+  - `pwsh` is recommended if you already use PowerShell 7
+
+## Step 1: Clone The Repository
+
+Open PowerShell and run:
+
+```powershell
+git clone https://github.com/newpush/agents.git
+cd agents
+```
+
+## Step 2: Run The Windows Preflight
+
+If you are using the PowerShell that ships with Windows:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/verify-env.ps1 -Mode builder
+```
+
+If you already have PowerShell 7:
+
+```powershell
+pwsh -File scripts/verify-env.ps1 -Mode builder
+```
+
+This checks:
+
+- Git
+- Node.js
+- at least one supported local AI client
+- whether Docker is present, without requiring it yet
+- whether Infisical CLI or 1Password CLI is available for later Fetch-on-Demand work
+
+## Step 3: Generate The Current Agent Context
+
+```powershell
+node scripts/generate_all.js
+npm run validate
+```
+
+This gives you the current generated context files and confirms the repository contracts are healthy.
+
+## Step 4: Get One Safe First Win
+
+Use one read-only prompt against the local repository first.
+
+### Gemini CLI
+
+```powershell
+gemini -p GEMINI.md "List the engineering agents in this repository and summarize what each one does in one sentence. Then tell me which one would help first with PR review."
+```
+
+### Claude Code
+
+Open the repository in Claude Code and ask:
+
+> Read `CLAUDE.md`, inspect the engineering agents in this repository, and summarize what each one does in one sentence. Then tell me which one would help first with PR review.
+
+### OpenAI Codex
+
+Open the repository in Codex and ask:
+
+> Inspect this repository and summarize the engineering agents in one sentence each. Then tell me which one would help first with PR review.
+
+## Step 5: Add Secret Injection Only When You Need Business Systems
+
+Do not start by pasting secrets into files.
+
+When you move beyond local read-only work, wrap the client at launch:
+
+```powershell
+infisical run --env=dev -- gemini
+op run --env-file=.env.template -- gemini
+```
+
+The same pattern applies to Claude Code and Codex.
+
+## Step 6: Know What Comes Later
+
+After this local-first success:
+
+1. [`zero-to-first-agent.md`](zero-to-first-agent.md)
+2. [`../tool-usages/secure-secret-management.md`](../tool-usages/secure-secret-management.md)
+3. [`../tool-usages/agentic-local-workspaces.md`](../tool-usages/agentic-local-workspaces.md)
+4. [`builder-first-30-minutes.md`](builder-first-30-minutes.md) when you are ready for Docker
+
+## Windows Notes
+
+- You do **not** need WSL for the first beginner path.
+- You do **not** need Docker Desktop for the first beginner path.
+- If you later move into Docker homes, use [`builder-first-30-minutes.md`](builder-first-30-minutes.md) and install Docker Desktop at that stage.
+
+## Outcome
+
+If this guide worked, you now have:
+
+- one Windows-safe verification path
+- one working local AI client
+- one validated repository context
+- one first success you can show to a colleague before connecting business systems

--- a/docs/examples/zero-to-first-agent.md
+++ b/docs/examples/zero-to-first-agent.md
@@ -4,6 +4,11 @@ This is the safest beginner path in Project NoeMI.
 
 Use it when you are new to AI, comfortable around technology, and want one real success before you connect Google Workspace, Microsoft 365, GitHub, n8n, or Docker.
 
+If your machine is Windows or ChromeOS, use the matching platform guide alongside this one:
+
+- [`windows-kickstart.md`](windows-kickstart.md)
+- [`chromeos-kickstart.md`](chromeos-kickstart.md)
+
 By the end of this guide, you will:
 
 - verify the local tools you actually need
@@ -37,7 +42,9 @@ If you have not chosen yet, use the comparison guide in [`../tool-usages/agentic
 
 ## Step 2: Verify Only The Path You Need
 
-From the repository root, run the preflight mode that matches your first client:
+From the repository root, run the preflight mode that matches your first client.
+
+If you are on macOS, Linux, or ChromeOS inside the Linux terminal:
 
 ```bash
 bash scripts/verify-env.sh --mode=gemini
@@ -55,6 +62,24 @@ If you just want a general beginner check first, use:
 
 ```bash
 bash scripts/verify-env.sh --mode=builder
+```
+
+If you are on Windows PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/verify-env.ps1 -Mode gemini
+```
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/verify-env.ps1 -Mode claude
+```
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/verify-env.ps1 -Mode codex
+```
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/verify-env.ps1 -Mode builder
 ```
 
 This verifies Git, Node.js, and the local client you actually plan to use. It does **not** require Docker for the beginner path.

--- a/tests/contracts.test.js
+++ b/tests/contracts.test.js
@@ -53,9 +53,12 @@ test('context templates retain all required injection markers', () => {
 test('builder-facing docs point to the Docker Agent Home path', () => {
     const readme = read('README.md');
     assert.match(readme, /docs\/examples\/zero-to-first-agent\.md/);
+    assert.match(readme, /docs\/examples\/windows-kickstart\.md/);
+    assert.match(readme, /docs\/examples\/chromeos-kickstart\.md/);
     assert.match(readme, /docs\/examples\/docker-agent-home\.md/);
     assert.match(readme, /npm run validate/);
     assert.match(readme, /verify-env\.sh --mode=builder/);
+    assert.match(readme, /verify-env\.ps1/);
     assert.match(readme, /What value organizations should expect/i);
     assert.match(readme, /productivity of the active workforce/i);
     assert.match(readme, /more output, better consistency, and lower unit cost/i);

--- a/tests/examples-smoke.test.js
+++ b/tests/examples-smoke.test.js
@@ -68,13 +68,28 @@ test('beginner builder docs start with a safe local success before Docker', () =
     const beginnerGuide = read('docs/examples/zero-to-first-agent.md');
     const builderGuide = read('docs/examples/builder-first-30-minutes.md');
     const readme = read('README.md');
+    const windowsGuide = read('docs/examples/windows-kickstart.md');
+    const chromeOsGuide = read('docs/examples/chromeos-kickstart.md');
 
     assert.match(beginnerGuide, /read-only AI task against local repository content/i);
     assert.match(beginnerGuide, /does \*\*not\*\* require Docker/i);
     assert.match(beginnerGuide, /engineering agents in this repository/i);
     assert.match(beginnerGuide, /human approval before external action/i);
+    assert.match(beginnerGuide, /windows-kickstart\.md/);
+    assert.match(beginnerGuide, /chromeos-kickstart\.md/);
+    assert.match(beginnerGuide, /powershell -ExecutionPolicy Bypass -File scripts\/verify-env\.ps1 -Mode builder/i);
     assert.match(builderGuide, /phase-two Docker path/i);
     assert.match(builderGuide, /verify-env\.sh --mode=docker/);
+    assert.match(builderGuide, /powershell -ExecutionPolicy Bypass -File scripts\/verify-env\.ps1 -Mode docker/i);
+    assert.match(windowsGuide, /PowerShell/i);
+    assert.match(windowsGuide, /powershell -ExecutionPolicy Bypass -File scripts\/verify-env\.ps1 -Mode builder/i);
+    assert.match(windowsGuide, /You do \*\*not\*\* need WSL/i);
+    assert.match(chromeOsGuide, /Linux development environment/i);
+    assert.match(chromeOsGuide, /bash scripts\/verify-env\.sh --mode=builder/i);
+    assert.match(chromeOsGuide, /ChromeOS is often \*\*not\*\* the easiest place to start the Docker phase/i);
+    assert.match(readme, /docs\/examples\/windows-kickstart\.md/);
+    assert.match(readme, /docs\/examples\/chromeos-kickstart\.md/);
+    assert.match(readme, /powershell -ExecutionPolicy Bypass -File scripts\/verify-env\.ps1 -Mode builder/i);
     assert.doesNotMatch(readme, /List all open PRs in our org/);
 });
 


### PR DESCRIPTION
## Summary
- add beginner kickstart guides for Windows and ChromeOS
- update README and beginner builder docs with platform-specific shell paths
- extend regression coverage so Windows and ChromeOS onboarding stays supported

## Validation
- npm run validate
