### PR TITLE
feat(operations): add QBR Presenter agent

### DIFF
--- a/agents/operations/qbr-presenter.md
+++ b/agents/operations/qbr-presenter.md
@@ -1,0 +1,247 @@
+# QBR Presenter — Operations Agent
+
+## Role
+MSP Quarterly Business Review Specialist responsible for automating the end-to-end preparation and delivery of client-facing QBR presentations. Aggregates operational data from ticketing, monitoring, security, and financial systems into a structured, executive-ready review deck with narrative insights, trend analysis, and strategic recommendations.
+
+## Tone
+Executive-appropriate, data-driven, consultative, and proactively strategic.
+
+## Capabilities
+- Aggregate ticket/incident metrics (volume, MTTR, SLA compliance, category breakdown) from PSA and ticketing systems.
+- Pull uptime, availability, and performance data from RMM/monitoring platforms.
+- Summarize security posture: patch compliance, endpoint protection status, vulnerability counts, and incident history.
+- Track asset inventory changes (new devices, decommissions, license utilization) quarter-over-quarter.
+- Review and score previous QBR action items as completed, in-progress, or overdue.
+- Generate trend analysis comparing current quarter to prior quarters with directional indicators.
+- Produce an executive narrative that translates raw metrics into business-impact language.
+- Build a Google Slides presentation using branded templates.
+- Draft a client-facing email summary with the QBR deck attached.
+- Flag risk items and strategic recommendations that require client decision or budget approval.
+
+## Mission
+Transform scattered operational data into a compelling, consultative QBR narrative that demonstrates MSP value, surfaces risks proactively, and drives strategic alignment with the client — reducing QBR prep from days to under an hour.
+
+## Rules & Constraints (4D Diligence)
+1. **Data before narrative:** Never write executive commentary without first gathering and validating the underlying metrics. All claims must trace to a data source.
+2. **Quarter-over-quarter context:** Every metric must be presented with at least one prior quarter for comparison. A number without trend context is meaningless to an executive.
+3. **Business language:** Translate technical metrics into business impact. "MTTR dropped from 4.2h to 2.8h" becomes "Issues are resolved 33% faster, reducing downtime risk to your operations."
+4. **Balanced reporting:** Include both wins and areas for improvement. A QBR that only highlights successes erodes trust. A QBR that only flags problems erodes confidence.
+5. **Action item continuity:** Always review the previous QBR's action items and report their status. Dropping action items between reviews signals disorganization.
+6. **No fabrication:** If a data source is unavailable or incomplete, explicitly state the gap rather than interpolating or omitting the section silently.
+7. **Client-specific framing:** Tailor recommendations to the client's industry, size, risk tolerance, and contract tier. A 10-person law firm has different priorities than a 200-person manufacturing plant.
+
+## Boundaries
+- **Always:** Include prior-quarter comparisons for every metric. Review previous action items. Cite data sources. Present both strengths and improvement areas. Generate the deck as a draft for human review before client delivery.
+- **Ask First:** Sending the QBR deck or summary email directly to the client. Including financial data (contract value, overages). Recommending contract tier changes or upsells. Sharing security vulnerability details in the deck.
+- **Never:** Fabricate or interpolate missing data. Send a QBR to a client without human review. Include raw security scan outputs or vulnerability details in client-facing materials. Expose internal margin, cost, or pricing data.
+
+## Workflow
+
+### 1. INTAKE
+Accept QBR parameters and validate inputs:
+- **Required:** Client ID, review period (quarter + year), presenter name, QBR date.
+- **Optional:** Focus areas (e.g., "security deep-dive", "cloud migration progress"), custom KPIs, previous QBR document reference.
+- Load the client's profile from `clients/{client-id}/` for contract tier, industry vertical, and historical context.
+- Load the previous QBR's action items for continuity tracking.
+
+### 2. GATHER
+Collect data from operational systems for the review period:
+
+#### 2a. Service Desk Metrics
+- Total ticket volume (new, resolved, open/backlog)
+- Ticket breakdown by category (hardware, software, network, security, user request)
+- Ticket breakdown by priority (critical, high, medium, low)
+- Mean Time to Respond (MTTR) and Mean Time to Resolve
+- SLA compliance rate (% of tickets meeting contracted response/resolution targets)
+- Top 5 recurring issue types
+- Customer satisfaction scores (if available)
+
+#### 2b. Infrastructure & Availability
+- Overall uptime percentage per monitored system/site
+- Planned vs. unplanned downtime events
+- Backup success rate and last verified restore test date
+- Network performance metrics (latency, packet loss) for managed circuits
+- Disk/storage utilization trends
+
+#### 2c. Security Posture
+- Patch compliance rate (OS, application, firmware)
+- Endpoint protection coverage and detection counts
+- Number of security incidents (phishing attempts blocked, malware detections, unauthorized access)
+- MFA adoption rate
+- Security awareness training completion (if tracked)
+- Vulnerability scan summary: critical/high/medium counts and remediation rate
+
+#### 2d. Asset & License Inventory
+- New devices/users added during quarter
+- Devices/users decommissioned
+- Current total managed endpoints
+- License utilization (Microsoft 365, security tools, LOB applications)
+- Warranty/end-of-life status for critical hardware
+
+#### 2e. Project & Initiatives
+- Active projects: status, milestones achieved, blockers
+- Completed projects: summary and outcomes
+- Upcoming planned initiatives
+
+#### 2f. Previous Action Items
+- Load action items from the prior QBR
+- Cross-reference each against current system state or project status
+- Classify as: `COMPLETED`, `IN_PROGRESS`, `OVERDUE`, or `DEFERRED`
+
+**Skill:** `verification/cross-reference` — Verify completion claims for previous action items against source-of-truth systems.
+
+### 3. ANALYZE
+Transform raw data into insights:
+
+1. **Trend analysis** — Compare each KPI against the prior 1-3 quarters. Calculate percentage change and assign a directional indicator (`improving`, `stable`, `declining`).
+2. **SLA health** — Identify any SLA categories at risk of breach. Project forward based on current trajectory.
+3. **Risk identification** — Flag items requiring client attention:
+   - End-of-life hardware with no replacement plan
+   - Declining patch compliance
+   - Rising ticket volume in a specific category (indicates systemic issue)
+   - Overdue action items from prior QBRs
+   - Security gaps (low MFA adoption, missed training)
+4. **Win highlights** — Identify measurable improvements to lead the narrative with (faster resolution times, higher uptime, successful project completions).
+5. **Strategic recommendations** — Generate 3-5 prioritized recommendations based on the data, categorized as:
+   - `quick_win` — Low effort, immediate impact
+   - `strategic` — Requires planning/budget, high long-term value
+   - `risk_mitigation` — Addresses an identified vulnerability or trend
+
+**Skill:** `classification/risk-triage` — Classify each identified risk as Low / Medium / High based on business impact and likelihood.
+
+### 4. BUILD
+Generate the QBR deliverables:
+
+#### 4a. Slide Deck (Google Slides)
+Build the presentation using the client's branded template:
+
+| Slide | Content |
+|-------|---------|
+| 1. Title | Client logo, "Quarterly Business Review", period, date |
+| 2. Agenda | Section overview |
+| 3. Executive Summary | 3-5 bullet narrative of the quarter's story |
+| 4. Previous Action Items | Status table with completion indicators |
+| 5. Service Desk Overview | Ticket volume chart, SLA gauge, MTTR trend |
+| 6. Top Issues | Recurring issue breakdown with root cause notes |
+| 7. Infrastructure & Uptime | Availability scorecard, backup status, capacity trends |
+| 8. Security Posture | Patch compliance, threat summary, MFA adoption |
+| 9. Asset Inventory | Device/user counts, license utilization, EOL alerts |
+| 10. Projects & Initiatives | Status dashboard for active/completed/upcoming |
+| 11. Strategic Recommendations | Prioritized list with effort/impact indicators |
+| 12. Proposed Action Items | New actions with owners, deadlines, and priority |
+| 13. Q&A / Discussion | Open discussion prompts |
+
+#### 4b. Executive Summary Email
+Draft a concise email for the client contact summarizing:
+- Quarter highlights (2-3 wins)
+- Items requiring attention (1-2 risks)
+- QBR meeting logistics (date, time, attendees)
+- Deck attached as PDF export
+
+#### 4c. Internal Prep Notes
+Generate a companion document for the MSP presenter:
+- Talking points for each slide
+- Anticipated client questions and suggested responses
+- Upsell/cross-sell opportunities identified from the data (if applicable)
+- Risk items that may generate pushback and how to frame them constructively
+
+### 5. REVIEW
+**Skill:** `reporting/structured-report` — Generate the QBR metadata report for the Fleet Dashboard.
+
+Present all deliverables for human review:
+- Slide deck (Google Slides link)
+- Executive summary email (Gmail draft)
+- Internal prep notes
+- Data source citations for every metric
+
+Flag any data gaps or low-confidence metrics that the reviewer should validate manually.
+
+### 6. DELIVER (Ask First)
+Upon human approval:
+1. Export the slide deck as PDF.
+2. Send the executive summary email with PDF attached to the client contact.
+3. Log the QBR completion and new action items for next-quarter continuity.
+
+**Skill:** `reporting/alert-notify` — Post QBR completion summary to the MSP ops Slack channel.
+
+## External Tooling Dependencies
+- **PSA / Ticketing system** — ConnectWise, Autotask, HaloPSA, or equivalent for ticket metrics and SLA data.
+- **RMM platform** — Datto RMM, NinjaOne, ConnectWise Automate, or equivalent for uptime, patch, and asset data.
+- **Security tools** — Endpoint protection console, vulnerability scanner, email security gateway for security posture data.
+- **Google Workspace** — Slides for deck generation, Gmail for email delivery, Drive for storage.
+- **1Password CLI / Infisical** — Runtime credential injection for all API access.
+- **Fleet Dashboard API** — QBR completion reporting and historical QBR tracking.
+
+## Tool Usage
+- **Google Slides MCP** — Create and populate the QBR presentation from the branded template.
+- **Google Drive MCP** — Retrieve previous QBR decks and store the new one in the client's folder.
+- **Gmail MCP** — Draft the executive summary email (never send without human approval).
+- **Google Sheets MCP** — Read/write KPI tracking spreadsheets if the client uses a shared metrics sheet.
+- **Slack MCP** — Post QBR completion notifications and flag overdue action items.
+- **Web search** — Look up vendor EOL dates, security advisories, or industry benchmarks when needed.
+
+## Output Format
+```yaml
+qbr_report:
+  client_id: "<slug>"
+  client_name: "<display name>"
+  period: "Q1 2026"
+  qbr_date: "2026-04-15"
+  presenter: "<name>"
+  status: "DRAFT | APPROVED | DELIVERED"
+  deliverables:
+    slide_deck:
+      format: "google_slides"
+      url: "<slides URL>"
+      pdf_export: "<drive URL>"
+      slide_count: 13
+    email_draft:
+      format: "gmail_draft"
+      draft_id: "<gmail draft ID>"
+      recipient: "<client contact email>"
+    prep_notes:
+      format: "markdown"
+      path: "clients/<client-id>/qbr/2026-Q1/prep-notes.md"
+  metrics_snapshot:
+    tickets:
+      total: 342
+      resolved: 328
+      sla_compliance: "96.2%"
+      mttr_hours: 2.8
+      trend: "improving"
+    uptime:
+      overall: "99.94%"
+      incidents: 3
+      trend: "stable"
+    security:
+      patch_compliance: "91%"
+      threats_blocked: 47
+      mfa_adoption: "88%"
+      trend: "improving"
+    assets:
+      managed_endpoints: 187
+      net_change: "+12"
+  action_items:
+    previous:
+      completed: 4
+      in_progress: 1
+      overdue: 1
+    new:
+      - description: "<action>"
+        owner: "<person>"
+        deadline: "2026-06-30"
+        priority: "high"
+  risks:
+    - item: "<risk description>"
+      tier: "HIGH"
+      recommendation: "<mitigation>"
+  data_gaps:
+    - "<description of missing/incomplete data source>"
+  timestamp: "<ISO 8601>"
+  actor: "qbr-presenter-agent"
+```
+
+## Files of Interest
+- `clients/{client-id}/qbr/` — Historical QBR deliverables and action item logs per client.
+- `clients/{client-id}/mcp.config.json` — Client's tier and MCP configuration.
+- `docs/agents/operations/qbr-presenter/` — Setup guide, branded template instructions, and KPI reference.

--- a/docs/agents/operations/qbr-presenter/README.md
+++ b/docs/agents/operations/qbr-presenter/README.md
@@ -1,0 +1,460 @@
+# QBR Presenter — Setup & Operations Guide
+
+## Overview
+
+The QBR Presenter agent automates Quarterly Business Review preparation for MSP clients. It pulls operational data from ticketing, monitoring, and security systems, analyzes trends, generates a branded slide deck, drafts the client email, and produces internal presenter prep notes.
+
+The agent generates everything as **drafts for human review** — it never sends materials to a client autonomously.
+
+---
+
+## Architecture
+
+```
+┌──────────────┐  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+│ PSA / Tickets│  │ RMM / Monitor│  │ Security     │  │ Previous QBR │
+│ (ConnectWise,│  │ (Datto,      │  │ (EDR, Patch, │  │ Action Items │
+│  Autotask)   │  │  NinjaOne)   │  │  Email GW)   │  │              │
+└──────┬───────┘  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘
+       │                 │                 │                 │
+       ▼                 ▼                 ▼                 ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                        QBR Presenter Agent                          │
+│                                                                      │
+│  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌──────────┐ │
+│  │ INTAKE  │→ │ GATHER  │→ │ ANALYZE │→ │ BUILD   │→ │ REVIEW   │ │
+│  └─────────┘  └─────────┘  └─────────┘  └─────────┘  └──────────┘ │
+└──────────────────────────┬───────────────────────────────────────────┘
+                           │
+              ┌────────────┼────────────┐
+              ▼            ▼            ▼
+     ┌──────────────┐ ┌─────────┐ ┌───────────┐
+     │ Google Slides│ │ Gmail   │ │ Prep Notes│
+     │ (QBR Deck)   │ │ (Draft) │ │ (Markdown)│
+     └──────────────┘ └─────────┘ └───────────┘
+```
+
+---
+
+## Prerequisites
+
+### Required MCP Integrations
+
+| MCP | Purpose | Config Key |
+|-----|---------|------------|
+| Google Slides | Deck generation | `google-slides` |
+| Google Drive | Template retrieval, deck storage | `google-drive` |
+| Gmail | Executive summary email draft | `gmail` |
+| Slack | Completion notifications | `slack` |
+
+### Optional MCP Integrations
+
+| MCP | Purpose |
+|-----|---------|
+| Google Sheets | KPI tracking spreadsheets |
+| Google Calendar | QBR meeting scheduling |
+
+### Data Source Access
+
+The agent needs read access to your operational platforms. Configure API credentials in your vault:
+
+```bash
+# Example: ConnectWise PSA credentials
+op item create --category=login --title="ConnectWise API" \
+  --field="company_id=mycompany" \
+  --field="public_key=<key>" \
+  --field="private_key=<key>" \
+  --field="site=na.myconnectwise.net"
+
+# Example: Datto RMM credentials
+op item create --category=login --title="Datto RMM API" \
+  --field="api_url=https://pinotage-api.centrastage.net" \
+  --field="api_key=<key>" \
+  --field="api_secret=<secret>"
+```
+
+---
+
+## Client Setup
+
+### 1. Client Folder Structure
+
+Each client needs a QBR directory for storing historical data and action items:
+
+```
+clients/{client-id}/
+├── mcp.config.json          # Client MCP config (from onboarding)
+├── profile.yml              # Client metadata
+└── qbr/
+    ├── templates/
+    │   └── slide-template-id.txt   # Google Slides template ID
+    ├── 2025-Q4/
+    │   ├── deck.pdf
+    │   ├── prep-notes.md
+    │   └── action-items.yml
+    └── 2026-Q1/
+        ├── deck.pdf
+        ├── prep-notes.md
+        └── action-items.yml
+```
+
+### 2. Client Profile
+
+Create `clients/{client-id}/profile.yml` with client metadata:
+
+```yaml
+client_id: acme-corp
+display_name: "ACME Corporation"
+industry: "Manufacturing"
+tier: "Premium"
+size: "150 employees"
+contacts:
+  primary:
+    name: "Jane Smith"
+    email: "jane.smith@acme-corp.com"
+    role: "IT Director"
+  executive:
+    name: "Bob Johnson"
+    email: "bob.johnson@acme-corp.com"
+    role: "CFO"
+qbr:
+  frequency: "quarterly"
+  presenter: "Alex Martinez"
+  slide_template_id: "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
+  branded_colors:
+    primary: "#1B365D"
+    accent: "#E87722"
+  focus_areas:
+    - "security"
+    - "cloud_migration"
+  custom_kpis:
+    - name: "ERP Uptime"
+      target: "99.9%"
+      source: "rrmm_monitor_id_1234"
+data_sources:
+  psa: "connectwise"
+  rmm: "datto"
+  security:
+    edr: "sentinelone"
+    email: "proofpoint"
+    patch: "datto"
+```
+
+### 3. Branded Slide Template
+
+Create a Google Slides template with the client's branding and the following placeholder slides. The agent populates content into this template.
+
+**Template setup:**
+1. Create a new Google Slides presentation with the client's logo, colors, and font choices.
+2. Add 13 placeholder slides matching the deck structure in the agent spec.
+3. Note the presentation ID from the URL (the long string between `/d/` and `/edit`).
+4. Store the ID in `clients/{client-id}/qbr/templates/slide-template-id.txt`.
+
+---
+
+## Running a QBR
+
+### Manual Invocation
+
+Trigger QBR preparation by providing the required parameters:
+
+```
+Prepare the Q1 2026 QBR for client acme-corp.
+QBR date: April 15, 2026.
+Presenter: Alex Martinez.
+Focus areas: security deep-dive, cloud migration progress.
+```
+
+The agent will:
+1. Load the client profile and previous QBR action items.
+2. Pull metrics from all configured data sources.
+3. Analyze trends and identify risks.
+4. Generate the slide deck, email draft, and prep notes.
+5. Present everything for your review.
+
+### Scheduled Invocation
+
+Set up a recurring trigger to begin QBR prep automatically at the start of each quarter:
+
+```yaml
+# In your orchestrator schedule config
+qbr_prep:
+  schedule: "0 9 1 1,4,7,10 *"  # 9 AM on the 1st of Jan, Apr, Jul, Oct
+  agent: "qbr-presenter"
+  params:
+    client_ids: ["acme-corp", "globex", "initech"]
+    quarter: "auto"  # Derives from current date
+```
+
+---
+
+## Workflow Detail
+
+### Phase 1: INTAKE
+
+The agent validates inputs and loads context:
+
+```yaml
+# Validated intake payload
+intake:
+  client_id: "acme-corp"
+  period: "Q1 2026"
+  quarter_start: "2026-01-01"
+  quarter_end: "2026-03-31"
+  qbr_date: "2026-04-15"
+  presenter: "Alex Martinez"
+  focus_areas: ["security", "cloud_migration"]
+  previous_qbr: "clients/acme-corp/qbr/2025-Q4/action-items.yml"
+  template_id: "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
+```
+
+### Phase 2: GATHER
+
+Data collection from each source. The agent handles API pagination, rate limiting, and timeout gracefully.
+
+**Example: Service desk query**
+```
+Tickets created between 2026-01-01 and 2026-03-31 for company "ACME Corporation"
+→ Group by: category, priority, month
+→ Calculate: count, MTTR, SLA compliance rate
+```
+
+**Data gap handling:** If a source is unavailable, the agent logs the gap and continues:
+```yaml
+data_gaps:
+  - source: "SentinelOne API"
+    reason: "API returned 401 — credential may need rotation"
+    impact: "Security incident counts and endpoint coverage unavailable"
+    recommendation: "Check vault entry op://MSP-Clients/acme-corp/sentinelone-api-key"
+```
+
+### Phase 3: ANALYZE
+
+The agent computes trends and generates insights:
+
+```yaml
+# Example trend analysis output
+trends:
+  tickets:
+    current_quarter: 342
+    previous_quarter: 389
+    change: "-12.1%"
+    direction: "improving"
+    insight: "Ticket volume decreased 12% QoQ, driven by resolution of recurring printer issues identified in the Q4 QBR."
+
+  sla_compliance:
+    current_quarter: "96.2%"
+    previous_quarter: "94.8%"
+    target: "95%"
+    change: "+1.4pp"
+    direction: "improving"
+    insight: "SLA compliance exceeded the 95% target for the first time in 3 quarters."
+
+  patch_compliance:
+    current_quarter: "91%"
+    previous_quarter: "95%"
+    target: "95%"
+    change: "-4pp"
+    direction: "declining"
+    insight: "Patch compliance dropped below the 95% target. Root cause: 14 servers deferred March patches due to ERP maintenance window."
+```
+
+**Risk identification output:**
+```yaml
+risks:
+  - item: "3 servers running Windows Server 2019 reach end of extended support in Jan 2027"
+    tier: "MEDIUM"
+    category: "risk_mitigation"
+    recommendation: "Begin migration planning this quarter. Estimated effort: 2-3 days per server."
+
+  - item: "Patch compliance dropped to 91%, below the 95% contractual target"
+    tier: "HIGH"
+    category: "quick_win"
+    recommendation: "Schedule a catch-up patching window in April to address the 14 deferred servers."
+
+  - item: "MFA adoption stalled at 88% — 18 users without MFA are in the finance department"
+    tier: "HIGH"
+    category: "risk_mitigation"
+    recommendation: "Enforce MFA for all finance users by end of Q2. Coordinate with client IT Director."
+```
+
+### Phase 4: BUILD
+
+The agent generates three deliverables:
+
+**Slide deck** — Populated into the branded Google Slides template. Each slide includes:
+- A headline that tells the story (not just the metric name)
+- Supporting data visualization description (charts are described for Slides API rendering)
+- Context footnotes citing the data source
+
+**Example slide 3 — Executive Summary:**
+> **A Strong Quarter with One Area Requiring Attention**
+>
+> - Ticket volume dropped 12% as recurring printer issues from Q4 were permanently resolved
+> - SLA compliance exceeded the 95% target for the first time in three quarters (96.2%)
+> - Cloud migration Phase 1 completed on schedule — 40 users now on Azure AD
+> - **Action needed:** Patch compliance dipped to 91% due to deferred March maintenance; catch-up window recommended for April
+
+**Email draft** — Concise, executive-appropriate:
+> Subject: ACME Corporation — Q1 2026 Quarterly Business Review
+>
+> Hi Jane,
+>
+> Attached is the Q1 2026 Quarterly Business Review for ACME Corporation. Here are the highlights:
+>
+> - Ticket volume decreased 12% quarter-over-quarter, and SLA compliance exceeded the 95% target at 96.2%.
+> - Cloud migration Phase 1 completed on schedule with 40 users transitioned to Azure AD.
+> - One item requires attention: patch compliance dropped to 91%, and we're recommending a catch-up window in April.
+>
+> Our QBR meeting is scheduled for April 15 at 2:00 PM CT. Please let me know if you'd like to adjust the agenda or add any topics.
+>
+> Best regards,
+> Alex Martinez
+
+**Prep notes** — Internal-only document:
+```markdown
+## Talking Points
+
+### Slide 5: Service Desk Overview
+- Lead with the 12% volume reduction — this validates the printer fleet replacement we recommended last quarter
+- MTTR improved from 4.2h to 2.8h — tie this to the new triage process we implemented in February
+- If asked about the 14 unresolved tickets: 8 are waiting on vendor parts (ETA next week), 6 are low-priority requests in backlog
+
+### Slide 8: Security Posture
+- Patch compliance drop is likely to generate questions
+- Frame proactively: "We identified this trend mid-quarter and have already scheduled the catch-up window"
+- MFA gap in finance is a sensitive topic — present as a risk, not a criticism of their team
+
+### Upsell Opportunities
+- Client has expressed interest in SOC monitoring — the 47 blocked threats this quarter support the value proposition
+- Windows Server 2019 EOL creates a natural conversation about infrastructure refresh
+```
+
+### Phase 5: REVIEW
+
+The agent presents all deliverables and flags items needing attention:
+
+```yaml
+review_checklist:
+  - item: "Slide deck generated"
+    status: "ready"
+    url: "https://docs.google.com/presentation/d/..."
+
+  - item: "Email draft created"
+    status: "ready"
+    draft_id: "r1234567890"
+
+  - item: "Prep notes generated"
+    status: "ready"
+    path: "clients/acme-corp/qbr/2026-Q1/prep-notes.md"
+
+  - item: "SentinelOne data missing"
+    status: "warning"
+    note: "Security incident counts estimated from email gateway logs only. Verify with SentinelOne console manually."
+
+  - item: "CSAT data not available"
+    status: "gap"
+    note: "No CSAT survey configured for this client. Slide 5 omits satisfaction scores."
+```
+
+### Phase 6: DELIVER
+
+After human approval, the agent:
+1. Exports the deck as PDF to `clients/acme-corp/qbr/2026-Q1/deck.pdf`.
+2. Sends the email with PDF attached.
+3. Saves the new action items to `clients/acme-corp/qbr/2026-Q1/action-items.yml`.
+4. Posts a completion summary to the Slack ops channel.
+5. Reports completion to the Fleet Dashboard.
+
+---
+
+## Action Item Format
+
+Action items are stored as YAML for cross-quarter continuity:
+
+```yaml
+# clients/acme-corp/qbr/2026-Q1/action-items.yml
+qbr_period: "Q1 2026"
+qbr_date: "2026-04-15"
+items:
+  # Carried from previous QBR
+  - id: "2025Q4-003"
+    description: "Complete MFA rollout for finance department"
+    owner: "Jane Smith (ACME) + Alex Martinez (MSP)"
+    deadline: "2026-06-30"
+    priority: "high"
+    status: "in_progress"
+    notes: "18 of 24 finance users enrolled. Remaining 6 scheduled for May."
+    carried_from: "Q4 2025"
+
+  # New items from this QBR
+  - id: "2026Q1-001"
+    description: "Schedule catch-up patching window for 14 deferred servers"
+    owner: "Alex Martinez (MSP)"
+    deadline: "2026-04-30"
+    priority: "high"
+    status: "new"
+
+  - id: "2026Q1-002"
+    description: "Begin Windows Server 2019 migration planning (3 servers)"
+    owner: "Alex Martinez (MSP)"
+    deadline: "2026-06-30"
+    priority: "medium"
+    status: "new"
+
+  - id: "2026Q1-003"
+    description: "Evaluate SOC monitoring proposals and present options at next QBR"
+    owner: "Alex Martinez (MSP)"
+    deadline: "2026-07-01"
+    priority: "low"
+    status: "new"
+```
+
+---
+
+## KPI Reference
+
+Standard KPIs tracked across QBRs. Clients may add custom KPIs in their profile.
+
+| Category | KPI | Target (Typical) | Source |
+|----------|-----|-------------------|--------|
+| Service Desk | Ticket Volume | Trending down | PSA |
+| Service Desk | MTTR | < 4 hours | PSA |
+| Service Desk | SLA Compliance | > 95% | PSA |
+| Service Desk | CSAT | > 4.5 / 5.0 | PSA survey |
+| Infrastructure | Uptime | > 99.9% | RMM |
+| Infrastructure | Backup Success Rate | 100% | RMM / BDR |
+| Infrastructure | Last Verified Restore | < 30 days | Manual / RMM |
+| Security | Patch Compliance | > 95% | RMM / Patch Manager |
+| Security | Endpoint Protection Coverage | 100% | EDR |
+| Security | MFA Adoption | 100% | IdP / Azure AD |
+| Security | Security Incidents | Trending down | EDR + Email GW |
+| Assets | Managed Endpoints | Per contract | RMM |
+| Assets | License Utilization | < 100% | License portal |
+| Assets | EOL Hardware | 0 critical | RMM asset DB |
+
+---
+
+## Troubleshooting
+
+### "Data gap" for a metric source
+
+The agent couldn't reach a data source API. Check:
+1. Vault credentials are current: `op read "op://MSP-Clients/{client-id}/{source}-api-key"`
+2. API endpoint is reachable from the agent's network
+3. Rate limits haven't been hit (check the agent's stderr logs)
+
+### Slide deck uses wrong template
+
+Verify the template ID in `clients/{client-id}/qbr/templates/slide-template-id.txt` matches the Google Slides URL. The ID is the string between `/d/` and `/edit` in the URL.
+
+### Action items not carried from previous QBR
+
+The agent looks for `clients/{client-id}/qbr/{previous-quarter}/action-items.yml`. If the file doesn't exist or the path doesn't match the expected quarter label, items won't carry over. Check:
+- The previous quarter's directory exists
+- The `action-items.yml` file is properly formatted
+- Quarter labels use the format `YYYY-QN` (e.g., `2025-Q4`)
+
+### Email draft not appearing in Gmail
+
+Ensure the Gmail MCP is authenticated and the `gmail` integration is active in the client's MCP config. The agent creates drafts via the Gmail API — check the Drafts folder, not the Inbox.

--- a/docs/agents/operations/qbr-presenter/REQUIREMENTS.md
+++ b/docs/agents/operations/qbr-presenter/REQUIREMENTS.md
@@ -1,0 +1,138 @@
+# QBR Presenter Agent — Initial Requirements
+
+## Summary
+
+An operations agent that automates the preparation and assembly of Quarterly Business Reviews for MSP clients. It replaces the manual effort of pulling metrics from multiple systems, building slide decks, writing executive narratives, and tracking action item continuity — reducing QBR prep from days to under an hour.
+
+## Problem Statement
+
+QBR preparation at an MSP is labor-intensive and inconsistent:
+
+- **Data is scattered** across PSA (tickets, SLAs), RMM (uptime, patches, assets), security consoles, and project trackers. Gathering it manually takes hours per client.
+- **Narrative quality varies** by account manager. Some QBRs are data-heavy with no story; others are vague with no supporting numbers.
+- **Action item continuity breaks** when items from the previous QBR are forgotten or not tracked systematically.
+- **Deck formatting is inconsistent** across clients and presenters, undermining brand perception.
+- **Strategic recommendations are reactive** — surfacing only what the client already knows rather than proactively identifying risks and opportunities from the data.
+
+As the client portfolio grows, QBR quality degrades because the prep effort doesn't scale linearly with headcount.
+
+## Functional Requirements
+
+### FR-1: Data Aggregation
+
+The agent must collect metrics from the following operational domains for a specified quarter:
+
+| Domain | Metrics | Typical Source |
+|--------|---------|----------------|
+| Service Desk | Ticket volume, categories, priorities, MTTR, SLA compliance, CSAT | PSA (ConnectWise, Autotask, HaloPSA) |
+| Infrastructure | Uptime %, planned/unplanned downtime, backup success rate, capacity trends | RMM (Datto, NinjaOne, Automate) |
+| Security | Patch compliance, endpoint coverage, incidents, MFA adoption, vulnerability counts | EDR console, patch manager, email gateway |
+| Assets | Managed endpoints, new/decommissioned devices, license utilization, EOL hardware | RMM + license portal |
+| Projects | Active/completed/upcoming projects, milestones, blockers | PSA or project tracker |
+
+If a data source is unavailable, the agent must explicitly note the gap in the report rather than silently omitting the section.
+
+### FR-2: Trend Analysis
+
+Every metric must be presented with at least one prior quarter for comparison. The agent must:
+
+- Calculate percentage change quarter-over-quarter.
+- Assign a directional indicator: `improving`, `stable`, or `declining`.
+- Highlight metrics that crossed a threshold (e.g., SLA compliance dropped below contracted target).
+
+### FR-3: Action Item Continuity
+
+The agent must:
+
+- Load action items from the previous QBR (stored in `clients/{client-id}/qbr/`).
+- Cross-reference each item against current system state to determine status.
+- Classify each as `COMPLETED`, `IN_PROGRESS`, `OVERDUE`, or `DEFERRED`.
+- Carry over incomplete items into the new QBR's proposed action list.
+
+### FR-4: Risk & Recommendation Engine
+
+The agent must identify and classify risks from the data:
+
+- Hardware approaching end-of-life with no replacement plan.
+- Declining trend lines (patch compliance, SLA, uptime).
+- Rising ticket volume in a specific category (indicates systemic issue).
+- Security gaps (low MFA adoption, missed training, unpatched criticals).
+- Overdue action items from prior QBRs.
+
+Each risk must be classified (Low / Medium / High) and paired with a prioritized recommendation categorized as `quick_win`, `strategic`, or `risk_mitigation`.
+
+### FR-5: Presentation Generation
+
+The agent must produce a Google Slides deck following a standard structure:
+
+1. Title slide (client branding, period, date)
+2. Agenda
+3. Executive Summary (narrative, not bullets of numbers)
+4. Previous Action Items (status table)
+5. Service Desk Overview (charts + SLA gauge)
+6. Top Issues (recurring patterns)
+7. Infrastructure & Uptime (availability scorecard)
+8. Security Posture (compliance dashboard)
+9. Asset Inventory (changes + EOL alerts)
+10. Projects & Initiatives
+11. Strategic Recommendations (prioritized)
+12. Proposed Action Items (with owners and deadlines)
+13. Q&A / Discussion
+
+The deck must use the client's branded template if one exists in Google Drive.
+
+### FR-6: Supporting Deliverables
+
+In addition to the slide deck, the agent must produce:
+
+- **Executive summary email** — Gmail draft addressed to the client contact with a concise quarter summary and QBR meeting details.
+- **Internal prep notes** — Talking points, anticipated questions, and upsell opportunities for the MSP presenter.
+
+### FR-7: Human-in-the-Loop
+
+All deliverables must be generated as drafts for human review. The agent must never send the QBR deck or email to a client without explicit human approval.
+
+## Non-Functional Requirements
+
+- **Data integrity:** All metrics must trace to a named data source. No interpolation or fabrication of missing data.
+- **Balanced framing:** Presentation must include both wins and improvement areas. Exclusively positive or negative framing is rejected.
+- **Client-specific tailoring:** Recommendations must account for the client's industry, size, risk tolerance, and contract tier.
+- **Secrets:** The agent never handles raw API keys or credentials — all data source access uses vault-injected credentials at runtime.
+- **Performance:** Full QBR generation (data pull through deck creation) should complete within 15 minutes per client for standard data volumes.
+
+## Agent Spec Outline
+
+The agent spec (`agents/operations/qbr-presenter.md`) should follow `docs/AGENT_TEMPLATE.md` with:
+
+- **Role:** MSP Quarterly Business Review Specialist
+- **Tone:** Executive-appropriate, data-driven, consultative
+- **Capabilities:** Data aggregation, trend analysis, risk identification, deck generation, action item tracking
+- **Rules & Constraints (4D Diligence):**
+  1. Data before narrative — never write commentary without validated metrics
+  2. Quarter-over-quarter context required for every metric
+  3. Business language — translate technical metrics to impact
+  4. Balanced reporting — include wins and improvement areas
+  5. Action item continuity — always review previous QBR items
+  6. No fabrication — explicitly state data gaps
+- **Boundaries:**
+  - Always: Include prior-quarter comparisons, review previous action items, cite data sources, generate as draft
+  - Ask First: Sending to client, including financials, recommending tier changes
+  - Never: Fabricate data, send without human review, expose internal pricing, include raw vulnerability details
+
+## Dependencies
+
+- PSA / Ticketing API for service desk metrics
+- RMM API for infrastructure and asset data
+- Security tool APIs (EDR, patch management, email gateway)
+- Google Workspace MCPs (Slides, Drive, Gmail, Sheets)
+- Fleet Dashboard API for QBR completion tracking
+- Slack MCP for notifications
+- Vault CLI (`op` / `infisical`) for credential injection
+
+## Open Questions
+
+1. Should QBR data be cached in a local datastore (e.g., a per-client SQLite DB) to enable historical analysis beyond what the source APIs retain?
+2. What is the minimum set of data sources for a viable QBR? (e.g., if the client has no RMM data, can the agent still produce a service-desk-only review?)
+3. Should the branded slide template be stored in the NoéMI repo or fetched from the client's Google Drive folder each time?
+4. How should financial data (contract value, utilization, overages) be handled — separate data source, or manually provided during intake?
+5. Should the agent support ad-hoc "Monthly Business Review" or "Annual Review" variants, or should those be separate agent specs?


### PR DESCRIPTION
## Summary
- Adds a new **QBR Presenter** operations agent that automates MSP Quarterly Business Review preparation
- Includes agent spec (`agents/operations/qbr-presenter.md`), requirements doc, and full setup/operations guide with a worked ACME Corp example
- 6-phase workflow: INTAKE → GATHER → ANALYZE → BUILD → REVIEW → DELIVER covering service desk, infrastructure, security, assets, and project data

## Test plan
- [ ] Verify agent is auto-discovered by `node scripts/generate_all.js` (updates CLAUDE.md/GEMINI.md agent index)
- [ ] Confirm agent spec follows `docs/AGENT_TEMPLATE.md` structure (all required sections present)
- [ ] Review output format YAML for consistency with existing agent specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)