### PR TITLE
docs(readme, project-reference): rewrite public-facing docs as StoryBrand narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,660 +1,204 @@
-# Project NoéMI — Reference Architecture & Agents Library
+# NoéMI Architecture Blueprint — AI Workforce & Agents Library
 
-Project NoéMI is the **public reference architecture** for NewPush's AI fluency and Virtual Workforce model, and the **agent specification library** that backs it. It defines AI agent personas, MCP (Model Context Protocol) integrations, governance frameworks, and Phase 0 security guidance as Markdown files. It is **not** a runtime or execution engine — external orchestrators like [Gemini CLI](https://github.com/google-gemini/gemini-cli), Claude Code, OpenAI Codex, [n8n](https://n8n.io/), or [LangChain](https://www.langchain.com/) consume these specifications to execute tasks.
-
-The goal of Project NoéMI is not to accelerate a replacement narrative around AI. The goal is to help businesses and enterprises raise the productivity of the active workforce by teaching people how to govern AI doing repeatable first-pass work, so organizations can increase output, improve consistency, and lower delivery cost **without** treating mass unemployment as the strategy. In NoéMI terms, this is the move from people doing every task themselves to people managing a governed **Virtual Workforce** of AI agents.
-
-**What value organizations should expect:**
-- higher throughput without growing headcount at the same rate
-- lower delivery cost on repetitive, document-heavy, and coordination-heavy work
-- more consistent first-pass output with human approval still in control
-- role uplift, where skilled staff spend less time on repetition and more time on review, exceptions, and decisions
-- safer AI adoption through Phase 0 security, approval boundaries, and measurable ROI
-
-In plain business terms, NoéMI is useful because it helps an organization move from scattered AI experimentation to a governed operating model where AI creates **more output, better consistency, and lower unit cost**.
-
-> **New here?** Start with the [**Project Reference**](docs/PROJECT_REFERENCE.md) — the comprehensive public guide to NoéMI's philosophy, framework, curriculum, and technology stack.
-
-> **Need the fastest orientation?** Start with the [**Visual Guides**](docs/visuals/README.md) for the system map, audience path, runtime flow, and workshop mind map.
-
-> **New to AI and want one safe first win?** Start with [**Zero To First Agent**](docs/examples/zero-to-first-agent.md).
-
-> **Need the right workstation path first?** Start with [**Cross-Platform Kickstart**](docs/examples/cross-platform-kickstart.md), then follow the matching [**macOS/Linux**](docs/examples/macos-linux-kickstart.md), [**Windows**](docs/examples/windows-kickstart.md), or [**ChromeOS**](docs/examples/chromeos-kickstart.md) guide.
-
-**Audience paths:**
-- **Client / Buyer:** [Project Reference](docs/PROJECT_REFERENCE.md) → [Phase 0 Security Baseline](docs/PHASE_ZERO_SECURITY_BASELINE.md) → [Phase 0 Assessment Kit](docs/phase-zero-assessment/README.md)
-- **MSP / MSSP:** [Project Reference](docs/PROJECT_REFERENCE.md) → [MSP Deployment Guide](docs/examples/msp-deployment.md) → [Fleet / governance docs](docs/agents/operations/)
-- **Builder / Accelerator:** [Zero To First Agent](docs/examples/zero-to-first-agent.md) → [Cross-Platform Kickstart](docs/examples/cross-platform-kickstart.md) → [macOS/Linux Kickstart](docs/examples/macos-linux-kickstart.md), [Windows Kickstart](docs/examples/windows-kickstart.md), or [ChromeOS Kickstart](docs/examples/chromeos-kickstart.md) → [Secure Secret Management](docs/tool-usages/secure-secret-management.md) → [Agentic Local Workspaces](docs/tool-usages/agentic-local-workspaces.md) → [Google Local Workspace](docs/tool-usages/google-local-workspace.md), [Claude Code Local Workspace](docs/tool-usages/claude-code-local-workspace.md), or [OpenAI Codex Local Workspace](docs/tool-usages/openai-codex-local-workspace.md) → [GWS CLI Machine Setup](docs/mcp-setup/gws-cli-machine-setup.md) → [Google Workspace For Agentic Clients](docs/mcp-setup/google-workspace-agentic-clients.md) or [Microsoft 365 For Agentic Clients](docs/mcp-setup/microsoft-365-agentic-clients.md) → [Value Lenses](docs/frameworks/value-lenses.md) → [Gemini Workspace Quickstart](docs/tool-usages/gemini-workspace-quickstart.md) or [n8n Google Workspace Quickstart](docs/examples/n8n-google-workspace-quickstart.md) → [Builder First 30 Minutes](docs/examples/builder-first-30-minutes.md) → [Docker Agent Home](docs/examples/docker-agent-home.md) → [Orchestrator Runtime Contract](docs/tool-usages/orchestrator-runtime-contract.md)
-
-## Table of Contents
-
-- [Quick Start](#quick-start)
-- [Audience Paths](#audience-paths)
-- [What This Repository Contains](#what-this-repository-contains)
-- [Repository Structure](#repository-structure)
-- [Agents](#agents)
-- [MCP Protocols](#mcp-protocols)
-- [How It Works](#how-it-works)
-- [Deploying the Examples](#deploying-the-examples)
-- [Documentation Guide](#documentation-guide)
-- [Security Model](#security-model)
-- [Contributing](#contributing)
-- [Adding or Modifying Agents](#adding-or-modifying-agents)
-- [Governance](#governance)
-- [Commit Standards](#commit-standards)
-
----
-
-## Quick Start
-
-**Prerequisites:** [Node.js](https://nodejs.org/) (24.x LTS recommended; 25+ supported), [Git](https://git-scm.com/), one supported local client ([Gemini CLI](https://github.com/google-gemini/gemini-cli), Claude Code, or OpenAI Codex), and a secret manager ([Infisical CLI](https://infisical.com/docs/cli/overview) or [1Password CLI](https://developer.1password.com/docs/cli/)) before you connect business systems. [Docker](https://www.docker.com/) becomes part of the path when you are ready to build a runtime home.
-
-### Step 1: Choose Your Workstation Path
-
-| If your main machine is | Start here | What it means |
-|-------------------------|------------|---------------|
-| macOS or Linux | [`docs/examples/macos-linux-kickstart.md`](docs/examples/macos-linux-kickstart.md) | Native Terminal path using `bash`/`zsh`, best for local-first work and later Docker |
-| Windows | [`docs/examples/windows-kickstart.md`](docs/examples/windows-kickstart.md) | PowerShell-first path, no Bash guessing required |
-| ChromeOS | [`docs/examples/chromeos-kickstart.md`](docs/examples/chromeos-kickstart.md) | Start inside the Linux development environment terminal, then follow the local-first path |
-
-If you want the decision tree in one place before you choose, use [`docs/examples/cross-platform-kickstart.md`](docs/examples/cross-platform-kickstart.md).
-
-### Step 2: Run The Common Repository Loop
-
-Once your workstation path is in place, the shared repository workflow is the same:
-
-```bash
-node scripts/generate_all.js
-npm run validate
-gemini -p GEMINI.md "List the engineering agents in this repository and summarize what each one does in one sentence."
-```
-
-The generated `GEMINI.md` and `CLAUDE.md` files contain your agent personas, security mandates, and MCP protocol definitions. Claude Code reads `CLAUDE.md` automatically when opened in this repository, and Codex can use the same generated context and local docs.
-
-### Step 3: Add Secrets Only When You Need Business Systems
-
-Keep the first win local and read-only. Once you connect Gmail, GitHub, Google Workspace, Microsoft 365, or n8n, launch through the Fetch-on-Demand wrapper:
-
-```bash
-infisical run --env=dev -- gemini
-op run --env-file=.env.template -- gemini
-```
-
-### Step 4: Move To Docker Only When You Are Ready
-
-The Docker phase is separate from the first win. Start with [`docs/examples/zero-to-first-agent.md`](docs/examples/zero-to-first-agent.md), then move to [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md) and [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md) when you are ready to build a governed runtime home.
-
-The same validation gates are enforced in GitHub Actions on pushes and pull requests targeting `develop` and `main`, so local validation mirrors the repository's CI contract.
-When Docker smoke fails on a real host or in CI, inspect `test-artifacts/docker-smoke/` or the uploaded `docker-smoke-diagnostics` artifact.
-
----
-
-## Audience Paths
-
-| Audience | Start Here | Then Go To |
-|----------|------------|------------|
-| **Client / Buyer** | [`docs/PROJECT_REFERENCE.md`](docs/PROJECT_REFERENCE.md) | [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](docs/PHASE_ZERO_SECURITY_BASELINE.md), [`docs/phase-zero-assessment/README.md`](docs/phase-zero-assessment/README.md) |
-| **MSP / MSSP** | [`docs/PROJECT_REFERENCE.md`](docs/PROJECT_REFERENCE.md) | [`docs/examples/msp-deployment.md`](docs/examples/msp-deployment.md), [`docs/agents/operations/`](docs/agents/operations/) |
-| **Builder / Accelerator** | [`docs/examples/zero-to-first-agent.md`](docs/examples/zero-to-first-agent.md) | [`docs/examples/cross-platform-kickstart.md`](docs/examples/cross-platform-kickstart.md), [`docs/examples/macos-linux-kickstart.md`](docs/examples/macos-linux-kickstart.md), [`docs/examples/windows-kickstart.md`](docs/examples/windows-kickstart.md), [`docs/examples/chromeos-kickstart.md`](docs/examples/chromeos-kickstart.md), [`docs/tool-usages/secure-secret-management.md`](docs/tool-usages/secure-secret-management.md), [`docs/tool-usages/agentic-local-workspaces.md`](docs/tool-usages/agentic-local-workspaces.md), [`docs/tool-usages/google-local-workspace.md`](docs/tool-usages/google-local-workspace.md), [`docs/tool-usages/claude-code-local-workspace.md`](docs/tool-usages/claude-code-local-workspace.md), [`docs/tool-usages/openai-codex-local-workspace.md`](docs/tool-usages/openai-codex-local-workspace.md), [`docs/mcp-setup/gws-cli-machine-setup.md`](docs/mcp-setup/gws-cli-machine-setup.md), [`docs/mcp-setup/google-workspace-agentic-clients.md`](docs/mcp-setup/google-workspace-agentic-clients.md), [`docs/mcp-setup/microsoft-365-agentic-clients.md`](docs/mcp-setup/microsoft-365-agentic-clients.md), [`docs/tool-usages/gemini-workspace-quickstart.md`](docs/tool-usages/gemini-workspace-quickstart.md), [`docs/examples/n8n-google-workspace-quickstart.md`](docs/examples/n8n-google-workspace-quickstart.md), [`docs/mcp-setup/google-n8n-credential-matrix.md`](docs/mcp-setup/google-n8n-credential-matrix.md), [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md), [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md), [`docs/examples/docker-runtime-verification.md`](docs/examples/docker-runtime-verification.md), [`docs/tool-usages/orchestrator-runtime-contract.md`](docs/tool-usages/orchestrator-runtime-contract.md), [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md) |
+> **Future-Proof Your Company Against AI, By Using AI**
 
 ---
 
 ## What This Repository Contains
 
-| What | Where | Purpose |
-|------|-------|---------|
-| Agent specifications | `agents/` | Markdown definitions of AI agent personas across 8 domains |
-| Skill definitions | `skills/` | Reusable task recipes that agents compose into their workflows |
-| MCP protocol definitions | `mcp-protocols/` | Behavioral rules for 16 tool integrations (Google Workspace, Slack, GitHub, n8n, etc.) |
-| Deployment examples | `examples/` | Docker Compose stacks, workflow templates, and testing suites |
-| Documentation | `docs/` | Framework docs, setup guides, agent-specific documentation |
-| Visual guides | `docs/visuals/` | Mermaid system maps, onboarding diagrams, and workshop-friendly mental models |
-| Infrastructure templates | `templates/` | Base templates that the generators use to build orchestrator context files |
-| Operating profiles | `operating-profiles/` | Localized language, regional, and audience overlays for culturally grounded agent execution |
-| Value lenses | `value-lenses/` | Explicit success criteria and tradeoff overlays for comparing outcomes under different enterprise logics |
-| Build scripts | `scripts/` | Context generation, repo auditing, retry helpers, and environment verification |
-| Test harness | `tests/`, `package.json` | Built-in Node contract, golden fixture, example smoke, and Docker e2e tests |
-| Runtime diagnostics | `test-artifacts/docker-smoke/` | Failure artifacts emitted by Docker smoke verification on real hosts and in CI |
-| Contribution workflow | `CONTRIBUTING.md`, `.github/pull_request_template.md` | Human contributor expectations, validation flow, and PR checklist |
-| ROI tools | `tools/roi/` | Methodology for calculating agent return on investment |
+This repository is the **technical reference architecture and agent specification library** inspired by **Project NoéMI**—the global AI fluency accelerator program.
+
+It provides a structured blueprint for building a **governed Virtual Workforce** using:
+
+* 20+ AI agent specifications across 8 domains (marketing, engineering, operations, security, etc.)
+* Reusable skills for classification, validation, reporting, and orchestration
+* MCP protocol definitions for safe integration with tools like Google Workspace, Slack, GitHub, and n8n
+* Governance frameworks aligned with **Phase 0 Security** and **Gartner AI TRiSM**
+
+These components are designed to move organizations from **unstructured, high-risk AI usage** to a **controlled, auditable, and scalable operating model**.
+
+> This is not a runtime. It is the blueprint that orchestrators execute.
 
 ---
 
-## Repository Structure
+## How Organizations Use This Repository
 
-```
-.
-├── agents/                          # Agent specifications (source of truth)
-│   ├── coding/                      # Bolt (performance), Sentinel (security)
-│   ├── communication/               # Postman (email handling)
-│   ├── engineering/                  # AI Architect, Gatekeeper (PR triage)
-│   ├── guardian/                     # PII Guard, Prompt Shield, ROI Auditor
-│   ├── infrastructure/              # cPanel, Linux system administration
-│   ├── marketing/                   # Brand, SEO, Thumbnails, Video Content
-│   ├── operations/                  # Fleet Dashboard, Knowledge Manager, QA
-│   └── product/                     # Documentation specialist
-│
-├── skills/                          # Reusable task definitions (skills layer)
-│   ├── SKILL_TEMPLATE.md            # Canonical template for new skills
-│   ├── classification/              # Risk triage, multi-tier categorization
-│   ├── verification/                # Pre-flight checks, cross-referencing
-│   ├── reporting/                   # Structured reports, alert delivery
-│   ├── security/                    # HMAC signing, PII scanning
-│   └── orchestration/               # Sub-agent dispatch and coordination
-│
-├── mcp-protocols/                   # MCP behavioral rules (one file per tool)
-│   ├── gmail.md, slack.md, n8n.md, github.md, web-search.md
-│   └── google-*.md                  # Full Google Workspace suite (11 protocols)
-│
-├── docs/                            # All documentation
-│   ├── AGENT_TEMPLATE.md            # Canonical template for new agents
-│   ├── METHODOLOGY.md               # 4D Framework (Delegation, Description, ...)
-│   ├── GOVERNANCE.md                # AI TRiSM and Red Teaming protocols
-│   ├── PHASE_ZERO_SECURITY_BASELINE.md # Client-side cybersecurity grounding guide
-│   ├── REQUIREMENTS.md              # Project requirements and drift tracking
-│   ├── frameworks/                  # Meta-frameworks such as localized operating profiles and value lenses
-│   ├── visuals/                     # Visual system maps, runtime flows, and onboarding diagrams
-│   ├── phase-zero-assessment/       # Consent, findings, roadmap, and readiness kit
-│   ├── agents/                      # Per-agent documentation (mirrors agents/)
-│   ├── examples/                    # Deployment guides (MSP, RFP responder, etc.)
-│   ├── mcp-setup/                   # MCP infrastructure setup guides
-│   └── lifecycle/                   # 4D Framework lifecycle documentation
-│
-├── operating-profiles/              # Localized workstyle overlays and templates
-├── value-lenses/                    # Explicit success-criteria overlays and templates
-│
-├── examples/                        # Deployable examples
-│   ├── docker/                      # Docker sandbox with pgvector memory
-│   ├── fleet-deployment/            # Multi-tenant stack (Traefik + n8n + Grafana)
-│   ├── gatekeeper-deployment/       # PR triage agent + Fleet Dashboard
-│   ├── red-team-gauntlet/           # Adversarial testing suite
-│   ├── secure-secret-management/    # Fetch-on-Demand pattern demo
-│   ├── video-automation-pod/        # YouTube packaging automation
-│   ├── gmu-validation/              # Academic verification bot
-│   ├── rfp-split/                   # RFP document processing samples
-│   └── workflows/                   # n8n workflow JSON templates
-│
-├── scripts/
-│   ├── generate_all.js              # Runs both generators in sequence
-│   ├── generate_gemini.js           # Builds GEMINI.md from template + skills + MCPs
-│   ├── generate_claude.js           # Builds CLAUDE.md from template + agent index + skills + MCPs
-│   ├── audit-repo.js               # Fails on persona/generator drift
-│   ├── retry-with-backoff.sh       # Reference retry helper for transient failures
-│   └── verify-env.sh               # Checks prerequisites by path (builder, client, Docker)
-│
-├── templates/
-│   ├── README.md                    # Why templates live below the repo root
-│   └── context/                     # Base templates for generated orchestrator context files
-│
-├── tests/                          # Node built-in contract and smoke tests
-├── package.json                    # Validation and generation entrypoints
-│
-├── mcp.config.json                  # Declares which MCPs are active
-├── AGENTS.md                        # Global security mandates and directives
-├── GEMINI.md                        # Generated output for Gemini (do not edit directly)
-├── CLAUDE.md                        # Generated output for Claude Code (do not edit directly)
-└── .env.template                    # Environment variable reference
-```
+Organizations typically **fork or copy this repository into a private environment**, then adapt it progressively as they implement AI agents within their own systems.
 
-**Key rule:** The `docs/agents/` directory mirrors the `agents/` directory. If an agent spec exists at `agents/infrastructure/linux.md`, its documentation lives at `docs/agents/infrastructure/linux/`.
+This enables them to:
+
+* customize agents, workflows, and integrations for their specific business context
+* protect internal logic and intellectual property
+* move at their own pace without blocking on upstream changes
+
+In practice:
+
+* teams start with a small number of agents and workflows
+* validate them against real business use cases
+* gradually extend the system with additional agents, skills, and integrations
 
 ---
 
-## Agents
+### Staying Aligned with a Moving Architecture
 
-The library includes **22 agent specifications** organized into 8 domains. Each agent is a Markdown file that defines a persona an orchestrator can adopt.
+Project NoéMI is not a static framework.
+It evolves continuously as AI capabilities, tooling, and best practices change.
 
-| Domain | Agents | Purpose |
-|--------|--------|---------|
-| **Coding** | Bolt (core, Next.js 16), Sentinel | Performance optimization, security auditing |
-| **Communication** | Postman | Email drafting, tone management, routing |
-| **Engineering** | AI Architect, Gatekeeper | System design, automated PR triage |
-| **Guardian** | PII Guard, Prompt Shield, ROI Auditor | Data protection, prompt injection defense, value tracking |
-| **Infrastructure** | cPanel, Linux | Server administration via API and CLI |
-| **Marketing** | Brand Strategist, SEO Strategist, Thumbnail Specialist, Video Content Manager | Brand compliance, YouTube optimization, visual design, content orchestration |
-| **Operations** | Fleet Dashboard, Knowledge Manager, Multimodal Specialist, QA & Risk Manager | Observability, research, media processing, quality assurance |
-| **Product** | Doc | Technical documentation |
+To support this, organizations maintain a **private working copy** of the repository while selectively syncing improvements from upstream.
 
-Every agent spec follows the canonical template defined in [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md) with required sections: **Role**, **Tone**, **Capabilities**, **Mission**, **Rules & Constraints**, **Boundaries**, **Workflow**, **Audit Log**, and **External Tooling Dependencies**.
+This repository includes a reference sync mechanism:
 
----
+* Documentation: [docs/UPSTREAM_SYNC.md](https://github.com/project-noemi/agents/blob/main/docs/UPSTREAM_SYNC.md)
+* Script: [scripts/sync-upstream.sh](https://github.com/project-noemi/agents/blob/main/scripts/sync-upstream.sh)
 
-## Skills
+This allows teams to:
 
-Skills are **reusable task recipes** that agents compose into their workflows. They sit between agents (who) and MCP protocols (how) in the architecture:
+* pull in updates from the core architecture
+* avoid overwriting local customizations
+* stay aligned with the evolving NoéMI model
 
-```
-Agents (who)  →  compose  →  Skills (what)  →  use  →  MCP Protocols (how)
-                                    ↑
-                              Policies (why) govern everything
-```
+This model combines:
 
-| Category | Skills | Purpose |
-|----------|--------|---------|
-| **Classification** | Risk Triage | Multi-tier categorization (Safe / Needs Review / Blocked) |
-| **Verification** | Pre-Flight Check, Cross-Reference | Validate preconditions; verify claims against source of truth |
-| **Reporting** | Structured Report, Alert & Notify | Standardized report generation; Slack/email delivery |
-| **Security** | HMAC Sign & Submit, PII Scan | Cryptographic payload signing; data privacy scanning |
-| **Orchestration** | Dispatch & Coordinate | Sub-agent delegation and output aggregation |
+* **stability** (your controlled internal implementation)
+* with
+* **adaptability** (continuous improvements from upstream)
 
-Agents reference skills in their Workflow sections using the `**Skill:**` syntax:
-
-```markdown
-### 2. CLASSIFY
-**Skill:** `classification/risk-triage` — Classify each PR as Safe, Needs Review, or Stale Conflict
-```
-
-The skill template is at [`skills/SKILL_TEMPLATE.md`](skills/SKILL_TEMPLATE.md). Skills are declared in `mcp.config.json` under `active_skills` and injected into the generated context files alongside MCP protocols.
+The result is a system that does not become obsolete as the AI landscape evolves.
 
 ---
 
-## MCP Protocols
+## Why This Exists
 
-MCP (Model Context Protocol) protocols define **how agents interact with external tools**. Each protocol file in `mcp-protocols/` contains behavioral rules, validation steps, and error handling guidance.
+AI adoption is already happening inside most organizations, but either without structure, or with too many constraints driving people toward Shadow AI.
 
-**16 protocols available:**
+Common patterns include:
 
-| Category | Protocols |
-|----------|-----------|
-| **Google Workspace** | Docs, Sheets, Slides, Drive, Calendar, Meet, Chat, Keep, Forms, Contacts, Admin |
-| **Communication** | Gmail, Slack |
-| **Automation** | n8n |
-| **Development** | GitHub |
-| **Research** | Web Search |
+* fragmented tool usage across teams ("Shadow AI")
+* inconsistent outputs and quality
+* unclear security boundaries and data leakage risks
+* no reliable way to measure ROI or operational impact
 
-The file `mcp.config.json` controls which protocols are active. Only active protocols are injected into the generated `GEMINI.md` and `CLAUDE.md`.
+Project NoéMI addresses this by rejecting the **Replacement Trap**—the idea that AI's primary value is reducing headcount.
 
-For setup instructions, see [`docs/mcp-setup/`](docs/mcp-setup/).
+Instead, it introduces a **Virtual Workforce model**, where:
 
----
+* **AI Agents (Virtual Coworkers)** handle repeatable, data-intensive, first-pass work
+* **Humans** handle review, exceptions, and decision-making
+* The **Guardian Layer** (AI monitoring AI) ensures continuous control, compliance, and safety
 
-## How It Works
-
-### Context Generation Pipeline
-
-The core build step combines your agent specs and MCP protocols into context files that orchestrators consume. Two generated context pipelines exist today — one for Gemini CLI and one for Claude Code:
-
-```
-templates/context/{GEMINI,CLAUDE}.template.md + mcp.config.json + AGENTS.md
-         │                          │               │
-         │              ┌───────────┘               │
-         ▼              ▼                           ▼
-  scripts/generate_{gemini,claude}.js ──> {GEMINI,CLAUDE}.md
-```
-
-Both scripts follow the same steps:
-
-1. Read the base template (`templates/context/GEMINI.template.md` or `templates/context/CLAUDE.template.md`)
-2. Read `mcp.config.json` to determine which MCP integrations are active
-3. For each active MCP, inject the protocol definition from `mcp-protocols/`
-4. Extract the full global mandate set from `AGENTS.md`
-5. Write the final context file
-
-Both generators use the same shared helper logic, support `--config=path/to/mcp.config.json`, and inject the same full mandate set, agent index, active skills, and active MCP protocols.
-
-```bash
-# Regenerate after changing MCP config, protocol files, skills, or adding agents
-node scripts/generate_all.js
-
-# Run the canonical fast validation gate
-npm run validate
-
-# Run Docker smoke tests when Docker is available
-npm run test:e2e
-```
-
-### Using with Orchestrators
-
-**Claude Code** (reads CLAUDE.md automatically):
-Open this repository in Claude Code. It reads `CLAUDE.md` as project instructions at the start of every conversation — no manual setup required. The file includes the agent index, security mandates, and all active MCP protocols.
-
-**Gemini CLI** (direct agent interaction):
-```bash
-infisical run --env=dev -- gemini -p GEMINI.md "Analyze the server logs on web01"
-```
-
-**OpenAI Codex** (local agentic workspace):
-Use the repo's `AGENTS.md`, `mcp-protocols/`, and the builder-facing docs in [`docs/tool-usages/agentic-local-workspaces.md`](docs/tool-usages/agentic-local-workspaces.md). Codex configuration lives in `~/.codex/config.toml`, while project-level app actions and setup scripts can live in `.codex/`.
-
-**n8n** (automated workflows):
-Import workflow templates from `examples/workflows/` into your n8n instance. The workflows reference agent personas and MCP integrations defined in this repository.
-
-**LangChain / Custom** (programmatic):
-Read `GEMINI.md`, `CLAUDE.md`, or individual agent specs from `agents/` as system prompts in your LLM application.
+This is not about experimentation.
+This is about **operationalizing AI securely and at scale**.
 
 ---
 
-## Deploying the Examples
+## The Core Idea
 
-All examples use the **Fetch-on-Demand** security model: secrets are injected at runtime via vault CLI wrappers (`infisical run` or `op run`), never hardcoded. If you are new, start with [Zero To First Agent](docs/examples/zero-to-first-agent.md), then move into the [Secure Secret Management guide](docs/tool-usages/secure-secret-management.md), the [Builder First 30 Minutes guide](docs/examples/builder-first-30-minutes.md), and the [Docker Agent Home guide](docs/examples/docker-agent-home.md) before trying legacy Python examples. See [Security Model](#security-model) for details.
+This is not a software tool.
+This is a **system for redesigning how work gets done**.
 
-### 1. Docker Sandbox (Historical Python Example)
+Instead of individuals using AI tools in isolation, you get:
 
-A minimal environment with a PostgreSQL + pgvector memory layer and a Python runtime container. Good for experimenting with agent code locally.
-
-**Location:** `examples/docker/`
-
-```bash
-cd examples/docker
-
-# Start the stack
-op run --env-file=.env.example -- docker compose up -d --build
-# Or with Infisical:
-infisical run --env=dev -- docker compose up -d --build
-
-# Enter the runtime container
-docker exec -it noemi-agent-runtime bash
-
-# Run your agent code
-python agent.py
-```
-
-**What you get:**
-- `agent-memory` — PostgreSQL with pgvector for embedding storage
-- `agent-runtime` — Python 3.12 container with your code mounted at `/app`
+* defined AI roles (Virtual Coworkers)
+* structured task execution (Skills)
+* controlled system interaction (Protocols)
+* enforced governance (Phase 0 Security + Guardian Layer)
 
 ---
 
-### 2. Fleet Deployment (Multi-Tenant Infrastructure)
+## The 1:50 Equilibrium & Human Workforce Model
 
-A production-oriented stack simulating parallel environments with shared ingress and observability. Designed for running multiple isolated orchestrator instances (e.g., boot camp cohorts or MSP client tenants).
+While AI agents perform execution, humans govern the system.
 
-**Location:** `examples/fleet-deployment/`
+Project NoéMI introduces the **1:50 Equilibrium**—a scalable organizational model:
 
-```bash
-cd examples/fleet-deployment
+* **Accelerators (Pilots):** design architecture, implement security, and govern the AI ecosystem
+* **Practitioners (Crew):** build and orchestrate agent workflows ("vibe coding")
+* **Explorers (Passengers):** domain experts who define problems and validate outputs
 
-# Review the required variable names and store the real values in your vault
-cat .env.example
+In practice, one trained Accelerator can guide AI usage across dozens of users safely.
 
-# Start the full stack
-op run --env-file=.env.example -- docker compose up -d
-# Or with Infisical:
-infisical run --env=dev -- docker compose up -d
-```
+This model is reinforced through the NoéMI training program, where participants earn **Badges of Completion (micro-credentials)** issued with **George Mason University (GMU)** across three levels:
 
-**What you get:**
+* AI Fluent Professional
+* AI Implementation Specialist
+* AI Governance Architect
 
-| Service | URL | Purpose |
-|---------|-----|---------|
-| Traefik | `http://localhost:8080` | Reverse proxy and dashboard |
-| Casdoor | `http://localhost:8000` | Identity provider (SSO) |
-| Grafana | `http://localhost:3000` | Centralized log dashboard |
-| Loki | `http://localhost:3100` | Log aggregation backend |
-| n8n (Cohort 01) | `http://cohort01.noemi.local` | Isolated orchestrator instance |
-| n8n (Cohort 02) | `http://cohort02.noemi.local` | Isolated orchestrator instance |
-
-**Note:** Add `cohort01.noemi.local`, `cohort02.noemi.local`, `auth.noemi.local`, and `audit.noemi.local` to your `/etc/hosts` file pointing to `127.0.0.1` for local development.
+The objective is not to turn everyone into an AI engineer, but to create a **governed system where AI can scale safely across the organization**.
 
 ---
 
-### 3. Gatekeeper Deployment (PR Triage + Fleet Dashboard)
+## Security First: Phase 0 Security
 
-Deploys the Gatekeeper agent for automated GitHub PR triage, with InfluxDB for report storage, Grafana for visualization, and a Slack alert relay.
+Before deploying any agents, organizations must establish a **security baseline**.
 
-**Location:** `examples/gatekeeper-deployment/`
+Most AI initiatives start with prompting.
+NoéMI starts with **control of the data perimeter**.
 
-```bash
-cd examples/gatekeeper-deployment
+Phase 0 addresses:
 
-# Review the required variable names and store the real values in your vault
-cat .env.example
+* Shadow AI (unauthorized tool usage)
+* data classification and boundary definition
+* credential and access management (Fetch-on-Demand secrets)
+* deployment of Guardian agents for monitoring
 
-# Build and start
-op run --env-file=.env.example -- docker compose up -d --build
-```
+Without Phase 0, scaling AI introduces risk faster than value.
 
-**What you get:**
-
-| Service | URL | Purpose |
-|---------|-----|---------|
-| InfluxDB | `http://localhost:8086` | Time-series store for triage reports |
-| Grafana | `http://localhost:3000` | Fleet Dashboard visualization |
-| Dashboard Ingest | internal only | Verifies HMAC signatures and relays signed reports into InfluxDB |
-| Gatekeeper | (runs on schedule) | Scans PRs every 4 hours (configurable) |
-| Alert Relay | (background) | Posts Slack alerts when agents go stale |
-
-**Configuration options** (set via vault-backed environment variables):
-- `GATEKEEPER_REPOS` — Comma-separated repo allowlist (empty = scan all)
-- `GATEKEEPER_DRY_RUN=true` — Set to `false` to enable actual merges/closes
-- `GATEKEEPER_INTERVAL_HOURS=4` — Triage cycle frequency
+👉 Start here: [docs/PHASE_ZERO_SECURITY_BASELINE.md](docs/PHASE_ZERO_SECURITY_BASELINE.md)
 
 ---
 
-### 4. Red Team Gauntlet (Security Testing)
+## What This Repository Is (And Isn't)
 
-A set of adversarial test cases for validating Guardian agents (PII Guard and Prompt Shield). No infrastructure required — these are test vectors you pass to your agents.
+### This IS:
 
-**Location:** `examples/red-team-gauntlet/`
+* a reference architecture
+* an AI Virtual Workforce blueprint
+* a library of governed agent specifications
+* a foundation for building production systems
 
-```bash
-# No deployment needed. Open the README for test cases:
-cat examples/red-team-gauntlet/README.md
-```
+### This is NOT:
 
-**What it tests:**
-- **Prompt injection** — Direct override, roleplay-based bypass, invisible prompting
-- **PII leaks** — SSN/credit card redaction, credential exfiltration blocking
+* a SaaS product
+* a no-code automation tool
+* a runtime or execution engine
+* the NoéMI training program itself
 
-Pass each test case to your Guardian agent. A correctly functioning agent will return `{ "status": "BLOCKED" }` for injection attempts and redacted output for PII leaks.
+It is designed to work with orchestrators such as:
 
----
-
-### 5. Video Automation Pod (Historical Python Example)
-
-Automates the video content lifecycle: transcription, title/thumbnail generation, and SEO optimization using the marketing agent team.
-
-**Location:** `examples/video-automation-pod/`
-
-```bash
-cd examples/video-automation-pod
-
-# Install Python dependencies
-pip install -r requirements.txt
-
-# Run the pod with your video files
-op run --env-file=.env.example -- python manager.py \
-  --project "MyVideo" \
-  --rough_cut rough_assembly.mp4 \
-  --pose_clip pose_video.mp4
-```
-
-**What it does:**
-1. Transcribes your rough assembly to extract the core message
-2. Generates 3+ curiosity-driven titles and thumbnail hooks
-3. Scans the pose clip for the most expressive frames
-4. Composites 15+ thumbnail variations with your brand assets
-
-**Prerequisites:** Python 3.12+, FFmpeg, vault-backed API credentials. This example is retained as historical reference, not the recommended first implementation path.
+* n8n (primary orchestration layer in the NewPush Labs stack)
+* Gemini CLI
+* Claude Code
+* OpenAI Codex
+* LangChain
 
 ---
 
-### 6. Secure Secret Management (Pattern Demo)
+## Getting Started
 
-Demonstrates the Fetch-on-Demand architecture — how agents should read credentials from the environment rather than from files or hardcoded values.
+**Business / Decision Makers**
+→ [docs/PROJECT_REFERENCE.md](docs/PROJECT_REFERENCE.md)
+(Strategy, Virtual Workforce model, organizational impact)
 
-**Location:** `examples/secure-secret-management/`
+**Security / IT Leaders**
+→ [docs/PHASE_ZERO_SECURITY_BASELINE.md](docs/PHASE_ZERO_SECURITY_BASELINE.md)
+(Security foundation and readiness)
 
-```bash
-# Install Infisical CLI (if not already installed)
-bash examples/secure-secret-management/setup.sh
+**Practitioners / Builders**
+→ [docs/examples/zero-to-first-agent.md](docs/examples/zero-to-first-agent.md)
+(Building your first Virtual Coworker)
 
-# Run agent code with secrets injected
-infisical run --env=dev -- python examples/secure-secret-management/agent_logic.py
-```
-
-**Key principle:** Agent code uses `os.getenv("DATABASE_URL")` — never `dotenv.load()` or hardcoded strings. The vault CLI wrapper injects secrets into the process environment at launch time.
-
----
-
-### 7. n8n Workflow Templates
-
-Pre-built n8n workflow JSON files you can import into any n8n instance.
-
-**Location:** `examples/workflows/`
-
-| Workflow | File | Purpose |
-|----------|------|---------|
-| RFP Auto-Responder | `rfp-responder.json` | Watches Gmail for RFPs, analyzes with Gemini, creates Google Doc drafts |
-| ROI Tracking Pipeline | `roi-tracking-pipeline.json` | Collects agent execution metrics and writes to Google Sheets |
-| Video Automation Pod | `video-automation-pod.json` | Orchestrates the video packaging workflow via n8n |
-
-**To import:**
-1. Open your n8n instance
-2. Go to **Workflows > Import from File**
-3. Select the `.json` file
-4. Configure credentials (Gmail, Google Docs, Gemini API) in the n8n credential manager
+**Visual Orientation**
+→ [docs/visuals/README.md](docs/visuals/README.md)
+(System maps and flows)
 
 ---
 
-### 8. GMU Validation Bot
+## Context
 
-A verification bot for academic credentialing validation, used in the George Mason University partnership.
-
-**Location:** `examples/gmu-validation/`
-
-```bash
-node examples/gmu-validation/verification-bot.js
-```
+* **Project NoéMI** — the methodology, 4D framework, and GMU-backed training program
+* **This repository** — the implementation blueprint for the Virtual Workforce
+* **NewPush** — the founding cybersecurity and infrastructure organization
 
 ---
 
-## Documentation Guide
-
-All documentation lives in `docs/`. Here's where to find what:
-
-| Looking for... | Go to |
-|----------------|-------|
-| Client-side Phase 0 guidance | [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](docs/PHASE_ZERO_SECURITY_BASELINE.md) |
-| Phase 0 assessment kit | [`docs/phase-zero-assessment/README.md`](docs/phase-zero-assessment/README.md) |
-| Beginner first-win guide | [`docs/examples/zero-to-first-agent.md`](docs/examples/zero-to-first-agent.md) |
-| Cross-platform workstation decision guide | [`docs/examples/cross-platform-kickstart.md`](docs/examples/cross-platform-kickstart.md) |
-| macOS/Linux beginner guide | [`docs/examples/macos-linux-kickstart.md`](docs/examples/macos-linux-kickstart.md) |
-| Windows beginner guide | [`docs/examples/windows-kickstart.md`](docs/examples/windows-kickstart.md) |
-| ChromeOS beginner guide | [`docs/examples/chromeos-kickstart.md`](docs/examples/chromeos-kickstart.md) |
-| Google Workspace machine setup | [`docs/mcp-setup/gws-cli-machine-setup.md`](docs/mcp-setup/gws-cli-machine-setup.md) |
-| Builder onboarding walkthrough | [`docs/examples/builder-first-30-minutes.md`](docs/examples/builder-first-30-minutes.md) |
-| Builder-facing Docker home guide | [`docs/examples/docker-agent-home.md`](docs/examples/docker-agent-home.md) |
-| Visual orientation maps | [`docs/visuals/README.md`](docs/visuals/README.md) |
-| How to create a new agent | [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md) |
-| The 4D Framework methodology | [`docs/METHODOLOGY.md`](docs/METHODOLOGY.md) |
-| Governance and compliance | [`docs/GOVERNANCE.md`](docs/GOVERNANCE.md) |
-| Project requirements | [`docs/REQUIREMENTS.md`](docs/REQUIREMENTS.md) |
-| Design decisions and rationale | [`docs/DECISION_LOG.md`](docs/DECISION_LOG.md) |
-| Open questions and clarifications | [`docs/CLARIFICATIONS.md`](docs/CLARIFICATIONS.md) |
-| MCP setup guides | [`docs/mcp-setup/`](docs/mcp-setup/) |
-| 4D lifecycle deep-dives | [`docs/lifecycle/`](docs/lifecycle/) |
-| Per-agent documentation | [`docs/agents/`](docs/agents/) (mirrors `agents/` structure) |
-| Deployment examples and guides | [`docs/examples/`](docs/examples/) |
-| MSP deployment guide | [`docs/examples/msp-deployment.md`](docs/examples/msp-deployment.md) |
-| Gartner TRiSM framework reference | [`docs/frameworks/gartner-trism.md`](docs/frameworks/gartner-trism.md) |
-
----
-
-## Security Model
-
-Project NoéMI enforces a **Fetch-on-Demand** architecture for all secrets:
-
-1. **Never hardcode credentials** — not in agent specs, not in scripts, not in config files
-2. **Store secrets in vaults** — [Infisical](https://infisical.com/) or [1Password](https://1password.com/)
-3. **Inject at runtime** — Use CLI wrappers to pass secrets into the process environment:
-
-```bash
-# Using Infisical
-infisical run --env=dev -- [your command]
-
-# Using 1Password
-op run --env-file=.env.template -- [your command]
-```
-
-4. **Read from environment** — Agent code accesses credentials via `process.env` or `os.getenv()`, never by parsing `.env` files
-
-The `.env.template` file at the repository root documents the shared environment variables without containing actual values. Example-specific `.env.example` files are inventories of required variables and should contain only vault references or placeholders, never real secrets.
-
-See [`docs/tool-usages/secure-secret-management.md`](docs/tool-usages/secure-secret-management.md) for the full guide and [`examples/secure-secret-management/`](examples/secure-secret-management/) for a working demo.
-
----
-
-## Contributing
-
-Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening a pull request. It documents the contributor workflow, the canonical validation commands, regeneration rules, and the Fetch-on-Demand security expectations that CI now enforces.
-
----
-
-## Adding or Modifying Agents
-
-1. **Start from the template:** Copy [`docs/AGENT_TEMPLATE.md`](docs/AGENT_TEMPLATE.md)
-2. **Place the spec** in `agents/{domain}/{name}.md`
-3. **Create matching docs** at `docs/agents/{domain}/{name}/`
-4. **If the agent uses MCP tools**, ensure referenced protocols exist in `mcp-protocols/`
-5. **Run the Red Team Gauntlet** (`examples/red-team-gauntlet/`) against your new agent before deployment
-6. **Regenerate context:** `node scripts/generate_gemini.js`
-7. **Run validation:** `npm run validate`
-8. **Run Docker smoke tests when relevant:** `npm run test:e2e`
-
-GitHub Actions enforces the same fast and Docker validation entrypoints for changes targeting `develop` and `main`.
-
-**Required sections:** Role, Tone, Capabilities, Mission, Rules & Constraints, Boundaries, Workflow, Audit Log, External Tooling Dependencies
-
-**H1 format:** `# {Name} — {Domain} Agent`
-
----
-
-## Governance
-
-All agents are evaluated against two frameworks before deployment:
-
-### 4D AI Fluency Framework
-
-Developed in partnership with George Mason University. Every agent design decision maps to one of four dimensions:
-
-| Dimension | Focus | Agent Spec Section |
-|-----------|-------|--------------------|
-| **Delegation** | Decide what should be automated and define done criteria | Mission, Workflow |
-| **Description** | Precise instruction and contextualization | Role, Tone, Capabilities |
-| **Discernment** | Validate boundaries, quality, and human escalation points | Boundaries, Audit Log |
-| **Diligence** | Continuous verification, security, and ethical alignment | Rules & Constraints, External Tooling Dependencies |
-
-See [`docs/METHODOLOGY.md`](docs/METHODOLOGY.md) and [`docs/lifecycle/`](docs/lifecycle/) for details.
-
-### Gartner AI TRiSM (Trust, Risk, Security Management)
-
-| Pillar | How We Address It |
-|--------|-------------------|
-| **Trust** | Transparent boundaries, auditable action trails, Fleet Dashboard observability |
-| **Risk** | Fetch-on-Demand credentials, data minimization, PII Guard |
-| **Security** | Prompt Shield, Red Team Gauntlet, execution confirmation for critical operations |
-
-See [`docs/GOVERNANCE.md`](docs/GOVERNANCE.md) and [`docs/frameworks/gartner-trism.md`](docs/frameworks/gartner-trism.md).
-
----
-
-## Commit Standards
-
-All commits follow [Conventional Commits](https://www.conventionalcommits.org/):
-
-```
-type(scope): subject
-```
-
-| Type | Purpose |
-|------|---------|
-| `feat` | New agent or feature |
-| `fix` | Bug fix in a spec or doc |
-| `docs` | Documentation changes |
-| `style` | Formatting changes |
-| `refactor` | Code restructuring |
-| `chore` | Maintenance tasks |
-
-**Scope** matches the domain or area: `marketing`, `guardian`, `agents`, `lifecycle`, etc.
-
-**Examples:**
-- `feat(engineering): add gatekeeper PR triage agent`
-- `fix(agents): resolve code review findings across specs`
-- `docs(examples): add MSP deployment guide`
-
----
-
-## License
-
-See [LICENSE](LICENSE) for details.
+👉 Continue with: [docs/PROJECT_REFERENCE.md](docs/PROJECT_REFERENCE.md)

--- a/docs/PROJECT_REFERENCE.md
+++ b/docs/PROJECT_REFERENCE.md
@@ -1,120 +1,181 @@
-# Project NoéMI — Public Reference
+# Project NoéMI — Public Reference Guide
 
-**Version 1.0 | March 2026**
+**Version 2.0 | April 2026**
 
 > **"We help you future-proof your organization against AI, by using AI."**
 
-This document is the canonical public reference for Project NoéMI. It introduces the project's philosophy, framework, curriculum, and technology stack, and serves as a guide to the other documents in this repository.
+---
 
-At the highest level, NoéMI exists to help organizations respond to AI by increasing the productivity of the active population, not by normalizing a story of mass unemployment. The program teaches businesses how to redesign work so AI handles governed, repeatable first-pass tasks while people move upward into review, exception handling, decision-making, and governance. The intended result is a surge in output, resilience, and economic usefulness through a **Virtual Workforce** model, not a simplistic replacement model.
+## How to Read This Document
 
-**What organizations should expect from this model:**
+This guide is written as a journey — your journey.
 
-- more throughput from the same team
-- lower unit cost on repetitive operational work
-- more consistent drafts, classifications, and first-pass decisions
-- less skilled human time lost to low-leverage repetition
-- stronger governance, auditability, and security around AI-enabled workflows
+It starts with the problem every organization is facing right now, moves through the philosophy and architecture of Project NoéMI, and ends with a concrete path to implementation. Each chapter builds on the last.
 
-That is the practical promise of NoéMI: not "use AI because it is trendy," but build the ability to manage AI doing bounded work so the organization produces more, with better control, and with less wasted human effort.
+If you are a decision-maker, this document will help you understand what an AI Workforce looks like, why most AI initiatives fail, and what makes this approach different.
 
-Readers who want the fastest structural overview should start with the visual set in [`docs/visuals/`](visuals/).
+If you are a builder, this document will show you the architecture, the tools, and the framework that ties it all together.
+
+If you are somewhere in between — curious but cautious, interested but skeptical — this is exactly where you should start.
+
+For a visual overview of the system, start with the maps in [`docs/visuals/`](visuals/).
 
 ---
 
 ## Table of Contents
 
-1. [What Is Project NoéMI?](#1-what-is-project-noémi)
-2. [Origin Story & Name](#2-origin-story--name)
-3. [The Core Philosophy](#3-the-core-philosophy)
-4. [The Canonical Glossary](#4-the-canonical-glossary)
-5. [The Framework: The 4 Ds of AI Fluency](#5-the-framework-the-4-ds-of-ai-fluency)
-6. [The Three Modalities of Human-AI Interaction](#6-the-three-modalities-of-human-ai-interaction)
-7. [The Pedagogical Model: The "High-Tech Surfboard"](#7-the-pedagogical-model-the-high-tech-surfboard)
-8. [Curriculum Architecture: The Two-Layer System](#8-curriculum-architecture-the-two-layer-system)
-9. [Current Curriculum (v3.0)](#9-current-curriculum-v30--the-unified-curriculum)
-10. [Product Offerings & Delivery Variants](#10-product-offerings--delivery-variants)
-11. [Phase 0 Security — The Technical Foundation](#11-phase-0-security--the-technical-foundation)
-12. [The NewPush Labs Technology Stack](#12-the-newpush-labs-technology-stack)
-13. [Partnerships & Credentials](#13-partnerships--credentials)
-14. [Thought Leadership Positions](#14-thought-leadership-positions)
-15. [Repository Guide](#15-repository-guide)
+1. [The Flood](#chapter-1-the-flood)
+2. [What Is Project NoéMI?](#chapter-2-what-is-project-noémi)
+3. [The Name Behind the Name](#chapter-3-the-name-behind-the-name)
+4. [Three Pillars: The Core Philosophy](#chapter-4-three-pillars-the-core-philosophy)
+5. [The Language of NoéMI: A Glossary](#chapter-5-the-language-of-noémi-a-glossary)
+6. [The 4 Ds of AI Fluency](#chapter-6-the-4-ds-of-ai-fluency)
+7. [Three Ways Humans Work with AI](#chapter-7-three-ways-humans-work-with-ai)
+8. [The High-Tech Surfboard: How People Learn](#chapter-8-the-high-tech-surfboard-how-people-learn)
+9. [The Curriculum: What Gets Taught](#chapter-9-the-curriculum-what-gets-taught)
+10. [Ways to Engage: Product Offerings](#chapter-10-ways-to-engage-product-offerings)
+11. [Phase 0 Security: The Foundation You Cannot Skip](#chapter-11-phase-0-security-the-foundation-you-cannot-skip)
+12. [The Technology Stack Concept](#chapter-12-the-technology-stack-concept)
+13. [Partnerships and Credentials](#chapter-13-partnerships-and-credentials)
+14. [Questions Organizations Ask](#chapter-14-questions-organizations-ask)
+15. [Thought Leadership](#chapter-15-thought-leadership)
+16. [Where You Go From Here](#chapter-16-where-you-go-from-here)
+17. [Repository Guide](#chapter-17-repository-guide)
 
 ---
 
-## 1. What Is Project NoéMI?
+## Chapter 1: The Flood
 
-Project NoéMI is a **global AI fluency accelerator program** delivered by **NewPush** and academically credentialed by **George Mason University (GMU)**. It trains *organizations* — not individuals — to build, govern, and deploy a "Virtual Workforce" of AI agents securely and at scale.
+There is a flood coming.
 
-It is **not** a generic "prompt engineering" course. It is an enterprise AI transformation program that begins with cybersecurity (Phase 0 Security) and ends with certified, production-ready AI workflows governed by trained human leaders.
+Actually — it is already here. AI is not a future event. It is a present reality reshaping every industry, every workflow, every competitive landscape. The only question that matters now is this:
 
-Its strategic aim is to help enterprises convert AI from a labor-displacement fear into a productivity system. In practice, that means enabling teams to produce more with the same people, shift skilled staff away from repetitive execution, and build the managerial capability to supervise AI doing bounded operational work.
+**Will your organization react to the flood, or build an Ark?**
 
-The expected business outcomes are concrete:
+Because here is what is happening inside most companies right now: employees are already using AI. They are pasting proprietary data — your financials, your client lists, your source code, your strategic plans — into public AI tools. They are doing it because it makes their work faster. They are doing it because nobody told them not to. And they are doing it without any governance, any oversight, or any understanding of where that data goes.
 
-- identify the first safe, worthwhile pilot
-- improve cycle time and throughput on targeted workflows
-- reduce the labor intensity of repetitive first-pass work
-- preserve human control over approvals, exceptions, and sensitive decisions
-- create the conditions for measurable ROI instead of endless experimentation
+This is not a hypothetical risk. It is happening today. It has a name: **Shadow AI**.
+
+And it is just one symptom of a bigger problem. Most organizations are not lacking AI access. They are lacking **AI architecture**.
+
+The typical symptoms look like this:
+
+- Fragmented tool usage across teams, with no coordination or consistency
+- Outputs that vary wildly in quality depending on who prompted what
+- No clear boundaries around what data can and cannot touch AI systems
+- No way to measure whether AI usage is actually producing value
+- A growing sense that "we should be doing something with AI" without a plan for what that something is
+
+If this sounds familiar, you are not behind. You are normal. But normal is not safe.
+
+The organizations that will thrive in the next decade are not the ones with the most AI tools. They are the ones with the best AI architecture — the ones who figured out how to make AI work *inside* their existing operations, safely, governed, and at scale.
+
+That is what Project NoéMI was built to do.
+
+---
+
+## Chapter 2: What Is Project NoéMI?
+
+Project NoéMI is a **global AI fluency accelerator program** delivered by **NewPush®** and academically credentialed by **George Mason University**.
+
+But that sentence, while accurate, undersells what it actually is.
+
+Here is a better way to think about it: NoéMI trains *organizations* — not individuals — to build, govern, and deploy what we call a **Virtual Workforce**. That Virtual Workforce is made up of AI agents — structured, governed, auditable AI systems that perform repeatable work alongside your human team.
+
+It is **not** a prompt engineering course. It is not a "learn ChatGPT in a day" workshop. It is an enterprise AI transformation program that begins with cybersecurity, runs through structured training, and ends with certified, production-ready AI workflows governed by trained human leaders.
+
+The strategic aim is concrete: help enterprises convert AI from a labor-displacement fear into a productivity system. In practice, that means:
+
+- Enabling teams to produce more with the same people
+- Shifting skilled staff away from repetitive execution toward review, judgment, and strategy
+- Building the managerial capability to supervise AI doing bounded operational work
+- Creating conditions for measurable ROI instead of endless experimentation
 
 **Key facts:**
 
-- **Lead Organization:** NewPush (cybersecurity/infrastructure company, founded 1999)
+- **Lead Organization:** NewPush® (cybersecurity/infrastructure company, founded in 1999)
 - **Academic Partner:** George Mason University — Center for Infrastructure Security in the Era of AI (ISEAI)
-- **Framework:** Dakan & Feller "4 Ds" of AI Fluency + Gartner AI TRiSM
-- **Credential:** GMU-issued Badges of Completion (micro-credentials) at three levels
-- **Languages:** English and Hungarian
-- **Active Markets:** United States, Hungary, Germany, Lithuania
+- **Framework:** Dakan & Feller "4 Ds" of AI Fluency + Gartner AI TRiSM (Trust Risk and Security Management)
+- **Credential:** George Mason University-issued Badges of Completion (micro-credentials) at three levels
+- **Languages:** English, Spanish, French, German, Hungarian, ...
+- **Active Markets:** United States, Latin America, Europe (France, Germany, Hungary, Lithuania, ...)
 - **Target Audience:** SMB leaders, mid-market executives, government contractors, municipal/public sector, non-profit managers
+
+One thing NoéMI is explicitly **not** for: individual solopreneurs or self-improvement seekers. This is a program for organizations — teams, departments, companies — that need to transform how work gets done across groups of people. If you are looking for individual upskilling, there are excellent resources for that. NoéMI is the architecture that makes AI work at the organizational level.
 
 ---
 
-## 2. Origin Story & Name
+## Chapter 3: The Name Behind the Name
 
 The name **"NoéMI"** is a Hungarian linguistic play on words:
 
 - **"Noé"** = Hungarian for Noah
-- **"MI"** = Hungarian acronym for Artificial Intelligence (*Mesterséges Intelligencia*)
+- **"MI"** = Hungarian acronym for Artificial Intelligence (*Mesterséges Intelligencia*) or you could just say Machine Intelligence
 - **Combined meaning:** "Noah's AI" — building an Ark to navigate the flood of AI disruption
 
-**The philosophy:** AI disruption is inevitable. The question is not *if* your industry will be disrupted, but *who* controls the disruption. If you disrupt your own business, it is a "controlled demolition and reconstruction." If you wait for a competitor to do it, it is an "earthquake."
+It is also, conveniently, a common Hungarian female first name — which gives the project a human identity in a space that desperately needs one.
 
-NoéMI rejects the **"Replacement Trap"** — the naive idea that AI simply replaces humans to cut headcount. Instead, it builds a **"Virtual Workforce"** where humans and AI agents work in a governed, secure ecosystem.
+The philosophy embedded in the name is this: AI disruption is inevitable. The question is not *if* your industry will be disrupted, but *who controls the disruption*. If you disrupt your own business proactively, it is a **controlled demolition and reconstruction** — painful, yes, but deliberate and on your terms. If you wait for a competitor, a new technology wave, or regulatory pressure to force the change, it is a **tsunami** — sudden, uncontrolled, and potentially fatal.
 
-The project was first piloted in Hungary with support from Rotary Clubs, then expanded to the United States through the GMU partnership. It has served **100+ students** across multiple cohorts, with ongoing international expansion.
+NoéMI is the Ark you build before the flood, not the life raft you scramble for during it.
+
+The project was first piloted in Hungary with support from the International Rotary Clubs, then expanded to the United States through the partnership with George Mason University. It has served **numerous participants** across multiple cohorts with a train the trainer model that enables exponential growth, and ongoing expansion to major cities across the Americas and Europe.
 
 ---
 
-## 3. The Core Philosophy
+## Chapter 4: Three Pillars — The Core Philosophy
 
-Three pillars define NoéMI's worldview:
+Every decision in NoéMI flows from three non-negotiable principles. These are not marketing slogans. They are architectural constraints that shape every agent, every workflow, and every training module.
 
 ### A. "Security First, Then Speed"
 
-Every engagement begins with **Phase 0 Security** — establishing the data perimeter before any AI deployment. This is the opposite of most AI training programs that jump straight to prompting.
+Every building begins with solid foundations, and every AI architecture begins with **Phase 0 Security** — establishing the data perimeter before any AI is deployed.
+
+This is the opposite of what most AI programs do. Most start with "let's try prompting." NoéMI starts with "let's make sure your data cannot leak." The reasoning is simple: if you build AI capabilities on top of a compromised or ungoverned foundation, every efficiency gain you achieve also increases your risk surface. You move faster, but you move faster toward a breach.
+
+Phase 0 is covered in depth in [Chapter 11](#chapter-11-phase-0-security-the-foundation-you-cannot-skip).
 
 ### B. "Architecture Over Tools"
 
-NoéMI teaches **durable mental models** (the 4 Ds), not specific software. Tools change monthly; the ability to think about AI governance does not. The curriculum uses a **Two-Layer System**: Layer A (First Principles that never change) and Layer B (Dynamic Labs updated per cohort/tool release).
+Tools change monthly. The AI model that is state-of-the-art today will be surpassed next quarter. The workflow automation platform you pick will release breaking changes. The API you integrated will deprecate an endpoint.
+
+NoéMI does not teach tools. It teaches **durable mental models** — the 4 Ds framework, governance principles, delegation patterns, discernment skills — that remain valid regardless of which AI model or platform is current.
+
+NoéMI teaches how to keep learning and using new tools with ease, and how to design and build agent workflows that can be easily adapted to new tools and models. This reference architecture keeps being updated to reflect the latest changes in the AI landscape, so you don't have to wonder how to adapt to the constant onslaught of changes. This is your guide to stay on the swelling wave.
+
+The curriculum achieves this through a **Two-Layer System**: Layer A contains First Principles that never change, and Layer B contains Dynamic Labs that get updated per cohort, per tool release, or per quarter. You learn how to think about AI governance once. You learn the specific buttons to click in the current tool version this week. This is how you stay ahead of the curve.
 
 ### C. "The Replacement Trap Is a Dead End"
 
-The program explicitly rejects the narrative that AI replaces humans. Instead, it restructures organizations into the **1:50 Equilibrium** where trained human leaders govern fleets of AI agents. This creates a "Virtual Workforce" — not a smaller workforce, but a *different kind* of workforce.
+This is perhaps the most important pillar, and the one many organizations get wrong. Armed with this architecture, you can help your organization steer clear of this trap.
+
+The **Replacement Trap** is the strategic dead end where organizations try to use AI simply to cut headcount. The logic seems sound on a spreadsheet: if AI can do the work of five people, fire four and pocket the savings.
+
+Here is why that logic fails: if your only competitive advantage becomes "cheaper labor via AI," a competitor with a slightly better algorithm, a slightly cheaper model, or a slightly more automated pipeline puts you out of business in six months. You have not built a moat. You have built a race to the bottom.
+
+NoéMI rejects this entirely. Instead, it restructures organizations into what we call the **1:50 Equilibrium** — a model where trained human leaders govern fleets of AI agents. This creates a **Virtual Workforce**: not a smaller workforce, but a *different kind* of workforce. One where AI handles the repeatable, data-intensive, first-pass work, and humans handle the judgment, the exceptions, the creativity, and the governance.
+
+Not fewer people. *Different* people. People who are more valuable, more strategic, and harder to replace.
+
+This shift changes the social contract between organizations and individuals. In the previous paradigm, the organization's responsibility was to provide clear job descriptions and support the role, while the individual's responsibility was to perform the job properly. Managers and HR provided the guidance. The relationship was straightforward: define the work, do the work.
+
+In the new paradigm, the organization's responsibility is to enable the shift — providing sound AI architecture, governed tools, and the environment for people to upskill. The individual's role shifts from *doing* the work to *describing* the work, monitoring its execution by AI, and continuously improving the workflows. Managers become governors of AI-augmented teams rather than supervisors of manual tasks.
+
+This transition will not stay confined to knowledge work. It will extend into robotics and the physical realm as well. The organizations that build this architecture now — while the shift is still primarily digital — will be the ones prepared when it reaches every part of their operations.
 
 ---
 
-## 4. The Canonical Glossary
+## Chapter 5: The Language of NoéMI — A Glossary
 
-These are the official definitions of NoéMI terminology.
+Every system needs shared language. These are the official definitions of NoéMI terminology. When you encounter these terms in other documents, agent specifications, or training materials, these are the meanings that apply.
 
 ### The 1:50 Equilibrium
 
-The organizational ratio where **1 highly trained Accelerator (Pilot)** can effectively govern and stabilize the AI usage of **50 Explorers (Passengers)**. In NoéMI, this ratio is the architecture of workforce transformation — you don't need 50 AI engineers; you need 1 Pilot and a structured system.
+The organizational ratio where **1 highly trained Accelerator (Pilot)** can effectively govern and stabilize the AI usage of **50 Explorers (Passengers)**. The name is inspired by Steve Jobs' 1995 observation about the 50:1 productivity ratio between great and average software engineers. In NoéMI, this ratio is not about individual talent — it is about architecture. You do not need 50 AI engineers. You need 1 Pilot and a structured system.
 
 ### The Replacement Trap
 
-The strategic dead end where organizations try to use AI simply to cut headcount. If your only competitive advantage becomes "cheaper labor," a competitor with a slightly better algorithm puts you out of business in six months. NoéMI rejects this in favor of the Virtual Workforce model.
+The strategic dead end where organizations try to use AI simply to cut headcount. Covered in depth in [Chapter 4](#c-the-replacement-trap-is-a-dead-end).
 
 ### The Virtual Workforce
 
@@ -122,188 +183,216 @@ The NoéMI model where organizations build AI agents ("Virtual Coworkers") that 
 
 ### Phase 0 Security
 
-NewPush's security methodology. Before any AI deployment, the organization's data perimeter must be established: Shadow AI audited, data classified (Public/Internal/Confidential), egress filters in place, SSO configured. "You cannot build an AI-enabled enterprise on a compromised foundation."
+NewPush's security methodology built on Gartner's AI TRiSM. Before any AI deployment, the organization's data perimeter must be established: Shadow AI audited, data classified (Public/Internal/Confidential), egress filters in place, SSO configured. "You cannot build an AI-enabled enterprise on a compromised foundation."
 
 ### Shadow AI
 
-The unauthorized, ungoverned use of public AI tools by employees who paste proprietary data into unvetted platforms. Phase 0 exists specifically to eliminate Shadow AI.
+The unauthorized, ungoverned use of public AI tools by employees who paste proprietary data — the organization's **Secret Sauce** — into unvetted platforms. Phase 0 exists specifically to eliminate Shadow AI.
+
+### The "Secret Sauce"
+
+An organization's proprietary data, trade secrets, financial projections, source code, and client information — anything that would damage the business if leaked to a public LLM's training data. Protecting the Secret Sauce is the core motivation behind Phase 0.
 
 ### The High-Tech Surfboard
 
-The pedagogical metaphor. NoéMI doesn't build a "Big Boat" (slow, centralized education). It equips "Surfboards" — agile teams where a Pilot steers Passengers through the wave of AI disruption.
+The pedagogical metaphor. NoéMI does not build a "Big Boat" — a slow, centralized education program that takes years to turn. It equips "Surfboards" — agile teams where a Pilot steers Passengers through the wave of AI disruption. Small, fast, maneuverable.
 
 ### Layer A (First Principles)
 
-Durable mental models and abstract reasoning frameworks that remain valid regardless of which AI model or platform is current. These never need updating.
+Durable mental models and abstract reasoning frameworks that remain valid regardless of which AI model or platform is current. These never need updating. They are the "why" behind every competency.
 
 ### Layer B (Dynamic Labs)
 
-Ephemeral technical exercises tied to specific tools and platforms. Updated per cohort, per model release, or per quarter. In v3.0, exclusively built on the NewPush Labs open-source stack.
+Ephemeral technical exercises tied to specific tools and platforms. Updated per cohort, per model release, or per quarter. In v3.0, exclusively built on well known and reputable open-source technologies, assembled to be ready to go in the *NewPush Labs* open-source stack. They are the "how" that changes with the technology.
 
 ### The Guardian Layer
 
-The principle that "the best defense against AI is another AI acting as a critic." A Guardian Agent is a specialized AI whose sole job is to monitor, critique, and audit the outputs of operational AI agents — checking for hallucinations, policy violations, data leakage, and prompt injection.
+The principle that "the best defense against AI is another AI acting as a critic." A Guardian Agent is a specialized AI whose sole job is to monitor, critique, and audit the outputs of operational AI agents — checking for hallucinations, policy violations, data leakage, and prompt injection. You would not run a factory without quality control inspectors. You should not run an AI workforce without Guardians.
 
 ### The Feynman Requirement
 
-Accelerators cannot earn their badge unless they can teach a core concept to Explorers. "You do not know it until you can teach it." This ensures true mastery and creates a self-sustaining ecosystem of trainers.
+Named after Richard Feynman's famous principle: "If you can't explain it simply, you don't understand it." Accelerators cannot earn their badge unless they can teach a core concept to Explorers. This ensures true mastery and creates a self-sustaining ecosystem of trainers within the organization.
 
 ### The Refusal Principle
 
-The most important delegation skill is knowing when **not** to use AI. Some tasks, due to data sensitivity, ethical concerns, or the need for human empathy, must remain human.
+The most important delegation skill is knowing when **not** to use AI. Some tasks, due to data sensitivity, ethical concerns, or the need for human empathy, must remain human. The ability to refuse — to say "this is not an AI task" — is not a limitation. It is a governance capability.
 
 ### Vibe Coding
 
-Programming AI agents and workflows using natural language rather than traditional code. Practitioners "vibe code" by describing desired behavior in plain language, and the AI system translates this into functional workflows.
+Programming AI agents and workflows using natural language rather than traditional code. Practitioners "vibe code" by describing desired behavior in plain language, and the AI system translates this into functional workflows. This is what makes the Practitioner track accessible to people who are not traditional software developers.
 
 ### The Loop of Doom
 
-The risk of infinite loops in autonomous multi-agent systems, where agents trigger each other indefinitely without human intervention. A core governance challenge that Accelerators must manage.
+The risk of infinite loops in autonomous multi-agent systems, where agents trigger each other indefinitely without human intervention. When Agent A's output triggers Agent B, whose output triggers Agent A again, you get a runaway loop that burns tokens, produces garbage, and potentially takes actions nobody authorized. A core governance challenge that Accelerators must learn to manage.
 
 ---
 
-## 5. The Framework: The 4 Ds of AI Fluency
+## Chapter 6: The 4 Ds of AI Fluency
 
-NoéMI's pedagogical framework is built on the **"4 Ds"** — originally developed by Prof. Rick Dakan (Ringling College of Art and Design) and Prof. Joseph Feller (University College Cork, Ireland). NoéMI adapts this framework for enterprise contexts and overlays it with Gartner's AI TRiSM.
+This is the intellectual engine of NoéMI.
+
+The **"4 Ds"** framework was originally developed by Prof. Rick Dakan (Ringling College of Art and Design) and Prof. Joseph Feller (University College Cork, Ireland). NoéMI adapts this framework for enterprise contexts and overlays it with Gartner's AI TRiSM (Trust, Risk, and Security Management).
 
 > **Citation:** Dakan, Rick and Feller, Joseph. "Framework for AI Fluency," Version 1.1, CC BY-NC-ND 4.0.
 
+Think of the 4 Ds as four competencies that, together, make someone (or an organization) genuinely AI-fluent — not just capable of using AI, but capable of *governing* it.
+
 ### 1. DELEGATION — Knowing WHEN and WHETHER to use AI
 
+This is where most organizations fail first. They either delegate everything to AI (dangerous) or nothing (wasteful). Delegation is the skill of looking at a task and determining: should this be done by AI, by a human, or by both in collaboration?
+
 - **Goal & Task Awareness:** Understanding task requirements; deconstructing work into AI, human, and collaborative components
-- **Platform Awareness:** Knowledge of AI capabilities/limitations; evaluating tools based on requirements and compliance
+- **Platform Awareness:** Knowledge of AI capabilities and limitations; evaluating tools based on requirements and compliance
 - **Task Delegation:** Balancing AI and human capabilities; assigning tasks optimally
+
+The Refusal Principle lives here. The most important delegation decision is sometimes "no."
 
 ### 2. DESCRIPTION — Communicating requirements to AI effectively
 
+Once you have decided to use AI, you need to tell it what to do — and how to do it — with precision. This is more than "prompt engineering." It is the discipline of translating human intent into machine-actionable instructions.
+
 - **Product Description:** Defining the desired output; translating vision into AI-understandable terms
-- **Process Description:** Dialogic prompting for iterative collaboration
-- **Performance Description:** Directive prompting to define future AI behaviors
+- **Process Description:** Dialogic prompting for iterative collaboration — working *with* AI, not just *at* it
+- **Performance Description:** Directive prompting to define future AI behaviors — configuring agents, not just chatbots
 
 ### 3. DISCERNMENT — Critically evaluating AI outputs
 
-- **Product Discernment:** Evaluating output quality, relevance, strengths/weaknesses
-- **Process Discernment:** Assessing whether the Human-AI collaborative dynamic is fruitful
-- **Performance Discernment:** Evaluating independent AI behaviors; gathering feedback to improve
+AI produces confident-sounding output regardless of whether it is correct. Discernment is the ability to evaluate what comes back — to catch hallucinations, spot reasoning failures, identify when the AI followed the letter of your instructions but missed the spirit.
+
+- **Product Discernment:** Evaluating output quality, relevance, strengths, and weaknesses
+- **Process Discernment:** Assessing whether the human-AI collaborative dynamic is actually productive
+- **Performance Discernment:** Evaluating independent AI behaviors over time; gathering feedback to improve
 
 ### 4. DILIGENCE — Taking responsibility for AI-assisted work
 
-- **Creation Diligence:** Ethical/legal best practices; awareness of biases, flaws, stakeholder impacts
-- **Transparency Diligence:** Understanding expectations; communicating AI involvement
-- **Deployment Diligence:** Verifying outputs; implementing safety checks; assuming responsibility
+You used AI to produce something. Your name is on it. Diligence is the ethical, legal, and operational discipline of taking full responsibility for AI-assisted outputs — including the parts the AI got wrong.
+
+- **Creation Diligence:** Ethical and legal best practices; awareness of biases, flaws, and stakeholder impacts
+- **Transparency Diligence:** Understanding expectations around disclosure; communicating AI involvement
+- **Deployment Diligence:** Verifying outputs; implementing safety checks; assuming responsibility for what ships
 
 For deeper methodology details, see [`docs/METHODOLOGY.md`](METHODOLOGY.md) and the lifecycle documents in [`docs/lifecycle/`](lifecycle/).
 
 ---
 
-## 6. The Three Modalities of Human-AI Interaction
+## Chapter 7: Three Ways Humans Work with AI
 
-From the Dakan & Feller framework:
+The Dakan & Feller framework identifies three modalities of human-AI interaction. Understanding these is crucial because each modality requires different governance, different skills, and different risk management.
 
 | **Modality** | **Human Role** | **AI Role** | **4D Focus** |
 | --- | --- | --- | --- |
-| **Automation** — AI performs a human-defined task | Define task, evaluate | Execute independently | Delegation, Description |
-| **Augmentation** — AI and human collaborate iteratively | Co-create, iterate | Thinking partner | Description, Discernment |
+| **Automation** — AI performs a human-defined task | Define task, evaluate output | Execute independently | Delegation, Description |
+| **Augmentation** — AI and human collaborate iteratively | Co-create, iterate, refine | Thinking partner | Description, Discernment |
 | **Agency** — Human configures AI to act independently | Configure, monitor, govern | Pursue goals autonomously | Performance Description, Diligence |
+
+Most people's experience with AI is in the first two modalities: you ask it a question (Automation) or you work with it back and forth on a document (Augmentation). The third modality — Agency — is where the real transformation happens, and where the real risk lives. An AI agent operating with Agency is making decisions, taking actions, and interacting with systems on its own. This is where governance stops being optional and becomes existential.
+
+The Virtual Workforce operates primarily in the Agency modality. That is why Phase 0 Security, the Guardian Layer, and the 4 Ds framework are not nice-to-haves. They are the control system that makes Agency safe.
 
 ---
 
-## 7. The Pedagogical Model: The "High-Tech Surfboard"
+## Chapter 8: The High-Tech Surfboard — How People Learn
 
-NoéMI operates as a **"Team Sport"** with three complementary tracks in every cohort:
+NoéMI is not a lecture series. It is a **team sport**.
+
+The pedagogical metaphor is the "High-Tech Surfboard." While some programs try to build a Big Boat — a slow, comprehensive, one-size-fits-all education platform — NoéMI equips small, agile surfboard teams that can ride the wave of AI disruption rather than trying to outrun it.
+
+Every cohort contains three complementary tracks. They work together in what we call a **Montessori-style interaction** — all three tracks meet in the same environment, working on the same problems from different angles.
 
 ### EXPLORERS (The Passengers) — ~80% of participants
 
-- **Goal:** AI Fluency — understanding usage, ethics, identifying business needs
-- **Function:** "Problem Owners" — they bring the real-world business problems and validate solutions
-- They do not need to code or build
+- **Goal:** AI Fluency — understanding when and how to use AI, recognizing ethical implications, and identifying business needs
+- **Function:** "Problem Owners" — they bring the real-world business problems and validate whether the AI solutions actually solve them
+- They do **not** need to code or build anything
 - **Badge:** "AI Fluent Professional"
 - **4D Focus:** Delegation + Diligence
+
+These are your domain experts — the people who know the business inside out. They know which processes are painful, which outputs are inconsistent, which tasks eat up hours of skilled human time. Their job is not to build AI systems. Their job is to define the problems worth solving and to judge whether the AI's work is actually good enough.
 
 ### PRACTITIONERS (The Crew) — ~15% of participants
 
 - **Goal:** AI Implementation — building agentic workflows through "vibe coding"
 - **Function:** "Builders" — they translate Explorer problems into working AI agents
-- They configure tools, connect APIs, build n8n workflows
+- They configure tools, connect APIs, build n8n workflows, and deploy agents
 - **Badge:** "AI Implementation Specialist"
 - **4D Focus:** Description + Discernment
 
+These are your builders. They take the problems Explorers define and turn them into working systems. In NoéMI, Practitioners do not need to be traditional software developers. They use "vibe coding" — natural language descriptions of desired behavior — to build agent workflows. The barrier to entry is not programming skill. It is clarity of thought.
+
 ### ACCELERATORS (The Pilots) — ~5% of participants
 
-- **Goal:** AI Governance & Teaching — designing architecture, implementing security, mentoring
-- **Function:** "Guides" — they govern the AI ecosystem, implement Phase 0, and teach others
-- Must pass the **Feynman Requirement** (teach a concept to Explorers)
+- **Goal:** AI Governance & Teaching — designing architecture, implementing security, mentoring others
+- **Function:** "Guides" — they govern the AI ecosystem, implement Phase 0, and teach the rest of the organization
+- Must pass the **Feynman Requirement** (teach a core concept to Explorers and have them understand it)
 - **Badge:** "AI Governance Architect"
 - **4D Focus:** All 4 Ds + TRiSM
 - **Critical role:** In the 1:50 Equilibrium, these are the "1" who stabilize the "50"
 
-### Montessori-Style Interaction
+These are your organizational AI leaders. Not because they know the most about AI, but because they understand the full picture — security, governance, architecture, and teaching. An Accelerator's primary skill is not technical brilliance. It is the ability to make AI safe and productive for everyone else.
 
-All three tracks meet in the same environment. They function as an ecosystem:
+### How the Ecosystem Works
 
-- Explorers provide real-world business problems ("Business Reality")
-- Practitioners build the solutions ("Vibe Coding")
-- Accelerators ensure governance and mentor the cohort
+The magic is in how these three tracks interact:
 
-Cross-track exercises are built into every week.
+- **Explorers** provide real-world business problems ("Business Reality")
+- **Practitioners** build the solutions ("Vibe Coding")
+- **Accelerators** ensure governance, security, and mentor the cohort
 
----
+Cross-track exercises are built into every week. An Explorer who identifies a procurement bottleneck works with a Practitioner who builds an agent to handle first-pass vendor evaluation, under the governance of an Accelerator who ensures the agent cannot access confidential pricing data.
 
-## 8. Curriculum Architecture: The Two-Layer System
-
-Every week of the curriculum separates durable pedagogy from fleeting technical tactics:
-
-**LAYER A (First Principles) — STATIC**
-
-- Abstract reasoning frameworks
-- The "Why" behind each competency
-- Valid regardless of which AI model or platform is current
-- Examples: The Refusal Principle, The Communication Hierarchy, The Agentic Shift, Hallucination Taxonomy, ROI Framework, Ethics Integration Framework
-- Updated: Rarely (only when the underlying pedagogy evolves)
-
-**LAYER B (Dynamic Labs) — VARIABLE**
-
-- Technical exercises tied to specific tools
-- In v3.0: exclusively uses the NewPush Labs open-source stack (n8n, Casdoor, Traefik, Grafana, Loki, Infisical)
-- Updated: Per cohort, per model release, or quarterly
-- Ensures students learn "Production Reality" rather than vendor-locked solutions
+This is not a classroom exercise. It is a rehearsal for how the Virtual Workforce operates in production.
 
 ---
 
-## 9. Current Curriculum (v3.0 — The Unified Curriculum)
+## Chapter 9: The Curriculum — What Gets Taught
 
-The canonical, current curriculum is **v3.0: "The Unified High-Tech Surfboard Curriculum."**
+The canonical curriculum is **v3.0: "The Unified High-Tech Surfboard Curriculum."**
+
+Every week separates content into two layers:
+
+- **Layer A (First Principles):** Durable concepts that remain valid regardless of which AI model or platform is current. These are the "why."
+- **Layer B (Dynamic Labs):** Technical exercises tied to specific tools in the current NewPush Labs stack. These are the "how," and they get updated with every cohort.
 
 ### Week 0 (Prerequisite): Foundation & Triage
 
 - **Layer A:** The Refusal Principle; The 1:50 Equilibrium
-- **Layer B:** Security Stack — Casdoor (SSO), Traefik (Ingress), Egress Test
-- **Activity:** "The Triage" — Explorers identify pain points; Accelerators audit data safety
-- **Output:** Signed "Security Perimeter Document"
+- **Layer B:** Lab Security Stack — Casdoor (SSO), Traefik (Ingress), Egress Test
+- **Activity:** "The Triage" — Explorers identify their biggest pain points; Accelerators audit data safety
+- **Output:** A signed "Security Perimeter Document" — the organization's commitment to data boundaries
+
+This is where the journey begins. Before anyone touches an AI agent, the organization establishes what data is off-limits, what tools are authorized, and who is responsible for what. If this sounds unsexy, good. It is the most important week.
 
 ### Week 1: Description & Interaction
 
 - **Layer A:** Communication Hierarchy (Vague → Specific → Structured → Contextual); Product vs. Process Description
 - **Layer B:** Labs Chat UI for structured prompting; Token cost optimization
-- **Activity:** "The Prompt Relay" — Explorer writes request → Practitioner translates → Accelerator critiques
+- **Activity:** "The Prompt Relay" — Explorer writes a request → Practitioner translates it into a structured prompt → Accelerator critiques the result
+
+Participants learn that the quality of AI output is directly proportional to the quality of human input. This is not about learning magic prompting tricks. It is about learning to think clearly enough that a machine can execute your intent.
 
 ### Week 2: Delegation & The Agentic Shift
 
-- **Layer A:** The Agentic Shift (Stateless Query → Stateful Loop); The Loop of Doom
+- **Layer A:** The Agentic Shift (from Stateless Query to Stateful Loop); The Loop of Doom
 - **Layer B:** n8n Workflows — building agents with nodes and API connectors; Multi-agent orchestration
 - **Activity:** "The Delegation Audit" — defining "Done" criteria for autonomous agents
+
+This is where chatbots become agents. Participants learn the difference between asking AI a question (stateless) and configuring AI to pursue a goal over time (stateful). They also learn why the second one is both more powerful and more dangerous.
 
 ### Week 3: Discernment & The Guardian Layer
 
 - **Layer A:** The Guardian Layer (AI monitoring AI); Hallucination Taxonomy (Factual, Reasoning, Citation, Consistency, Confidence)
 - **Layer B:** Observability — Grafana + Loki for monitoring agent logs; Automated Guardian scripts
-- **Activity:** "The Red Team Gauntlet" — Accelerators break Practitioners' agents
+- **Activity:** "The Red Team Gauntlet" — Accelerators try to break Practitioners' agents
+
+This is the week that separates real AI programs from toy demos. Participants learn that AI systems will confidently produce wrong answers, leak data, follow injected instructions, and fail in ways nobody anticipated. Then they learn how to catch it.
 
 ### Week 4: Diligence & Enterprise Integration
 
 - **Layer A:** The Integration Imperative (Deep Integration vs. Walled Gardens); Ethics: Bias, Transparency, Reversibility; ROI modeling
 - **Layer B:** n8n Webhooks connecting to mock ERP/CRM; Complex routing with Switch nodes
-- **Activity:** "The Board Meeting" — ROI presentation to "Executives" (Explorers role-playing CFO/CISO/COO)
+- **Activity:** "The Board Meeting" — teams present ROI cases to "Executives" (Explorers role-playing CFO, CISO, and COO)
+
+Theory meets business reality. Participants must prove that their AI workflows produce measurable value — not just "cool demos," but workflows with calculated time savings, cost reductions, and quality improvements.
 
 ### Week 5: Optimization & Capstone (Fleet Launch)
 
@@ -312,18 +401,21 @@ The canonical, current curriculum is **v3.0: "The Unified High-Tech Surfboard Cu
 - **Activity:** "The Architecture Debate" → "The Teach-Back" → "Fleet Launch" (live deployment)
 - **Outcome:** Badge submission, security audit, governance documentation handoff
 
+The capstone is not a presentation. It is a live deployment. Agents go into production on real infrastructure. Accelerators must teach a concept to Explorers (Feynman Requirement). The cohort leaves with working systems, not just knowledge.
+
 ---
 
-## 10. Product Offerings & Delivery Variants
+## Chapter 10: Ways to Engage — Product Offerings
 
-NoéMI has multiple delivery formats to match client maturity and commitment:
+NoéMI meets organizations where they are. Different maturity levels need different entry points.
 
 ### A. The NoéMI Workshops (5-Week Structured Program)
 
 - **For:** Organizations building AI fluency from the ground up
-- **Format:** 1 day per week, 5–6 weeks
+- **Format:** 1 day per week, 5-6 weeks
 - Full curriculum (v3.0), includes Phase 0 security assessment
 - GMU badge upon completion
+- The most thorough path from zero to governed AI operations
 
 ### B. The NoéMI Intensive (5-Day Sprint)
 
@@ -331,13 +423,14 @@ NoéMI has multiple delivery formats to match client maturity and commitment:
 - **Format:** 5 consecutive days, dual-track (Basic/Advanced)
 - Basic track: Strategy and exploration (Explorers)
 - Advanced track: Building with n8n, Gems, multi-agent systems (Practitioners/Accelerators)
+- Same depth, compressed timeline
 
 ### C. The 1-Day Workshop (Condensed Introduction)
 
-- **For:** Conference events, initial engagement
-- **Format:** Single day, 9:00–17:00
+- **For:** Conference events, initial engagement, executive buy-in
+- **Format:** Single day, 9:00-17:00
 - Three blocks: (1) Build a Virtual Coworker, (2) Marketing automation with AI agents, (3) Security
-- Strong practical focus with coach approach
+- Hands-on with a coaching approach — participants leave with something working
 
 ### D. The NoéMI Velocity (Hackathon)
 
@@ -345,78 +438,88 @@ NoéMI has multiple delivery formats to match client maturity and commitment:
 - Two gears:
   - **"Ignition" Sprint (1 day):** Executive alignment, Shark Tank-style prototyping, prove ROI on one pain point
   - **"Forge" Week (5 days):** Deploy a fleet of Virtual Coworkers into production
+- For organizations that already have the foundation and want to move fast
 
 ### E. Entry Point: The AI Readiness Assessment
 
 - Every engagement starts with a **Cyber Hygiene & AI Readiness Assessment**
 - Routes the client to the right product based on organizational maturity
+- No commitment required — this is the diagnostic that determines what you actually need
 
 ---
 
-## 11. Phase 0 Security — The Technical Foundation
+## Chapter 11: Phase 0 Security — The Foundation You Cannot Skip
 
-Phase 0 is what distinguishes NoéMI from other AI training programs. It is the security perimeter established **before** any AI deployment begins.
+This is the chapter most AI programs do not have. It is also the reason most AI programs fail.
 
-### The Phase 0 Executive Checklist (5 Pillars):
+Phase 0 is what distinguishes NoéMI from every other AI training program on the market. It is the security perimeter established **before** any AI deployment begins. Not after. Not alongside. Before.
+
+The logic is unforgiving: every AI capability you deploy without governance is a risk surface you have added to your organization. The faster you move without Phase 0, the faster you move toward a breach, a compliance violation, or a data leak that ends up in a public LLM's training data.
+
+### The Phase 0 Executive Checklist (5 Pillars)
 
 **1. The Shadow AI Audit**
 
-- Complete inventory of AI tools accessed by the workforce
-- Define the Refusal Principle — what data/tasks must never touch AI
+- Complete inventory of AI tools currently accessed by the workforce
+- Define the Refusal Principle — what data and tasks must **never** touch AI
 - Identify and eliminate unauthorized AI usage
+- Answer the question: "Is your Secret Sauce already in someone else's training data?"
 
 **2. The Data Perimeter & Access Control**
 
-- Classify all data: Public, Internal, Confidential
+- Classify all organizational data: Public, Internal, Confidential
 - Deploy automated egress filters to block sensitive data from leaving the network
-- Implement Enterprise SSO (Casdoor in NewPush Labs)
+- Implement Enterprise SSO (Casdoor in the NewPush Labs stack)
+- Establish clear rules: who can use what AI tools, with what data, for what purposes
 
 **3. The Guardian Layer (Governance & Trust)**
 
-- Implement Gartner AI TRiSM framework
+- Implement the Gartner AI TRiSM framework
 - Deploy Guardian Agents to monitor operational AI agents
-- Types: Compliance Guardian, Quality Guardian, Security Guardian
+- Three types: Compliance Guardian, Quality Guardian, Security Guardian
+- Establish the principle that operational AI is never trusted without oversight
 
 **4. The Pedagogical Framework (The 4 Ds)**
 
 - Workforce trained in Delegation, Description, Discernment, Diligence
 - Not just tool usage — critical thinking about AI governance
+- Ensure every person who touches AI understands the boundaries
 
 **5. The 1:50 Equilibrium (Workforce Architecture)**
 
 - Restructure into Explorers (the 50), Practitioners (the Crew), Accelerators (the 1)
-- Establish secure governance hierarchy
+- Establish the governance hierarchy
+- Define who is accountable for what
 
 ### Secure Secret Management
 
-- NoéMI uses a **"Fetch-on-Demand" architecture** for secrets
+NoéMI uses a **"Fetch-on-Demand" architecture** for secrets — a principle that extends to any organization deploying AI agents:
+
 - Primary tool: **Infisical** (open-source, self-hosted SecretOps)
-- Secrets live only in encrypted vault, injected into process memory at runtime via CLI
-- Never written to disk, committed to Git, or exposed in AI context windows
+- Secrets live **only** in an encrypted vault, injected into process memory at runtime via CLI
+- Never written to disk, never committed to Git, never exposed in AI context windows
 - Machine Identities (not human SSO) for headless agent environments
 
-### Client-Side Phase 0 Baseline
+This is not optional. If your AI agents have access to credentials that are stored in plaintext, in `.env` files, or in configuration repos, you do not have a security perimeter. You have a time bomb.
 
-Organizations should complete a short, written **Phase 0 initial assessment** before starting an advanced AI initiative. In NoeMI, this should now be treated as two linked tracks:
+### The Two-Track Assessment
 
-- a **Security Assessment** that evaluates identity, endpoint hygiene, backups, logging, secrets management, SaaS and vendor exposure, data boundaries, and incident readiness
-- an **AI Readiness Assessment** that evaluates business use-case clarity, process stability, approval boundaries, role uplift, and measurement readiness
+Organizations should complete a written Phase 0 assessment before starting any advanced AI initiative. In NoéMI, this assessment covers two linked tracks:
 
-Together, these two tracks answer both executive questions:
+- A **Security Assessment:** identity, endpoint hygiene, backups, logging, secrets management, SaaS and vendor exposure, data boundaries, and incident readiness
+- An **AI Readiness Assessment:** business use-case clarity, process stability, approval boundaries, role uplift potential, and measurement readiness
 
-- can we do this safely?
-- can we do this in a way that creates real business value?
+Together, these answer the two questions every executive needs answered: *Can we do this safely?* and *Can we do this in a way that creates real business value?*
 
-For a client-oriented guide on what to assess, how to work with an MSP or MSSP, and how to request a grounded baseline without turning the conversation into a product pitch, see [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](PHASE_ZERO_SECURITY_BASELINE.md).
-For reusable assessment assets, see [`docs/phase-zero-assessment/`](phase-zero-assessment/).
-
+For the client-oriented guide, see [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](PHASE_ZERO_SECURITY_BASELINE.md).
+For reusable assessment templates, see [`docs/phase-zero-assessment/`](phase-zero-assessment/).
 For implementation details, see [`docs/tool-usages/secure-secret-management.md`](tool-usages/secure-secret-management.md) and [`docs/GOVERNANCE.md`](GOVERNANCE.md).
 
 ---
 
-## 12. The NewPush Labs Technology Stack
+## Chapter 12: The Technology Stack Concept
 
-v3.0 of the curriculum exclusively uses the NewPush Labs open-source stack. This ensures students learn "Production Reality" rather than vendor-locked solutions.
+v3.0 of the curriculum leverages the **NewPush Labs open-source stack**. This is a deliberate choice. NoéMI teaches "Production Reality" — real tools, real infrastructure, real deployment — not vendor-locked demos that fall apart outside a controlled environment.
 
 | **Component** | **Function** |
 | --- | --- |
@@ -430,28 +533,43 @@ v3.0 of the curriculum exclusively uses the NewPush Labs open-source stack. This
 | **NotebookLM** | Document-based knowledge retrieval and RAG-like interactions |
 | **Google Gemini Gems** | Custom AI personas for specific tasks |
 
-All tools are provided **free** to participants. **No vendor lock-in.** What participants build, they take home.
+Three principles govern the stack:
+
+**No vendor lock-in.** Every component is open-source or has an open-source equivalent. What participants build during the program, they take home. No subscription required to keep running what you built.
+
+**Production-grade from day one.** This is not a sandbox. The same stack that participants learn on is the same stack that runs in production environments. The gap between "training exercise" and "deployed system" is zero.
+
+**Customizable, ready to build on an organization's actual investment.** The stack is designed to be deployed on top of an organization's existing infrastructure, whether it's on-premise, in the cloud, or a hybrid environment, taking advantage of their existing investment. Because all the components are entirely free, there is no financial constraint to the scale of deployment on top of an existing infrastructure. None of it can be deployed or all of it can be deployed. It all depends on preferences and governance.
 
 For n8n integration patterns, see [`docs/tool-usages/n8n-expert-persona.md`](tool-usages/n8n-expert-persona.md).
 
 ---
 
-## 13. Partnerships & Credentials
+## Chapter 13: Partnerships and Credentials
+
+NoéMI's credibility comes from the company it keeps.
 
 ### Academic Partners
 
-- **George Mason University (GMU)** — Primary academic anchor. Reviews curriculum and issues Badges of Completion.
-- **University of Pécs (PTE), Hungary** — Curriculum development and validation.
-- **Óbuda University, Hungary** — Micro-diploma program development.
-- **ESSCA School of Management** — Classroom facilities.
+- **George Mason University** — Primary academic anchor. Reviews curriculum and issues Badges of Completion through the Center for Infrastructure Security in the Era of AI (ISEAI).
+- **University of Pecs (PTE), Hungary** — Curriculum development and validation. Key people in Project NoéMI teach courses there.
+- **Obuda University, Hungary** — Micro-diploma program development.
+- **ESSCA School of Management** — Classroom facilities for European cohorts.
 
 ### Industry Partnerships
 
-- **Gartner:** Enterprise AI methodology, case studies, TRiSM framework, ongoing research updates.
-- **Rotary Clubs (Hungary):** Venue support, participant recruitment, community network.
-- **Hungarian Chamber of Commerce:** Local division support.
+- **Gartner:** Enterprise AI methodology, case studies, TRiSM framework, and ongoing research updates.
+- **International Rotary Clubs:** Venue support, participant recruitment, and community network for the initial pilot cohorts.
+- **Local Chambers of Commerce:** Local division support for market delivery.
 
-### Badge System (3 Levels)
+### International Delivery Partners
+
+- **Vilnius, Lithuania:** Cybersecurity and AI thought leadership, European Digital ID coordination.
+- **Bonn/Berlin, Germany:** IT security and energy sector partnerships.
+
+### The Badge System (3 Levels)
+
+These are not participation certificates. They are competency-based micro-credentials issued by George Mason University.
 
 | **Level** | **Badge Title** | **Requirements** |
 | --- | --- | --- |
@@ -459,31 +577,96 @@ For n8n integration patterns, see [`docs/tool-usages/n8n-expert-persona.md`](too
 | Practitioner | "AI Implementation Specialist" | Description (Product/Process), Discernment (Product/Process), Delegation (Task) |
 | Accelerator | "AI Governance Architect" | All 4 Ds at advanced level + TRiSM implementation + Feynman Requirement |
 
----
-
-## 14. Thought Leadership Positions
-
-### A. "AI Will Restructure How We Work"
-
-AI is not just a new technology — it is a paradigm-shifting force that will restructure economic systems. Organizations must invest in infrastructure now to help their workforce transition.
-
-### B. "Traditional Education Cannot Keep Pace"
-
-Traditional university curricula lag the AI revolution by months or years. The solution: semi-vocational accelerators like NoéMI that combine academic rigor with real-time tool mastery.
-
-### C. "Disruption Is Controlled Demolition, Not Earthquake"
-
-You either disrupt yourself (controlled) or get disrupted by competitors (catastrophic). NoéMI enables controlled self-disruption.
-
-### D. "The Unknown Unknowns"
-
-The real bottleneck in the AI era is not finding answers — answers are free and instant. The bottleneck is knowing the right questions. Only intensive, interactive workshops where real business pain meets live technical guidance can reveal an organization's "unknown unknowns."
+The Accelerator badge requires teaching. You cannot earn it by passing a test. You earn it by demonstrating that you can make someone else understand a core concept — because that is what Accelerators do in production: they make AI safe and productive for everyone around them.
 
 ---
 
-## 15. Repository Guide
+## Chapter 14: Questions Organizations Ask
 
-This document serves as the entry point to the NoéMI Agents Library. Below is a guide to the key documents and directories in this repository:
+These are real questions from real conversations. If you are thinking them, you are not alone.
+
+### "Our top performers already use AI on their own. Why do we need a program?"
+
+Your top performers — the 5-10% — absolutely self-learn AI. But NoéMI is not for them individually. It is for the **other 90%** of the organization, and for creating the governance structure that keeps the self-learners from creating Shadow AI chaos. The most productive individual AI user in an ungoverned environment is also your biggest data leakage risk. The value of NoéMI is not individual upskilling. It is organizational transformation.
+
+### "AI changes so fast that any curriculum becomes outdated in months."
+
+This is exactly why NoéMI uses the Two-Layer System. Layer A (First Principles) never goes stale — critical thinking about delegation, governance, and ethics is timeless. These are not skills that expire when the next innovation arrives tomorrow. Layer B (Dynamic Labs) is updated every cohort to reflect the current tool landscape. You learn how to think once. You learn with the technology that is state of the art right now.
+
+### "My team already gets huge productivity gains from self-directed AI use."
+
+Individual gains without governance equal organizational risk. Who audits what data your developers paste into public LLMs? Who handles compliance when an AI agent hallucinates a response to a customer? Who is accountable when an automated workflow sends confidential data to the wrong endpoint? NoéMI provides the governance layer that turns individual productivity into enterprise-safe operations.
+
+### "Show me ROI metrics."
+
+The program has graduated several organizations. The 5-day format produces a measurable deliverable: a working Virtual Coworker with calculated time savings. The formula is straightforward: Time Saved x Labor Cost = ROI. But the bigger ROI is organizational: the ability to deploy AI safely across the enterprise, not just in one team's side project. We are posting case studies and testimonials on our YouTube channel.
+
+### "Previous training did not translate to real implementation."
+
+That is because most programs teach theory without building anything consequential for the organization. NoéMI participants leave with working AI agents deployed on production infrastructure. The Practitioner track is entirely hands-on. The capstone is a live deployment, not a presentation.
+
+### "We are worried about job losses."
+
+You should be — but not from NoéMI. The organizations that will see job losses are the ones that do **nothing** and get disrupted by competitors who adopted AI architecture early. NoéMI explicitly rejects the Replacement Trap. The goal is a Virtual Workforce where AI handles the work humans should not be doing, and humans move into higher-value roles. Not fewer jobs. Different jobs. Better jobs.
+
+---
+
+## Chapter 15: Thought Leadership
+
+These are the positions NoéMI takes publicly. They are not hedged. They are not safe. They are what we believe.
+
+### "AI Will Restructure How We Work"
+
+AI is not just a new technology. It is a paradigm-shifting force on the scale of electrification or the internet. It will restructure economic systems, redefine competitive advantage, and reorganize how value is created. Organizations that treat it as "a useful tool" are bringing a knife to a gunfight. The organizations that will thrive are the ones that redesign their operating model around AI — not the ones that bolt AI onto their existing model.
+
+### "Traditional Education Cannot Keep Pace"
+
+University curricula lag the AI revolution by months or years. Trying to learn AI from a traditional academic program is like following a live Formula 1 race by reading the newspaper the next morning. By the time the curriculum is approved, the technology has moved on. The solution is not to abandon academic rigor — it is to pair it with real-time tool mastery, which is exactly what Project NoéMI does.
+
+### "Disruption Is Controlled Demolition, Not a Tsunami"
+
+You either disrupt yourself — deliberately, strategically, on your own terms — or you get disrupted by someone else. The first option is painful but survivable. The second is catastrophic. NoéMI exists to give organizations the tools, the training, and the architecture to execute controlled self-disruption.
+
+### "The Bottleneck Is Not Answers. It Is Questions."
+
+Echoing Picasso's famous statement "Computers are useless they only give answers." In the AI era, answers are free and instant. The real bottleneck is knowing the right questions to ask. What process should we automate first? What data is too sensitive for AI? How do we measure whether this is working? Only intensive, interactive programs where real business problems meet live technical guidance can reveal an organization's "unknown unknowns" — the things they do not know they do not know.
+
+---
+
+## Chapter 16: Where You Go From Here
+
+You have read the philosophy, the architecture, the framework, and the curriculum. Now comes the part that matters: doing something with it.
+
+This repository is the implementation blueprint. It contains everything you need to start building a governed AI Workforce. But knowing where to start depends on who you are.
+
+**If you are a business leader or decision maker:**
+Start with the security baseline. Understand what Phase 0 means for your organization. Then look at the agent specifications to understand what a Virtual Workforce looks like in practice.
+→ [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](PHASE_ZERO_SECURITY_BASELINE.md)
+
+**If you are a security or IT leader:**
+Start with Phase 0 and the governance framework. Your job is to ensure that whatever AI capabilities the organization adopts, they are adopted safely.
+→ [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](PHASE_ZERO_SECURITY_BASELINE.md)
+→ [`docs/GOVERNANCE.md`](GOVERNANCE.md)
+
+**If you are a builder — a Practitioner or aspiring Accelerator:**
+Start with the first agent tutorial. Build something. Then read the agent specifications in this repository to understand how production-grade agents are structured.
+→ [`docs/examples/zero-to-first-agent.md`](examples/zero-to-first-agent.md)
+
+**If you just want to see the big picture:**
+Start with the visual maps. They show the system architecture, the audience paths, the runtime flow, and the workshop structure in diagram form.
+→ [`docs/visuals/`](visuals/)
+
+If you feel that this is too much to do in a self directed way, inquire about a [NoéMI Workshop](https://noemi.newpush.com) for your organization.
+
+The Ark is here. The blueprints are open. The flood is not waiting for anyone.
+
+The only question left is yours: **will you build, or will you wait?**
+
+---
+
+## Chapter 17: Repository Guide
+
+This document serves as the entry point to the NoéMI Agents Library. Below is a map of the key documents and directories in this repository.
 
 ### Core Documentation
 
@@ -495,7 +678,7 @@ This document serves as the entry point to the NoéMI Agents Library. Below is a
 | [`docs/DECISION_LOG.md`](DECISION_LOG.md) | Architectural decision records |
 | [`docs/CLARIFICATIONS.md`](CLARIFICATIONS.md) | Clarifications and FAQs |
 | [`docs/AGENT_TEMPLATE.md`](AGENT_TEMPLATE.md) | Canonical template for all agent specifications |
-| [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](PHASE_ZERO_SECURITY_BASELINE.md) | Client-side guide to grounding cybersecurity before advanced AI work |
+| [`docs/PHASE_ZERO_SECURITY_BASELINE.md`](PHASE_ZERO_SECURITY_BASELINE.md) | Client-side guide to Phase 0 security |
 | [`docs/phase-zero-assessment/`](phase-zero-assessment/) | Assessment kit: consent, findings, roadmap, and readiness rubric |
 | [`docs/visuals/`](visuals/) | Visual system map, audience entry map, runtime flow, and workshop mind map |
 
@@ -503,7 +686,7 @@ This document serves as the entry point to the NoéMI Agents Library. Below is a
 
 | Directory | Description |
 | --- | --- |
-| [`docs/agents/guardian/`](agents/guardian/) | Guardian Agent — AI monitoring AI |
+| [`docs/agents/guardian/`](agents/guardian/) | Guardian Agents — AI monitoring AI |
 | [`docs/agents/coding/`](agents/coding/) | Coding agents (Bolt, Sentinel) |
 | [`docs/agents/infrastructure/`](agents/infrastructure/) | Infrastructure management agents |
 | [`docs/agents/marketing/`](agents/marketing/) | Marketing automation agents |
@@ -518,7 +701,7 @@ This document serves as the entry point to the NoéMI Agents Library. Below is a
 | --- | --- |
 | [`docs/lifecycle/`](lifecycle/) | The 4D lifecycle documents (Delegation, Description, Discernment, Diligence) |
 | [`docs/frameworks/gartner-trism.md`](frameworks/gartner-trism.md) | Gartner AI TRiSM framework reference |
-| [`docs/frameworks/value-lenses.md`](frameworks/value-lenses.md) | Explicit success-criteria overlays for comparing outcomes under different enterprise logics |
+| [`docs/frameworks/value-lenses.md`](frameworks/value-lenses.md) | Success-criteria overlays for comparing outcomes under different enterprise logics |
 | [`docs/mcp-setup/`](mcp-setup/) | MCP server setup guides (Google Workspace, n8n, Slack, Web Search) |
 | [`docs/tool-usages/`](tool-usages/) | Tool-specific guides and integration patterns |
 | [`docs/examples/`](examples/) | Example implementations (Docker sandbox, RFP Responder, Video Automation) |


### PR DESCRIPTION
## Summary
- rewrite the root README to distinguish Project NoeMI, this `agents` repository, and NewPush more clearly
- update `docs/PROJECT_REFERENCE.md` with the same clearer public framing
- keep the front door focused on trust, clarity, and the role of the reference architecture

## Validation
- npm run validate