### PR TITLE
fix(scripts): resolve secrets without a local Infisical project link

### DIFF
--- a/docs/MACHINE_IDENTITY.md
+++ b/docs/MACHINE_IDENTITY.md
@@ -258,6 +258,18 @@ Verify it resolves without printing it:
 bash scripts/agent-gh.sh whoami     # expect: noemi-agent (User)
 ```
 
+`.infisical.json` is gitignored (org-specific — each clone runs `infisical
+init`), so a fresh clone or a CI job has no project link and secret lookup fails.
+Set the project ID explicitly where running `init` is not practical:
+
+```bash
+export INFISICAL_PROJECT_ID=<your-workspace-id>
+```
+
+A project ID is not a secret. In GitHub Actions it belongs in **Variables**, not
+Secrets — putting non-secrets in Secrets makes it harder to see what genuinely
+needs protecting.
+
 ### 4. Grant repository access
 
 Run as a repo admin:

--- a/docs/examples/cross-model-review-setup.md
+++ b/docs/examples/cross-model-review-setup.md
@@ -415,7 +415,8 @@ editing the merge gate to unblock its own pull requests.
 |---|---|---|
 | `403 Resource not accessible` on writes | Org approval pending, or permission not set to Read **and write** | Check the org PAT-requests page (Part 3) |
 | `Token resolves to 'yourname', expected 'noemi-agent'` | Your own token is in the environment | The guard is working — unset `AGENT_GH_TOKEN` |
-| `Could not resolve the machine-identity token` | Secret missing, or repo not linked to Infisical | Run `infisical init`, then re-store the secret |
+| `Could not resolve the machine-identity token` | Secret missing from the vault | Re-store it (Part 2 / Part 3) |
+| `Infisical is installed but no project link was found` | `.infisical.json` is gitignored, so a fresh clone has none | `infisical init`, or set `INFISICAL_PROJECT_ID` for CI |
 | Workflow skips with a notice | `GEMINI_API_KEY` not reachable | Complete Part 4 |
 | `No available model meets the floor` | Your key lacks access to strong models | Check your tier; the failure is intentional |
 | Reviewer's write probe **succeeds** | Token over-scoped | Set Contents to Read-only and re-probe |

--- a/scripts/agent-gh.sh
+++ b/scripts/agent-gh.sh
@@ -39,16 +39,30 @@ OP_REF="${AGENT_GH_TOKEN_REF:-op://noemi/github-agent/token}"
 
 log() { printf '%s\n' "$*" >&2; }
 
+# Whether an Infisical project link is reachable at all. `.infisical.json` is
+# gitignored (org-specific; each clone runs `infisical init`), so a fresh clone
+# has no link and every `infisical secrets get` fails with a message about
+# projects that reads like a provisioning problem. Accept an explicit project ID
+# so CI and fresh clones can resolve secrets without the file.
+INFISICAL_PROJECT="${INFISICAL_PROJECT_ID:-}"
+
+infisical_available() {
+  command -v infisical >/dev/null 2>&1 || return 1
+  [[ -n "$INFISICAL_PROJECT" || -f .infisical.json ]]
+}
+
 resolve_token() {
   if [[ -n "${AGENT_GH_TOKEN:-}" ]]; then
     printf '%s' "$AGENT_GH_TOKEN"
     return 0
   fi
 
-  if command -v infisical >/dev/null 2>&1; then
+  if infisical_available; then
     local val
     if val=$(infisical secrets get "$SECRET_NAME" \
-               --env="$INFISICAL_ENVIRONMENT" --plain 2>/dev/null) \
+               --env="$INFISICAL_ENVIRONMENT" \
+               ${INFISICAL_PROJECT:+--projectId="$INFISICAL_PROJECT"} \
+               --plain 2>/dev/null) \
        && [[ -n "$val" ]]; then
       printf '%s' "$val"
       return 0
@@ -69,7 +83,19 @@ resolve_token() {
 if ! token=$(resolve_token); then
   log "✖ Could not resolve the machine-identity token."
   log "  Tried: \$AGENT_GH_TOKEN, Infisical secret '${SECRET_NAME}' (env=${INFISICAL_ENVIRONMENT}), 1Password '${OP_REF}'."
-  log "  Provision it per docs/MACHINE_IDENTITY.md, then re-run."
+
+  # Distinguish "no project link" from "secret missing". Conflating them sends
+  # people to re-provision a credential that already exists.
+  if command -v infisical >/dev/null 2>&1 && ! infisical_available; then
+    log ""
+    log "  Infisical is installed but no project link was found."
+    log "  '.infisical.json' is gitignored, so a fresh clone has none. Either:"
+    log "    infisical init                       # writes the link locally"
+    log "    export INFISICAL_PROJECT_ID=<id>     # for CI and non-interactive runs"
+  else
+    log "  Provision it per docs/MACHINE_IDENTITY.md, then re-run."
+  fi
+
   log "  Do NOT paste the token into a chat session or commit it to the repo."
   exit 1
 fi


### PR DESCRIPTION
## Premise

`.infisical.json` is gitignored on forkability grounds (`365a721`). `scripts/agent-gh.sh` calls `infisical secrets get` with no project ID, so it depended entirely on that file — meaning **a fresh clone cannot resolve any secret**, and CI never could.

Worse, the failure misdirected. It reported:

```
✖ Could not resolve the machine-identity token.
  Provision it per docs/MACHINE_IDENTITY.md, then re-run.
```

That sends the reader to re-provision a credential which already exists and is perfectly fine. The actual cause — no project link — was never mentioned.

**This was hit in practice, not hypothesised:** PR #352 pushed its branch but could not open its own pull request, and only recovered by hand-recreating the ignored file.

## Fix

1. **Accept `INFISICAL_PROJECT_ID`** and pass it through as `--projectId`, so CI and fresh clones resolve secrets without the file.
2. **Distinguish the two failure causes** and name both remedies. Conflating "no project link" with "secret missing" is what made the original message misleading rather than merely unhelpful.
3. **Document it** in `MACHINE_IDENTITY.md`, and correct the setup guide's troubleshooting table, which had folded both causes into a single row.

A project ID is not a secret. The docs note it belongs in Actions **Variables**, not Secrets — putting non-secrets in Secrets makes it harder to see what genuinely needs protecting.

## Verification

Three paths tested, including a real fresh-clone simulation in a temp directory with no `.infisical.json`:

| Scenario | Result |
|---|---|
| `.infisical.json` present | ✅ `noemi-agent (User)` |
| Fresh clone, no link, no env var | ✅ exits 1 with the correct diagnostic and both fixes |
| Fresh clone + `INFISICAL_PROJECT_ID` | ✅ `noemi-agent (User)` — resolves without the file |

Also: `bash -n` clean, `npm test` 44/44, `node scripts/audit-repo.js` passes, no generator drift.

## Scope

Deliberately kept out of #352 rather than bundled into a docs PR — undisclosed scope is what the framing gate exists to catch, and bundling it there would have earned a `high` finding under the rules that PR was documenting.