### PR TITLE
Document Substantive Persona Drift and Missing Reference Assets

### DIFF
--- a/docs/CLARIFICATIONS.md
+++ b/docs/CLARIFICATIONS.md
@@ -169,3 +169,17 @@ Add new questions below this line using the required format.
 **Question for Product Owner:** Should `scripts/audit-repo.js` be enhanced to perform strict JSON schema validation for the Audit Log section in both agents and skills?
 **Answer:** [LEAVE BLANK FOR HUMAN TO FILL]
 **🤖 Jules Action Prompt:** *Enhance `scripts/audit-repo.js` to parse the Audit Log section and validate it against the mandated JSON schema `{ "task": "...", "inputs": [], "actions": [], "risks": [], "result": "..." }`.*
+
+### ❓ Question [2026-04-26] - Substantive Persona Content Drift
+**Context:** A whole-codebase audit revealed that 100% of agent personas (22/22) currently use identical placeholder text for the `Data Inventory` and `Refusal Criteria` sections.
+**Ambiguity / Drift:** While the repository passes structural audits (headings are present), it has drifted into substantive non-compliance with the 4D framework (D2 Description) and the Refusal Principle. Agents lack the role-specific data definitions and safety-gating logic required for production readiness.
+**Question for Product Owner:** Should Jules be tasked with a bulk update to replace these placeholders with role-specific substantive content, or should this be handled incrementally during domain-specific work?
+**Answer:** [LEAVE BLANK FOR HUMAN TO FILL]
+**🤖 Jules Action Prompt:** *Perform a whole-fleet update of all agent personas in `agents/` to replace placeholder `Data Inventory` and `Refusal Criteria` sections with role-specific, technically accurate content.*
+
+### ❓ Question [2026-04-26] - Reference Asset Absence
+**Context:** Several agent specifications (e.g., `Client Onboarding`) mandate the use of assets from the `examples/` directory (e.g., `red-team-gauntlet` test vectors), but these directories are currently empty or missing the actual assets.
+**Ambiguity / Drift:** The agent specifications describe workflows that cannot be executed or validated with the current codebase state.
+**Question for Product Owner:** Should we prioritize populating these example directories with starter assets to make the agent specifications "truthful" and testable?
+**Answer:** [LEAVE BLANK FOR HUMAN TO FILL]
+**🤖 Jules Action Prompt:** *Populate `examples/red-team-gauntlet/` and other referenced example directories with the starter assets, test vectors, and templates required by the agent specifications.*

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -154,3 +154,5 @@ Lifecycle docs, templates, and governance text must not reorder these dimensions
 - Reference implementation services (e.g., `dashboard-ingest.js`) do not yet emit the mandated JSON Audit Log shape.
 - There is an implementation gap between the `Fleet Dashboard` multi-tenancy registry and verification specification and the current single-agent reference implementation.
 - The mandatory `Audit Log` JSON shape lacks automated technical validation in `scripts/audit-repo.js`.
+- **Structural vs. Substantive Compliance**: 100% of agent personas currently use identical placeholder text for the mandatory `Data Inventory` and `Refusal Criteria` sections. While these satisfy structural audit checks, they fail to provide role-specific technical and safety context required by the 4D framework.
+- **Reference Example Completeness**: Several reference examples, notably `examples/red-team-gauntlet/`, lack the actual assets (test vectors, prompts) required to execute the workflows described in agent specifications.


### PR DESCRIPTION
As part of the "Doc" persona workflow, I performed a holistic audit of the repository.

### Findings:
1. **Substantive Content Drift**: While all 22 agent personas pass the structural audit (`scripts/audit-repo.js`), they all use identical placeholder text for the mandatory `Data Inventory` and `Refusal Criteria` sections. This satisfies the "Presence" check but fails the "Substance" requirement of the 4D framework.
2. **Reference Asset Absence**: Agent specifications (like Client Onboarding) reference test vectors in `examples/red-team-gauntlet/` that do not currently exist in the repository.
3. **Skill Compliance**: Reusable skills are structurally compliant but currently lack automated audit enforcement.

### Actions Taken:
- Updated `REQUIREMENTS.md` to include these findings in "Current Known Limitations".
- Appended two new high-priority questions to `docs/CLARIFICATIONS.md` to trigger substantive updates.
- Verified that all 38 repository tests pass.

---
*PR created automatically by Jules for task [5831373945556765312](https://jules.google.com/task/5831373945556765312) started by @WSwarm*