### PR TITLE
fix(scripts): auto-detect repo in setup-branch-protection

### DIFF
--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -12,7 +12,8 @@
 #     re-run the moment the plan is upgraded.
 #
 # Usage:
-#   REPO=owner/repo bash scripts/setup-branch-protection.sh
+#   bash scripts/setup-branch-protection.sh              # auto-detects the repo
+#   REPO=owner/repo bash scripts/setup-branch-protection.sh   # explicit override
 #
 # The status-check `contexts` below must match the check-run names GitHub
 # surfaces for each workflow job. If a check name changes, update the
@@ -20,7 +21,15 @@
 
 set -euo pipefail
 
-REPO="${REPO:-owner/repo}"
+# Resolve the target repo. Prefer an explicit REPO override, otherwise derive it
+# from the checkout so the script is frictionless in forks (no hardcoded org).
+REPO="${REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)}"
+
+if [[ -z "$REPO" ]]; then
+  echo "✖ Could not determine the target repository." >&2
+  echo "  Run inside a GitHub checkout with 'gh' authenticated, or set REPO=owner/repo." >&2
+  exit 1
+fi
 
 apply_protection() {
   local branch="$1"


### PR DESCRIPTION
## Summary

`scripts/setup-branch-protection.sh` defaulted `REPO` to the literal placeholder `owner/repo`. Running it as documented (`bash scripts/setup-branch-protection.sh`) therefore hit a confusing 404 rather than applying anything — the caller had to know to pass `REPO=` explicitly.

The script now derives the repo from the checkout via `gh repo view --json nameWithOwner`, keeps `REPO=` as an explicit override, and exits with an actionable message when neither source resolves.

## Why

CLAUDE.md, Script Parameterization: *"Scripts intended for cross-organization use ... must use environment variables or CLI flags for organization-specific values ... rather than hardcoded placeholders to ensure frictionless forking."*

## Verification

- `bash -n` syntax check passes.
- Re-ran the script with auto-detection against `project-noemi/agents`; protection applied idempotently to both `main` and `develop`.
- Confirmed both required status-check contexts match real check-run names on a PR into main: `check-source-branch` and `Audit, Generate, and Fast Tests`.

## Related

The repo default branch was switched from `main` to `develop` alongside this, so new PRs target the integration branch by default and no longer trip the `check-source-branch` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)