### PR TITLE
docs(onboarding): friendlier per-OS entry points and generated-file guardrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,10 @@
+<!-- GENERATED FILE — DO NOT EDIT.
+     This file is built by `node scripts/generate_all.js` from templates/context/CLAUDE.template.md
+     plus the active agents/, skills/, mcp-protocols/, value-lenses/, operating-profiles/, AGENTS.md, and mcp.config.json.
+     • To change the static prose, edit templates/context/CLAUDE.template.md.
+     • To change the injected sections (agent index, skills, MCP protocols, value lenses, global mandates),
+       edit the upstream source, then re-run `node scripts/generate_all.js`.
+     Manual edits to CLAUDE.md are overwritten on the next run and will fail the CI golden-fixture / determinism checks. -->
 # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
@@ -10,11 +17,9 @@ Project NoéMI also serves as the **public reference architecture** for NewPush'
 ## Key Commands
 
 ```bash
-# Generate GEMINI.md from template + active MCP protocols
-node scripts/generate_gemini.js
-
-# Generate CLAUDE.md from template + active MCP protocols
-node scripts/generate_claude.js
+# Regenerate BOTH GEMINI.md and CLAUDE.md from templates + active agents/skills/MCP protocols
+node scripts/generate_all.js   # alias: npm run generate
+# (generate_gemini.js and generate_claude.js are thin shims that both forward to generate_all.js)
 
 # Verify environment prerequisites (Docker, Gemini CLI, etc.)
 bash scripts/verify-env.sh

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,3 +1,9 @@
+<!-- GENERATED FILE — DO NOT EDIT.
+     This file is built by `node scripts/generate_all.js` from templates/context/GEMINI.template.md
+     plus the active agents/, skills/, mcp-protocols/, value-lenses/, operating-profiles/, AGENTS.md, and mcp.config.json.
+     • To change the static prose, edit templates/context/GEMINI.template.md.
+     • To change the injected sections, edit the upstream source, then re-run `node scripts/generate_all.js`.
+     Manual edits to GEMINI.md are overwritten on the next run and will fail the CI golden-fixture / determinism checks. -->
 # Project NoéMI Context
 
 You are operating within **Project NoéMI**, the public reference architecture and agent specification library used to define governable AI personas, workflows, and MCP integrations.

--- a/README.md
+++ b/README.md
@@ -190,9 +190,11 @@ All reference tooling and Docker images use **Node.js 24** as the technical base
 → [docs/examples/zero-to-first-agent.md](docs/examples/zero-to-first-agent.md)
 (Building your first Virtual Coworker)
 
-**Onboarding by Platform**
-→ [docs/examples/cross-platform-kickstart.md](docs/examples/cross-platform-kickstart.md)
-(macOS / Linux, Windows, and ChromeOS kickstart paths)
+**Onboarding by Platform** — go straight to the guide for your machine and get one safe, read-only AI win in ~15 minutes:
+→ [macOS / Linux](docs/examples/macos-linux-kickstart.md)
+&nbsp;·&nbsp; [Windows](docs/examples/windows-kickstart.md)
+&nbsp;·&nbsp; [ChromeOS](docs/examples/chromeos-kickstart.md)
+(Not sure, or want the concepts first? Use the [platform chooser](docs/examples/cross-platform-kickstart.md) or [zero-to-first-agent.md](docs/examples/zero-to-first-agent.md).)
 
 **Contributors**
 → [CONTRIBUTING.md](CONTRIBUTING.md)
@@ -201,6 +203,10 @@ All reference tooling and Docker images use **Node.js 24** as the technical base
 **Visual Orientation**
 → [docs/visuals/README.md](docs/visuals/README.md)
 (System maps and flows)
+
+---
+
+> **Working in this repo?** `CLAUDE.md` and `GEMINI.md` are **generated** context files — built from `templates/context/` plus the active agents, skills, and MCP protocols. After changing any of those sources, run `node scripts/generate_all.js` to refresh them. Don't hand-edit `CLAUDE.md` or `GEMINI.md`: regeneration overwrites manual changes, and CI checks them against golden fixtures.
 
 ---
 

--- a/docs/examples/chromeos-kickstart.md
+++ b/docs/examples/chromeos-kickstart.md
@@ -27,7 +27,7 @@ If your Chromebook is managed and Linux is disabled, stop here and use another m
 ## Step 2: Clone The Repository In The Linux Terminal
 
 ```bash
-git clone https://github.com/newpush/agents.git
+git clone https://github.com/project-noemi/agents.git
 cd agents
 ```
 
@@ -54,6 +54,8 @@ node scripts/generate_all.js
 npm run validate
 ```
 
+> **Heads up:** `CLAUDE.md` and `GEMINI.md` are *generated* by this command — don't hand-edit them. To change what your client sees, edit the sources under `templates/context/` and re-run `node scripts/generate_all.js`. Manual edits get overwritten, and CI checks these files against golden fixtures.
+
 ## Step 5: Get One Safe First Win
 
 Use one read-only prompt against the local repository first.
@@ -66,9 +68,13 @@ gemini -p GEMINI.md "List the engineering agents in this repository and summariz
 
 ### Claude Code
 
-Open the repository in Claude Code and ask:
+From the repository root, launch Claude Code with the same task:
 
-> Read `CLAUDE.md`, inspect the engineering agents in this repository, and summarize what each one does in one sentence. Then tell me which one would help first with PR review.
+```bash
+claude "Read CLAUDE.md, inspect the engineering agents in this repository, and summarize what each one does in one sentence. Then tell me which one would help first with PR review."
+```
+
+(Prefer to drive it interactively? Just run `claude` in the repo and paste the same request.)
 
 ### OpenAI Codex
 
@@ -78,14 +84,19 @@ Open the repository in Codex and ask:
 
 ## Step 6: Add Secret Injection Only When You Need Business Systems
 
-When you move beyond local read-only work, wrap the client at launch:
+When you move beyond local read-only work, wrap the client at launch with whichever SecretOps CLI your team uses — **pick one**, don't run both:
 
 ```bash
+# Infisical
 infisical run --env=dev -- gemini
+```
+
+```bash
+# 1Password (.env.template maps env-var names to op:// secret references — no real secrets on disk)
 op run --env-file=.env.template -- gemini
 ```
 
-The same pattern applies to Claude Code and Codex.
+The same pattern applies to Claude Code and Codex (swap `gemini` for `claude` or `codex`).
 
 ## ChromeOS Notes
 

--- a/docs/examples/macos-linux-kickstart.md
+++ b/docs/examples/macos-linux-kickstart.md
@@ -22,7 +22,7 @@ If your machine is ChromeOS, use [`chromeos-kickstart.md`](chromeos-kickstart.md
 Open Terminal and run:
 
 ```bash
-git clone https://github.com/newpush/agents.git
+git clone https://github.com/project-noemi/agents.git
 cd agents
 ```
 
@@ -40,6 +40,12 @@ This checks:
 - whether Docker is present, without requiring it yet
 - whether Infisical CLI or 1Password CLI is available for later Fetch-on-Demand work
 
+Already know you want to start with **Claude Code**? Target it directly:
+
+```bash
+bash scripts/verify-env.sh --mode=claude
+```
+
 ## Step 3: Generate The Current Agent Context
 
 ```bash
@@ -48,6 +54,8 @@ npm run validate
 ```
 
 This gives you the current generated context files and confirms the repository contracts are healthy.
+
+> **Heads up:** `CLAUDE.md` and `GEMINI.md` are *generated* by this command — don't hand-edit them. To change what your client sees, edit the sources under `templates/context/` and re-run `node scripts/generate_all.js`. Manual edits get overwritten, and CI checks these files against golden fixtures.
 
 ## Step 4: Get One Safe First Win
 
@@ -61,9 +69,13 @@ gemini -p GEMINI.md "List the engineering agents in this repository and summariz
 
 ### Claude Code
 
-Open the repository in Claude Code and ask:
+From the repository root, launch Claude Code with the same task:
 
-> Read `CLAUDE.md`, inspect the engineering agents in this repository, and summarize what each one does in one sentence. Then tell me which one would help first with PR review.
+```bash
+claude "Read CLAUDE.md, inspect the engineering agents in this repository, and summarize what each one does in one sentence. Then tell me which one would help first with PR review."
+```
+
+(Prefer to drive it interactively? Just run `claude` in the repo and paste the same request.)
 
 ### OpenAI Codex
 
@@ -75,14 +87,19 @@ Open the repository in Codex and ask:
 
 Do not start by pasting secrets into files.
 
-When you move beyond local read-only work, wrap the client at launch:
+When you move beyond local read-only work, wrap the client at launch with whichever SecretOps CLI your team uses — **pick one**, don't run both:
 
 ```bash
+# Infisical
 infisical run --env=dev -- gemini
+```
+
+```bash
+# 1Password (.env.template maps env-var names to op:// secret references — no real secrets on disk)
 op run --env-file=.env.template -- gemini
 ```
 
-The same pattern applies to Claude Code and Codex.
+The same pattern applies to Claude Code and Codex (swap `gemini` for `claude` or `codex`).
 
 ## Step 6: Know What Comes Later
 

--- a/docs/examples/windows-kickstart.md
+++ b/docs/examples/windows-kickstart.md
@@ -14,6 +14,7 @@ This is the right starting point if:
 
 - Git
 - Node.js 24 or newer
+  - Install with `winget install OpenJS.NodeJS.LTS`, or use [nvm-windows](https://github.com/coreybutler/nvm-windows) to manage versions. Confirm with `node -v` showing `v24` or higher.
 - one supported local AI client: Gemini CLI, Claude Code, or OpenAI Codex
 - PowerShell
   - `powershell` works on stock Windows
@@ -24,7 +25,7 @@ This is the right starting point if:
 Open PowerShell and run:
 
 ```powershell
-git clone https://github.com/newpush/agents.git
+git clone https://github.com/project-noemi/agents.git
 cd agents
 ```
 
@@ -50,6 +51,12 @@ This checks:
 - whether Docker is present, without requiring it yet
 - whether Infisical CLI or 1Password CLI is available for later Fetch-on-Demand work
 
+Already know you want to start with **Claude Code**? Target it directly (swap `builder` for `claude`):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/verify-env.ps1 -Mode claude
+```
+
 ## Step 3: Generate The Current Agent Context
 
 ```powershell
@@ -58,6 +65,8 @@ npm run validate
 ```
 
 This gives you the current generated context files and confirms the repository contracts are healthy.
+
+> **Heads up:** `CLAUDE.md` and `GEMINI.md` are *generated* by this command — don't hand-edit them. To change what your client sees, edit the sources under `templates/context/` and re-run `node scripts/generate_all.js`. Manual edits get overwritten, and CI checks these files against golden fixtures.
 
 ## Step 4: Get One Safe First Win
 
@@ -71,9 +80,15 @@ gemini -p GEMINI.md "List the engineering agents in this repository and summariz
 
 ### Claude Code
 
-Open the repository in Claude Code and ask:
+From the repository root, launch Claude Code with the same task:
 
-> Read `CLAUDE.md`, inspect the engineering agents in this repository, and summarize what each one does in one sentence. Then tell me which one would help first with PR review.
+```powershell
+claude "Read CLAUDE.md, inspect the engineering agents in this repository, and summarize what each one does in one sentence. Then tell me which one would help first with PR review."
+```
+
+(Prefer to drive it interactively? Just run `claude` in the repo and paste the same request.)
+
+New to Claude Code, or only know the desktop app? See [`../tool-usages/claude-code-local-workspace.md`](../tool-usages/claude-code-local-workspace.md) for the difference between the CLI and the app.
 
 ### OpenAI Codex
 
@@ -85,14 +100,19 @@ Open the repository in Codex and ask:
 
 Do not start by pasting secrets into files.
 
-When you move beyond local read-only work, wrap the client at launch:
+When you move beyond local read-only work, wrap the client at launch with whichever SecretOps CLI your team uses — **pick one**, don't run both:
 
 ```powershell
+# Infisical
 infisical run --env=dev -- gemini
+```
+
+```powershell
+# 1Password (.env.template maps env-var names to op:// secret references — no real secrets on disk)
 op run --env-file=.env.template -- gemini
 ```
 
-The same pattern applies to Claude Code and Codex.
+The same pattern applies to Claude Code and Codex (swap `gemini` for `claude` or `codex`).
 
 ## Step 6: Know What Comes Later
 
@@ -107,6 +127,8 @@ After this local-first success:
 
 - You do **not** need WSL for the first beginner path.
 - You do **not** need Docker Desktop for the first beginner path.
+- Run every command in this guide in **PowerShell** — not Git Bash or WSL. Forward slashes in script paths (`scripts/verify-env.ps1`) work fine in PowerShell; you do not need to convert them to backslashes.
+- `-ExecutionPolicy Bypass` is needed only because Windows blocks unsigned local scripts by default. It applies to that single command and does **not** change your system-wide policy.
 - If you later move into Docker homes, use [`builder-first-30-minutes.md`](builder-first-30-minutes.md) and install Docker Desktop at that stage.
 
 ## Outcome

--- a/docs/examples/zero-to-first-agent.md
+++ b/docs/examples/zero-to-first-agent.md
@@ -53,7 +53,7 @@ From the repository root, run the preflight mode from your matching workstation 
 - `claude` if Claude Code is your first client
 - `codex` if OpenAI Codex is your first client
 
-Your workstation guide gives you the exact shell command for that machine architecture.
+Your workstation guide shows the exact `builder` command for your machine; substitute the client mode name (`gemini`, `claude`, or `codex`) in the same command to target one specific client.
 
 This verifies Git, Node.js, and the local client you actually plan to use. It does **not** require Docker for the beginner path.
 
@@ -71,6 +71,8 @@ This gives you the latest:
 
 and confirms the repo contracts are healthy before you ask the client to do anything with them.
 
+> **Heads up:** `CLAUDE.md` and `GEMINI.md` are *generated* by this command — don't hand-edit them. To change what your client sees, edit the sources under `templates/context/` (plus the agents, skills, and protocols they include) and re-run `node scripts/generate_all.js`. Manual edits are overwritten on the next run, and CI checks these files against golden fixtures.
+
 ## Step 4: Get One Safe First Win
 
 Use a local, read-only task that does not touch external systems.
@@ -87,9 +89,13 @@ gemini -p GEMINI.md "List the engineering agents in this repository and summariz
 
 ### Claude Code
 
-Open the repository in Claude Code and ask:
+From the repository root, launch Claude Code with the same task:
 
-> Read `CLAUDE.md`, inspect the engineering agents in this repository, and summarize what each one does in one sentence. Then tell me which one would help first with PR review.
+```bash
+claude "Read CLAUDE.md, inspect the engineering agents in this repository, and summarize what each one does in one sentence. Then tell me which one would help first with PR review."
+```
+
+(Prefer to drive it interactively? Just run `claude` in the repo and paste the same request.)
 
 ### OpenAI Codex
 

--- a/templates/context/CLAUDE.template.md
+++ b/templates/context/CLAUDE.template.md
@@ -1,3 +1,10 @@
+<!-- GENERATED FILE — DO NOT EDIT.
+     This file is built by `node scripts/generate_all.js` from templates/context/CLAUDE.template.md
+     plus the active agents/, skills/, mcp-protocols/, value-lenses/, operating-profiles/, AGENTS.md, and mcp.config.json.
+     • To change the static prose, edit templates/context/CLAUDE.template.md.
+     • To change the injected sections (agent index, skills, MCP protocols, value lenses, global mandates),
+       edit the upstream source, then re-run `node scripts/generate_all.js`.
+     Manual edits to CLAUDE.md are overwritten on the next run and will fail the CI golden-fixture / determinism checks. -->
 # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
@@ -10,11 +17,9 @@ Project NoéMI also serves as the **public reference architecture** for NewPush'
 ## Key Commands
 
 ```bash
-# Generate GEMINI.md from template + active MCP protocols
-node scripts/generate_gemini.js
-
-# Generate CLAUDE.md from template + active MCP protocols
-node scripts/generate_claude.js
+# Regenerate BOTH GEMINI.md and CLAUDE.md from templates + active agents/skills/MCP protocols
+node scripts/generate_all.js   # alias: npm run generate
+# (generate_gemini.js and generate_claude.js are thin shims that both forward to generate_all.js)
 
 # Verify environment prerequisites (Docker, Gemini CLI, etc.)
 bash scripts/verify-env.sh

--- a/templates/context/GEMINI.template.md
+++ b/templates/context/GEMINI.template.md
@@ -1,3 +1,9 @@
+<!-- GENERATED FILE — DO NOT EDIT.
+     This file is built by `node scripts/generate_all.js` from templates/context/GEMINI.template.md
+     plus the active agents/, skills/, mcp-protocols/, value-lenses/, operating-profiles/, AGENTS.md, and mcp.config.json.
+     • To change the static prose, edit templates/context/GEMINI.template.md.
+     • To change the injected sections, edit the upstream source, then re-run `node scripts/generate_all.js`.
+     Manual edits to GEMINI.md are overwritten on the next run and will fail the CI golden-fixture / determinism checks. -->
 # Project NoéMI Context
 
 You are operating within **Project NoéMI**, the public reference architecture and agent specification library used to define governable AI personas, workflows, and MCP integrations.


### PR DESCRIPTION
## What & why
Improves the new-user entry experience (macOS / Windows / ChromeOS) and closes two footguns spotted during an onboarding review.

### README
- "Onboarding by Platform" now links **directly** to the per-OS kickstart guides instead of one generic hop.
- Adds a note that `CLAUDE.md` / `GEMINI.md` are **generated** (run `node scripts/generate_all.js`; don't hand-edit).

### Kickstart guides (zero-to-first + macOS/Linux, Windows, ChromeOS)
- A concrete copy-paste **`claude "..."`** first-win command, at parity with the existing Gemini one-liner (was prose-only).
- Optional `--mode=claude` / `-Mode claude` preflight for Claude-first users.
- "This file is generated — regenerate, don't hand-edit" note at the generate step.
- SecretOps wrappers reframed as **pick one** (Infisical *or* 1Password), with `.env.template` explained.

### Windows-specific friendliness
- Node 24 install guidance (`winget` / nvm-windows).
- Explains `-ExecutionPolicy Bypass` is single-command scoped; use PowerShell (not Git Bash/WSL).
- Pointer to the Claude Code CLI-vs-app workspace doc.

### Correctness fixes
- Clone URL `newpush/agents` → **`project-noemi/agents`** (matches `origin` and the README's own upstream-sync links) in the macOS, Windows, and ChromeOS guides.
- **Generated-file banner baked into `templates/context/{CLAUDE,GEMINI}.template.md`** above the H1, so it renders in the generated `CLAUDE.md`/`GEMINI.md` — the file a new client user is most likely to open and hand-edit.
- Corrected the template "Key Commands" block to the single canonical `node scripts/generate_all.js` (the per-file `generate_{gemini,claude}.js` are thin shims that both forward to it).

## Notes
- Targets `develop` per the branching model in CONTRIBUTING.md.
- `CLAUDE.md` / `GEMINI.md` were **regenerated** from the templates (not hand-edited).
- All asserted strings in `tests/examples-smoke.test.js` preserved.

## Validation
`npm run validate` → **44/44 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)