### PR TITLE
feat(governance): reviewer identity and code-owner gate

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,6 +19,15 @@ GITHUB_PERSONAL_ACCESS_TOKEN=op://noemi/github/token
 # docs/MACHINE_IDENTITY.md. Consumed by scripts/agent-gh.sh.
 AGENT_GH_TOKEN=op://noemi/github-agent/token
 AGENT_GH_EXPECTED_LOGIN=noemi-agent
+
+# Reviewer machine identity — posts three-gate review findings. Deliberately
+# scoped to Contents:read so it cannot author code. Separate from the producer
+# identity above: same-account review is blocked by GitHub and destroys
+# attribution. See docs/AI_REVIEW_GOVERNANCE.md.
+REVIEWER_GH_TOKEN=op://noemi/github-reviewer/token
+REVIEWER_GH_EXPECTED_LOGIN=noemi-reviewer
+# The reviewer also consumes GEMINI_API_KEY (declared above). The model itself
+# is resolved at runtime by scripts/resolve-gemini-model.js, never pinned here.
 SLACK_BOT_TOKEN=op://noemi/slack/bot-token
 GEMINI_API_KEY=op://noemi/google/gemini-api-key
 OPENAI_API_KEY=op://noemi/openai/api-key

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,35 @@
 # The merge gate enforces the absolute develop-only rule (Requirement §7) and was
 # repeatedly edited by automation during 2026-07 to unblock its own direct-to-main PRs;
 # changes to it (and to this file) must be approved by the repository owner.
+
+# --- Default owner -----------------------------------------------------------
+# Every path requires a human code-owner approval. This exists so that an
+# approval from a reviewing AGENT cannot, on its own, satisfy the merge gate.
+#
+# GitHub grants no permission that separates "may comment on a PR" from "may
+# approve a PR" — both are `Pull requests: write`. So the phase-1 rule that
+# `noemi-reviewer` posts findings but never approves cannot be enforced by token
+# scoping. This line enforces it structurally instead: a reviewer approval never
+# satisfies a code-owner requirement, because the reviewer is not an owner.
+#
+# See docs/AI_REVIEW_GOVERNANCE.md.
+#
+# ⚠ CONSEQUENCE: with `require_code_owner_reviews` enabled, a PR authored by the
+# sole owner below cannot be approved by that owner (GitHub blocks
+# self-approval) and will need either a second owner or an admin bypass. Since
+# the fleet direction is bot-authored PRs, that case should be rare — but if
+# human-authored PRs remain common, add co-owners here:
+#
+#     * @WSwarm @second-admin @third-admin
+#
+# Any ONE listed owner satisfies the requirement, so co-owners remove the
+# self-approval deadlock without weakening the gate against agent approvals.
+* @WSwarm
+
+# --- Carve-out: repository owner only ----------------------------------------
+# These paths stay restricted to the owner even if co-owners are added above.
+# Later rules win in CODEOWNERS, so these override the default.
 /.github/workflows/require-develop-source.yml @WSwarm
 /.github/CODEOWNERS @WSwarm
+/docs/MACHINE_IDENTITY.md @WSwarm
+/docs/AI_REVIEW_GOVERNANCE.md @WSwarm

--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,5 @@
+{
+    "workspaceId": "61ee586e-5cf8-4b7b-a3af-89c5a78437dc",
+    "defaultEnvironment": "",
+    "gitBranchToEnvironmentMapping": null
+}

--- a/docs/AI_REVIEW_GOVERNANCE.md
+++ b/docs/AI_REVIEW_GOVERNANCE.md
@@ -204,6 +204,41 @@ Every review records:
 Overrides are the highest-value records in the system. They are where human
 judgment enters, and the only place the framework can be observed adapting.
 
+## Rollout status
+
+Current as of 2026-08-02. Update this table when an item changes — it is the
+handoff point for anyone picking the work up.
+
+| Item | State | Blocked on |
+|---|---|---|
+| `noemi-agent` producer identity | ✅ provisioned, verified | — |
+| Bot-authored PR loop (author → human approve → merge, no bypass) | ✅ proven on #340, #341 | — |
+| `scripts/agent-gh.sh` wrapper + identity guard | ✅ working | — |
+| `scripts/resolve-gemini-model.js` | ✅ working, tested offline | live API call unverified |
+| Reviewer persona + governance framework | ✅ merged (#341) | — |
+| `.github/workflows/ai-review.yml` | ⚠️ skips cleanly; runner not implemented | `GEMINI_API_KEY` + runner |
+| `noemi-reviewer` identity | ❌ not provisioned | human: account, PAT, vault |
+| `GEMINI_API_KEY` repo secret | ❌ not set | human |
+| CODEOWNERS + `require_code_owner_reviews` | ⚠️ in repo, **not applied** | run `scripts/setup-branch-protection.sh` |
+| Three-gate review runner | ❌ not written | follow-up PR |
+| `enforce_admins: true` | ❌ still `false` on both branches | phase 1 operating cleanly |
+| `noemi-agent` effective permission | ⚠️ `maintain`, not `push` | remove from `developers` team |
+
+### Applying the code-owner gate
+
+The CODEOWNERS file and the `require_code_owner_reviews: true` payload in
+`scripts/setup-branch-protection.sh` are **inert until the script is run**:
+
+```bash
+bash scripts/setup-branch-protection.sh
+```
+
+Before running it, decide the co-owner question. With a single owner and
+`require_code_owner_reviews` enabled, a PR authored by that owner cannot be
+approved by them — GitHub blocks self-approval — and will need a second owner or
+an admin bypass. Bot-authored PRs are unaffected. See the comments in
+`.github/CODEOWNERS`.
+
 ## Audit Log
 
 ```json

--- a/docs/MACHINE_IDENTITY.md
+++ b/docs/MACHINE_IDENTITY.md
@@ -48,6 +48,83 @@ identities have named owners (`docs/phase-zero-assessment/weighted-assessment-sp
 | **May approve PRs?** | **No.** Approval is a human-only act |
 | **May merge PRs?** | **No.** Merge follows human approval |
 
+### Reviewer identity — `noemi-reviewer`
+
+Separation of duties needs two identities, not one. `noemi-agent` produces;
+`noemi-reviewer` reviews. A shared account fails mechanically (GitHub blocks
+self-approval) and destroys attribution even where it does not fail.
+
+| Field | Value |
+|---|---|
+| **Identity** | `noemi-reviewer` (GitHub user, machine account) |
+| **Status** | **Not yet provisioned** — steps 1–3 below are human-only |
+| **Purpose** | Post three-gate review findings on agent-authored PRs |
+| **Model family** | Gemini — deliberately *not* Claude (see below) |
+| **Named owner** | `@WSwarm` (Balazs Nagy) |
+| **Credential store** | Infisical — secret `REVIEWER_GH_TOKEN` |
+| **Repo permission** | `read` (pull) + `Pull requests: write` |
+| **Rotation** | 90 days, or immediately on suspected exposure |
+| **May author code?** | **No.** `Contents: read` only — enforced by token |
+| **May approve PRs?** | **No** in phase 1 — enforced by CODEOWNERS, not by token |
+
+Cross-model is the point: two instances of one model share training and blind
+spots, so a misreading made while writing is likely repeated while reviewing.
+See `docs/AI_REVIEW_GOVERNANCE.md`.
+
+#### Least-privilege scoping
+
+| Permission | Level | Why |
+|---|---|---|
+| Contents | **Read** | Read the diff. Not write — a reviewer that can push can fix what it reviews, collapsing the separation |
+| Pull requests | Read and write | Post review comments |
+| Metadata | Read | Mandatory for fine-grained tokens |
+
+`Contents: read` is a real, token-enforced boundary: this identity is
+structurally incapable of authoring code.
+
+#### The comment-vs-approve gap
+
+GitHub has **no permission distinguishing "may comment on a PR" from "may
+approve a PR."** Both are `Pull requests: write`. So the phase-1 rule that the
+reviewer posts findings but never approves cannot be enforced by token scoping.
+
+It is enforced structurally instead, by `.github/CODEOWNERS` plus
+`require_code_owner_reviews`: a reviewer approval never satisfies a code-owner
+requirement, because the reviewer is not an owner. Without that, a
+`noemi-reviewer` approval would satisfy `required_approving_review_count: 1` on
+its own and phase 1 would silently behave as phase 2.
+
+#### Provisioning
+
+Same shape as `noemi-agent` above — register the account with 2FA, mint a
+fine-grained PAT **while signed in as `noemi-reviewer`** scoped to
+`project-noemi/agents` with exactly the three permissions above, then:
+
+```bash
+infisical secrets set REVIEWER_GH_TOKEN="<paste-in-your-terminal>" --env=dev
+
+gh api --method PUT repos/project-noemi/agents/collaborators/noemi-reviewer \
+  -f permission=pull
+```
+
+Watch for the org approval hold that delayed `noemi-agent`: a fine-grained token
+against an org resource owner stays read-only until an owner approves it at
+Settings → Third-party Access → Personal access tokens.
+
+Verify without provisioning a new wrapper — `scripts/agent-gh.sh` is already
+parameterized:
+
+```bash
+AGENT_GH_TOKEN_SECRET=REVIEWER_GH_TOKEN \
+AGENT_GH_EXPECTED_LOGIN=noemi-reviewer \
+bash scripts/agent-gh.sh whoami        # expect: noemi-reviewer (User)
+```
+
+⚠ `$AGENT_GH_TOKEN` takes precedence over `AGENT_GH_TOKEN_SECRET` in the
+resolver, so a producer token already in the environment wins silently. The
+`AGENT_GH_EXPECTED_LOGIN` guard catches this and refuses rather than acting
+under the wrong identity — always set it.
+
 ### Effective-permission caveat
 
 The direct collaborator grant is `push` (write), but GitHub resolves a user's

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -63,7 +63,7 @@ MAIN_PAYLOAD=$(cat <<'JSON'
   "required_pull_request_reviews": {
     "required_approving_review_count": 1,
     "dismiss_stale_reviews": true,
-    "require_code_owner_reviews": false
+    "require_code_owner_reviews": true
   },
   "restrictions": null,
   "allow_force_pushes": false,
@@ -86,7 +86,7 @@ DEVELOP_PAYLOAD=$(cat <<'JSON'
   "required_pull_request_reviews": {
     "required_approving_review_count": 1,
     "dismiss_stale_reviews": true,
-    "require_code_owner_reviews": false
+    "require_code_owner_reviews": true
   },
   "restrictions": null,
   "allow_force_pushes": false,


### PR DESCRIPTION
## Premise

#341 established that `noemi-reviewer` posts findings but never approves. This PR makes that rule enforceable, and registers the identity so it can be provisioned.

## The gap this closes

GitHub grants **no permission separating "may comment on a PR" from "may approve a PR."** Both are `Pull requests: write`. The reviewer needs write to comment, so token scoping cannot stop it approving.

That is not academic. `develop` requires 1 approval with `require_code_owner_reviews: false`, so a `noemi-reviewer` approval would satisfy the gate on its own — phase 1 would silently behave as phase 2, one misconfigured workflow step away.

**Fix:** a default `* @WSwarm` code-owner plus `require_code_owner_reviews: true`. A reviewer approval can then never satisfy the gate, because the reviewer is not an owner. Structural, not policy.

## What's here

| File | Change |
|---|---|
| `.github/CODEOWNERS` | Default human owner; carve-out extended to the identity register and governance framework |
| `scripts/setup-branch-protection.sh` | `require_code_owner_reviews: true` on both branches |
| `docs/MACHINE_IDENTITY.md` | `noemi-reviewer` registered, scoped, and its provisioning runbook |
| `docs/AI_REVIEW_GOVERNANCE.md` | Rollout status table — the handoff point |
| `.env.template` | `REVIEWER_GH_TOKEN` / `REVIEWER_GH_EXPECTED_LOGIN` |
| `.infisical.json` | Project link so others resolve the same vault workspace |

## Reviewer scoping

`Contents: **read**`, not write. That one is genuinely token-enforced: `noemi-reviewer` is structurally incapable of authoring code, so it cannot fix what it reviews.

## Two things you must decide before this takes effect

**1. Nothing changes on merge.** The `require_code_owner_reviews: true` payload is inert until someone runs `bash scripts/setup-branch-protection.sh`. Merging this PR does not alter branch protection — applying it is a separate, deliberate act.

**2. The single-owner deadlock.** With `* @WSwarm` as sole owner and code-owner reviews enforced, **a PR you author cannot be approved by you** — GitHub blocks self-approval — so it needs a second owner or an admin bypass. Bot-authored PRs are unaffected, and the fleet direction is bot-authored, so this should be rare. But #339 is human-authored and open right now, so it is not hypothetical.

The one-line fix is co-owners (`* @WSwarm @second @third`); any one listed owner satisfies the requirement, which removes the deadlock without weakening the gate against agent approvals. I did not volunteer anyone — that is a people decision, so it is documented inline in CODEOWNERS rather than decided here.

## Sync note

This PR also carries `.infisical.json`, previously untracked, so the remote is a complete picture and others can pick up where this left off. It contains a workspace ID only — no credential material. The rollout status table in the governance doc lists every outstanding item and what each is blocked on.

## Verification

- `npm test` — 44/44 pass.
- `node scripts/audit-repo.js` — passes, including the merge-gate invariant.
- `node scripts/generate_all.js` — no drift.
- `bash -n scripts/setup-branch-protection.sh` — clean.

## Reviewer

Touches CODEOWNERS, the identity register, and the governance framework — three carve-out paths. **Human review required by its own rules.**