### PR TITLE
docs(contributing): require PRs to target develop

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+> ℹ️ **Base branch:** target `develop`, not `main`. See [CONTRIBUTING.md#branching-model](../CONTRIBUTING.md#branching-model).
+
 ## Summary
 
 - 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,25 @@ npm run validate
 - Use runtime env access (`process.env`, `os.getenv()`), not checked-in secrets or dotenv loaders.
 - Historical Python examples may remain, but do not present them as the recommended first path for new builders.
 
+## Branching Model
+
+This repository uses a two-branch flow:
+
+- **`develop`** — integration branch. All feature, fix, and docs PRs target `develop`.
+- **`main`** — release branch. Only `develop` is promoted into `main`, gated by the `Require develop source` CI check.
+
+When opening a pull request:
+
+1. Branch from `develop` and keep your branch current with `develop` to avoid conflicts on generated files (`CLAUDE.md`, `GEMINI.md`, golden fixtures).
+2. Set the PR base branch to `develop` — not `main`. PRs to `main` from any source other than `develop` are blocked by CI.
+3. Maintainers handle periodic `develop` → `main` promotion separately.
+
+If you accidentally open a PR against `main`, retarget it via the GitHub UI (Edit → Base branch) or:
+
+```bash
+gh pr edit <num> --base develop
+```
+
 ## Pull Request Expectations
 
 Every PR should explain:

--- a/tests/fixtures/generated/agent-index.md
+++ b/tests/fixtures/generated/agent-index.md
@@ -1,6 +1,6 @@
 ## Agent Index
 
-23 agent specifications across 8 domains:
+24 agent specifications across 9 domains:
 
 | Domain | Agent | Role | Spec File |
 |--------|-------|------|-----------|
@@ -8,6 +8,7 @@
 | coding | Bolt (Next.js 16) — Performance Agent | Performance-obsessed agent specializing in **Next. | `agents/coding/bolt/nextjs-16.md` |
 | coding | Sentinel — Security Agent | Security-focused agent who protects the codebase from vulnerabilities and security risks. | `agents/coding/sentinel/core.md` |
 | communication | Postman — Communication Agent | Professional communication assistant specializing in efficient email management and summarization. | `agents/communication/postman.md` |
+| education | Student Success Coach — Education Agent | A compassionate and strategic academic mentor specialized in supporting students from low-income backgrounds. | `agents/education/student-success-coach.md` |
 | engineering | AI Architect — Engineering Agent | You are the AI Architect, the capstone persona of Project NoeMI. | `agents/engineering/ai-architect.md` |
 | engineering | Gatekeeper — Engineering Agent | Automated pull request triage agent that continuously monitors all repositories in a GitHub organization, classifies open PRs by risk level, and takes decisive action: auto-merges safe changes, flags  | `agents/engineering/gatekeeper.md` |
 | guardian | PIIGuard — Guardian Agent | Primary Data Privacy Guardian for the Project NoéMI agent fleet. | `agents/guardian/pii-guard.md` |


### PR DESCRIPTION
## Summary

- Add a **Branching Model** section to [CONTRIBUTING.md](../blob/develop/CONTRIBUTING.md) explaining the two-branch flow (`develop` integration, `main` release) and how to retarget a PR if opened against the wrong base.
- Add a one-line base-branch callout to `.github/pull_request_template.md` so contributors see the rule directly in the PR composer.
- **Bonus:** refresh `tests/fixtures/generated/agent-index.md` to match generator output (pre-existing drift unblocking CI — see Notes for Reviewers).

## Why This Change

Surfaced by PR #158, which was opened against `main` by an external contributor and got blocked by the `Require develop source` CI gate. The branching rule was enforced in CI but not documented anywhere a contributor would find it before opening their PR.

## Audience Impact

- [x] Builder / Accelerator path
- [x] Internal repo contract only

## Validation

- [x] `npm run validate` — all 38 tests pass locally
- [ ] `npm run test:e2e` — n/a (docs + fixture only)
- [ ] `node scripts/generate_all.js` — n/a (no inputs to generators changed)

## Security and Secrets

- [x] No real secrets were added to the repo
- [x] Fetch-on-Demand patterns were preserved (`infisical run` / `op run`)
- [x] `.env.template` / `.env.example` files remain inventories or vault references only

## Docs and Generated Outputs

- [x] README or docs were updated when behavior changed
- [x] Generated outputs were refreshed when inputs changed
- [x] Golden fixtures were updated intentionally when generated sections changed

## Notes for Reviewers

- Two commits:
  1. `docs(contributing)` — the actual subject of this PR
  2. `test(fixtures)` — pre-existing drift on develop. The recent merge from main added `agents/education/student-success-coach.md` (introducing a new `education` domain) but the agent-index golden fixture was not refreshed. CI was failing on **any** PR to develop because of this. Surgical fix: only the count line (23/8 → 24/9) and one table row added.