### PR TITLE
ci(governance): harden main promotion branch protection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,14 +143,33 @@ npm run validate
 
 This repository uses a two-branch flow:
 
-- **`develop`** — integration branch. All feature, fix, and docs PRs target `develop`.
-- **`main`** — release branch. Only `develop` is promoted into `main`, gated by the `Require develop source` CI check.
+- **`develop`** — integration branch. All feature, fix, and docs PRs target `develop`. Reviews land here.
+- **`main`** — release branch. Only `develop` is promoted into `main`. Branch protection:
+  - **PR required** — no direct pushes to `main` for anyone (including admins and bots; `enforce_admins` is on).
+  - **`check-source-branch` required** — the `Require develop source` workflow must pass; the promotion PR head must be `develop` (never weaken this gate).
+  - **Approvals on main optional** — default is zero (work was already reviewed on `develop`). Operators may set `MAIN_REQUIRE_APPROVALS=1` when applying protection if they want one review on the release PR.
+  - **Allow auto-merge** is enabled so maintainers can arm `gh pr merge --auto` on the promotion PR once checks pass.
 
 When opening a pull request:
 
 1. Branch from `develop` and keep your branch current with `develop` to avoid conflicts on generated files (`CLAUDE.md`, `GEMINI.md`, golden fixtures).
 2. Set the PR base branch to `develop` — not `main`. PRs to `main` from any source other than `develop` are blocked by CI.
-3. Maintainers handle periodic `develop` → `main` promotion separately.
+3. Maintainers promote with a `develop` → `main` PR (not a direct push), for example:
+
+```bash
+gh pr create --base main --head develop --title "Release: promote develop to main"
+gh pr merge --auto --merge   # arms auto-merge once required checks are green
+```
+
+`PROMOTE_TOKEN` (a PAT or the `noemi-agent` app token) is only needed if you later require privileged status-check re-runs on the promotion PR that `GITHUB_TOKEN` cannot perform. With the default main rules (PR + `check-source-branch` + validate suite, all of which fire on `pull_request`), no extra secret is required.
+
+Apply or refresh protection (admin credentials):
+
+```bash
+bash scripts/setup-branch-protection.sh
+# optional: also require one approval on main PRs
+MAIN_REQUIRE_APPROVALS=1 bash scripts/setup-branch-protection.sh
+```
 
 If you accidentally open a PR against `main`, retarget it via the GitHub UI (Edit → Base branch) or:
 

--- a/docs/AI_REVIEW_GOVERNANCE.md
+++ b/docs/AI_REVIEW_GOVERNANCE.md
@@ -219,24 +219,31 @@ handoff point for anyone picking the work up.
 | `.github/workflows/ai-review.yml` | ⚠️ skips cleanly; runner not implemented | `GEMINI_API_KEY` + runner |
 | `noemi-reviewer` identity | ✅ provisioned 2026-08-03, capabilities verified | — |
 | `GEMINI_API_KEY` repo secret | ❌ not set | human |
-| CODEOWNERS + `require_code_owner_reviews` | ⚠️ in repo, **not applied** | run `scripts/setup-branch-protection.sh` |
+| CODEOWNERS + `require_code_owner_reviews` | ✅ on `develop` via `setup-branch-protection.sh` (main leaves code-owner reviews off) | re-run script after policy changes |
 | Three-gate review runner | ❌ not written | follow-up PR |
-| `enforce_admins: true` | ❌ still `false` on both branches | phase 1 operating cleanly |
+| `enforce_admins: true` on `main` | ✅ required by promotion policy (no direct push / no bot bypass) | — |
+| `enforce_admins: true` on `develop` | ❌ still `false` (escape hatch for integration) | bot-only integration path |
 | Both bot identities' effective permission | ✅ `maintain` accepted by decision 2026-08-03 — token scoping is the boundary | — |
 
-### Applying the code-owner gate
+### Applying branch protection
 
-The CODEOWNERS file and the `require_code_owner_reviews: true` payload in
-`scripts/setup-branch-protection.sh` are **inert until the script is run**:
+`scripts/setup-branch-protection.sh` is the source of truth for classic branch
+protection. It:
+
+- requires a PR into `main` with `enforce_admins: true` and empty bypass lists
+- always registers `check-source-branch` as a required check on `main` (do not weaken)
+- defaults main approvals to 0 (`MAIN_REQUIRE_APPROVALS=1` to require one)
+- enables repository **Allow auto-merge** for `gh pr merge --auto`
+- applies CODEOWNERS + 1 review on `develop`
 
 ```bash
 bash scripts/setup-branch-protection.sh
 ```
 
-Before running it, decide the co-owner question. With a single owner and
-`require_code_owner_reviews` enabled, a PR authored by that owner cannot be
-approved by them — GitHub blocks self-approval — and will need a second owner or
-an admin bypass. Bot-authored PRs are unaffected. See the comments in
+Before requiring code-owner reviews on `develop`, decide the co-owner question.
+With a single owner and `require_code_owner_reviews` enabled, a PR authored by
+that owner cannot be approved by them — GitHub blocks self-approval — and will
+need a second owner. Bot-authored PRs are unaffected. See the comments in
 `.github/CODEOWNERS`.
 
 ## Audit Log

--- a/docs/MACHINE_IDENTITY.md
+++ b/docs/MACHINE_IDENTITY.md
@@ -306,20 +306,28 @@ merge with their own credentials — the separation is the point.
 
 ## Re-tightening after rollout
 
-Branch protection currently runs with `enforce_admins: false` on `main` and
-`develop`, which is what permits an admin bypass merge. That was the only way to
-land a human-authored agent PR while this gap existed.
+`main` is configured with `enforce_admins: true` and empty PR bypass allowances
+via `scripts/setup-branch-protection.sh`: no direct pushes and no admin/bot
+bypass of the promotion PR path. That is intentional — promotion is only through
+a `develop` → `main` PR with required `check-source-branch` (and validate)
+checks. Approvals on main default to zero (`MAIN_REQUIRE_APPROVALS=0`) because
+review already happened on `develop`.
 
-Once agent PRs are reliably bot-authored, close the bypass:
+`develop` still runs with `enforce_admins: false` so humans can land exceptional
+integration fixes if needed; day-to-day agent work still goes through bot-authored
+PRs into `develop` with a human approval.
+
+To re-apply the full policy (including enabling repository auto-merge):
 
 ```bash
-gh api --method PATCH repos/project-noemi/agents/branches/develop/protection/enforce_admins
-gh api --method PATCH repos/project-noemi/agents/branches/main/protection/enforce_admins
+bash scripts/setup-branch-protection.sh
+# optional one-approval gate on the release PR only:
+MAIN_REQUIRE_APPROVALS=1 bash scripts/setup-branch-protection.sh
 ```
 
-Do **not** enable this before the machine identity is working. With
-`enforce_admins: true` and no bot identity, every agent PR becomes unmergeable
-and admins have no escape hatch.
+Do **not** turn `enforce_admins: true` on `develop` until agent PRs are reliably
+bot-authored. With that flag and no bot identity, every agent PR into `develop`
+becomes unmergeable and admins have no escape hatch.
 
 ## Rotation and revocation
 
@@ -344,7 +352,7 @@ and admins have no escape hatch.
   "risks": [
     "machine user consumes a paid Enterprise seat",
     "Workflows:write would let agents edit the merge gate — left ungranted",
-    "enforce_admins remains false until bot authorship is verified"
+    "main enforce_admins is true (no direct push/bypass); develop remains false until bot path is the only integration path"
   ],
   "result": "Producer and reviewer identities separated; approval gate enforceable"
 }

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,8 +1,25 @@
 #!/usr/bin/env bash
 # Apply branch protection rules on GitHub so that:
-#   - `develop` is the integration branch (no direct pushes, PRs + checks required)
-#   - `main` is the release branch, and only PRs whose source is `develop`
-#     can merge into it (enforced by the `require-develop-source` workflow)
+#   - `develop` is the integration branch (PRs + checks required; work is reviewed here)
+#   - `main` is the release branch; promotion is PR-only from `develop`, with no direct
+#     pushes and no admin/bot bypass
+#
+# Main policy (canonical promotion path):
+#   1. Require a pull request before merging into main (forces develop → main promotion
+#      through a PR that can be armed with `gh pr merge --auto`).
+#   2. Block / disallow direct pushes to main for everyone — enforce_admins true, empty
+#      bypass allowances (no bot or admin bypass of the PR requirement).
+#   3. Keep `check-source-branch` (require-develop-source workflow) as a required status
+#      check on main PRs — never remove or weaken it. Guarantees the promotion PR can
+#      only originate from `develop`.
+#   4. Optionally require 1 approving review on PRs into main (MAIN_REQUIRE_APPROVALS=1).
+#      Default is 0 — develop is already the review gate.
+#   5. Enable repository "Allow auto-merge" so `gh pr merge --auto` can arm the merge.
+#   6. PROMOTE_TOKEN: only needed if you require *privileged re-runs* of status checks on
+#      the promotion PR (e.g. a workflow that GITHUB_TOKEN cannot re-dispatch). If main
+#      only requires "must be a PR" + checks that fire on `pull_request` (including
+#      check-source-branch and the validate suite), no secret is needed — GitHub runs
+#      those checks automatically on the promotion PR.
 #
 # Requires:
 #   - gh CLI authenticated with admin rights on the target repo
@@ -12,23 +29,42 @@
 #     re-run the moment the plan is upgraded.
 #
 # Usage:
-#   bash scripts/setup-branch-protection.sh              # auto-detects the repo
-#   REPO=owner/repo bash scripts/setup-branch-protection.sh   # explicit override
+#   bash scripts/setup-branch-protection.sh
+#   REPO=owner/repo bash scripts/setup-branch-protection.sh
+#   MAIN_REQUIRE_APPROVALS=1 bash scripts/setup-branch-protection.sh   # optional 1 review on main
+#
+# Env:
+#   REPO                      owner/repo override (default: gh repo view)
+#   MAIN_REQUIRE_APPROVALS    0 (default) or 1 — approving reviews required on main PRs
+#   SKIP_AUTO_MERGE           if set to 1, do not enable repository allow_auto_merge
 #
 # The status-check `contexts` below must match the check-run names GitHub
 # surfaces for each workflow job. If a check name changes, update the
 # context list or protection will silently stop waiting for it.
+# Do NOT remove `check-source-branch` from main's contexts.
 
 set -euo pipefail
 
-# Resolve the target repo. Prefer an explicit REPO override, otherwise derive it
-# from the checkout so the script is frictionless in forks (no hardcoded org).
 REPO="${REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)}"
 
 if [[ -z "$REPO" ]]; then
   echo "✖ Could not determine the target repository." >&2
   echo "  Run inside a GitHub checkout with 'gh' authenticated, or set REPO=owner/repo." >&2
   exit 1
+fi
+
+MAIN_REQUIRE_APPROVALS="${MAIN_REQUIRE_APPROVALS:-0}"
+if [[ "$MAIN_REQUIRE_APPROVALS" != "0" && "$MAIN_REQUIRE_APPROVALS" != "1" ]]; then
+  echo "✖ MAIN_REQUIRE_APPROVALS must be 0 or 1 (got: ${MAIN_REQUIRE_APPROVALS})" >&2
+  exit 1
+fi
+
+# When approvals are required, also dismiss stale reviews. Code-owner reviews stay
+# off by default on main (develop is the CODEOWNERS gate for day-to-day work).
+if [[ "$MAIN_REQUIRE_APPROVALS" == "1" ]]; then
+  MAIN_DISMISS_STALE=true
+else
+  MAIN_DISMISS_STALE=false
 fi
 
 apply_protection() {
@@ -50,7 +86,32 @@ apply_protection() {
   return 1
 }
 
-MAIN_PAYLOAD=$(cat <<'JSON'
+enable_auto_merge() {
+  if [[ "${SKIP_AUTO_MERGE:-0}" == "1" ]]; then
+    echo "→ Skipping allow_auto_merge (SKIP_AUTO_MERGE=1)"
+    return 0
+  fi
+  echo "→ Enabling repository allow_auto_merge on ${REPO}"
+  local response http_status
+  response=$(gh api \
+    --method PATCH \
+    -H "Accept: application/vnd.github+json" \
+    "repos/${REPO}" \
+    -f allow_auto_merge=true 2>&1) && http_status=0 || http_status=$?
+  if [[ $http_status -eq 0 ]]; then
+    echo "  ✔ allow_auto_merge enabled (Settings → General)"
+    return 0
+  fi
+  echo "  ✖ failed to enable allow_auto_merge"
+  printf '    %s\n' "$response" | sed 's/^/    /'
+  return 1
+}
+
+# Main: PR-only promotion, no direct push, no admin/bot bypass.
+# check-source-branch is mandatory and must never be dropped (Decision [2026-08-01-0002]).
+# Validate suite is also required; it re-runs on pull_request → main automatically
+# (no PROMOTE_TOKEN for that path).
+MAIN_PAYLOAD=$(cat <<JSON
 {
   "required_status_checks": {
     "strict": true,
@@ -59,21 +120,31 @@ MAIN_PAYLOAD=$(cat <<'JSON'
       "Audit, Generate, and Fast Tests"
     ]
   },
-  "enforce_admins": false,
+  "enforce_admins": true,
   "required_pull_request_reviews": {
-    "required_approving_review_count": 1,
-    "dismiss_stale_reviews": true,
-    "require_code_owner_reviews": true
+    "required_approving_review_count": ${MAIN_REQUIRE_APPROVALS},
+    "dismiss_stale_reviews": ${MAIN_DISMISS_STALE},
+    "require_code_owner_reviews": false,
+    "require_last_push_approval": false,
+    "bypass_pull_request_allowances": {
+      "users": [],
+      "teams": [],
+      "apps": []
+    }
   },
   "restrictions": null,
   "allow_force_pushes": false,
   "allow_deletions": false,
   "required_conversation_resolution": true,
-  "required_linear_history": false
+  "required_linear_history": false,
+  "block_creations": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false
 }
 JSON
 )
 
+# Develop: integration branch — reviews and checks land here before promotion.
 DEVELOP_PAYLOAD=$(cat <<'JSON'
 {
   "required_status_checks": {
@@ -100,6 +171,7 @@ JSON
 failures=0
 apply_protection "main" "$MAIN_PAYLOAD" || failures=$((failures + 1))
 apply_protection "develop" "$DEVELOP_PAYLOAD" || failures=$((failures + 1))
+enable_auto_merge || failures=$((failures + 1))
 
 if [[ $failures -gt 0 ]]; then
   cat <<'MSG'
@@ -119,3 +191,12 @@ fi
 
 echo
 echo "✅ Branch protection applied to main and develop."
+echo "   main:  PR required, enforce_admins=true (no direct push / no bot bypass),"
+echo "          required checks: check-source-branch + Audit/Generate/Fast Tests,"
+echo "          approving reviews on main: ${MAIN_REQUIRE_APPROVALS} (set MAIN_REQUIRE_APPROVALS=1 to require one)."
+echo "   develop: PR + 1 review + validate checks (integration review gate)."
+echo "   repo:  allow_auto_merge enabled for gh pr merge --auto on the promotion PR."
+echo
+echo "   PROMOTE_TOKEN: not required for the default main checks (they run on pull_request)."
+echo "   Add a PROMOTE_TOKEN secret only if you later require privileged status-check"
+echo "   re-runs that GITHUB_TOKEN cannot perform."


### PR DESCRIPTION
## Summary
- Harden `scripts/setup-branch-protection.sh` so `main` is PR-only with `enforce_admins: true`, empty bypass allowances, and required `check-source-branch` (never weakened) plus the validate suite.
- Default main approvals to 0 (`MAIN_REQUIRE_APPROVALS=1` optional); enable repository Allow auto-merge for `gh pr merge --auto` promotion.
- Document promotion flow, optional approval, and that `PROMOTE_TOKEN` is only needed for privileged status-check re-runs (not for the default pull_request checks).

## Live settings
Already applied to `project-noemi/agents` via the updated script:
- main: PR required, `enforce_admins=true`, checks `check-source-branch` + `Audit, Generate, and Fast Tests`, 0 approvals
- repo: `allow_auto_merge=true`
- `.github/workflows/require-develop-source.yml` unchanged

## Test plan
- [x] Ran `bash scripts/setup-branch-protection.sh` successfully
- [x] Verified main protection via GitHub API (`enforce_admins`, required contexts, approvals=0)
- [x] Verified `allow_auto_merge=true`
- [ ] CI: Audit, Generate, and Fast Tests on this PR