### PR TITLE
docs(readme): refresh agent count, domains, skills, and stack baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ This repository is the **technical reference architecture and agent specificatio
 
 It provides a structured blueprint for building a **governed Virtual Workforce** using:
 
-* 20+ AI agent specifications across 8 domains (marketing, engineering, operations, security, etc.)
-* Reusable skills for classification, validation, reporting, and orchestration
-* MCP protocol definitions for safe integration with tools like Google Workspace, Slack, GitHub, and n8n
-* Governance frameworks aligned with **Phase 0 Security** and **Gartner AI TRiSM**
+* 26 AI agent specifications across 9 domains (coding, communication, education, engineering, guardian, infrastructure, marketing, operations, product)
+* 8 reusable skills covering classification, verification, reporting, security, and orchestration
+* 17 MCP protocol definitions for safe integration with Google Workspace (Drive, Docs, Sheets, Slides, Calendar, Gmail, Meet, Chat, Keep, Forms, Contacts, Admin), Slack, GitHub, n8n, web search, and unified logging (Loki/Grafana)
+* Governance frameworks aligned with **Phase 0 Security**, **Gartner AI TRiSM**, and the **4D AI Fluency Framework** (Delegation, Description, Discernment, Diligence)
+* Value lenses and operating profiles that let teams tune agents to specific business contexts without forking the specs
 
 These components are designed to move organizations from **unstructured, high-risk AI usage** to a **controlled, auditable, and scalable operating model**.
 
@@ -166,10 +167,12 @@ Without Phase 0, scaling AI introduces risk faster than value.
 It is designed to work with orchestrators such as:
 
 * n8n (primary orchestration layer in the NewPush Labs stack)
-* Gemini CLI
+* Gemini CLI (canonical baseline pinned to Gemini 2.5 Flash)
 * Claude Code
 * OpenAI Codex
 * LangChain
+
+All reference tooling and Docker images use **Node.js 24** as the technical baseline for cross-fleet compatibility.
 
 ---
 
@@ -186,6 +189,14 @@ It is designed to work with orchestrators such as:
 **Practitioners / Builders**
 → [docs/examples/zero-to-first-agent.md](docs/examples/zero-to-first-agent.md)
 (Building your first Virtual Coworker)
+
+**Onboarding by Platform**
+→ [docs/examples/cross-platform-kickstart.md](docs/examples/cross-platform-kickstart.md)
+(macOS / Linux, Windows, and ChromeOS kickstart paths)
+
+**Contributors**
+→ [CONTRIBUTING.md](CONTRIBUTING.md)
+(Contribution workflow, agent and skill standards)
 
 **Visual Orientation**
 → [docs/visuals/README.md](docs/visuals/README.md)


### PR DESCRIPTION
## Summary

Refreshes the public-facing README so the headline facts match the current state of the repo. The previous version still said "20+ agents across 8 domains" and an inexhaustive MCP / governance list.

## Changes

- Agent count: `20+ across 8 domains` → **26 across 9 domains** (lists the actual nine: coding, communication, education, engineering, guardian, infrastructure, marketing, operations, product).
- Skills line: now states **8 reusable skills** and adds the security family (PII Scan, HMAC Sign) that wasn't represented.
- MCP line: expanded to call out the **17 active protocols**, including all twelve Google Workspace services, Slack, GitHub, n8n, web search, and the logging-mcp (Loki/Grafana) addition.
- Governance line: added the **4D AI Fluency Framework** alongside Phase 0 Security and Gartner AI TRiSM.
- New bullet for **value lenses and operating profiles**, since those are first-class concepts in the repo now.
- Orchestrator section: noted the **Gemini 2.5 Flash** canonical baseline and the **Node.js 24** technical baseline.
- Getting Started: added entry points for **cross-platform onboarding** (`docs/examples/cross-platform-kickstart.md`) and **contributors** (`CONTRIBUTING.md`).

## Why This Change

Builder / Buyer-path audience impact — the README is the first surface a prospective fork/clone reader hits. Stale counts and missing concepts (4D, value lenses, logging-mcp) understate what the repo ships today.

## Validation

- [x] Counts cross-checked against `find agents/ -name '*.md' | wc -l` (26), `ls agents/` (9 domains), `find skills/ -name '*.md' -not -name 'SKILL_TEMPLATE.md'` (8), `ls mcp-protocols/` (17).
- [x] No generated artifacts touched — README is hand-authored.
- [x] No code or tests changed.

## Audience Impact

- [x] Client / Buyer path (public README accuracy)
- [x] Builder / Accelerator path (Getting Started entries)
- [ ] Internal repo contract only

## Security and Secrets

- [x] No real secrets were added to the repo
- [x] Fetch-on-Demand patterns preserved (not touched by this change)
- [x] `.env.template` / `.env.example` files not modified

## Docs and Generated Outputs

- [x] README updated to reflect current behavior
- [x] Generated outputs unaffected (no inputs changed)
- [x] Golden fixtures unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_013f1RzjoDMuE5DZpKpaJum5)_