### PR TITLE
fix(release): stop the release from pushing to protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,12 @@
 #
 #   1. promote-and-release  (DAILY + manual)
 #      A CONTENT-GATED auto-promotion. It only acts when `develop` carries an
-#      unreleased USER-FACING change vs `main` (≥1 Conventional Commit of type
-#      feat or fix in the main..develop range). If it does, and CI on develop is
-#      green, it opens (or reuses) a `develop -> main` PULL REQUEST and lets it
-#      AUTO-MERGE once required checks pass, then runs release-it on main to stamp
-#      a calendar-date CalVer tag (YYYY.MM.DD) + GitHub Release + changelog.
+#      unreleased USER-FACING change since the LAST RELEASE TAG (≥1 Conventional
+#      Commit of type feat or fix in the <last-tag>..develop range). If it does,
+#      and CI on develop is green, it opens (or reuses) a `develop -> main` PULL
+#      REQUEST and lets it AUTO-MERGE once required checks pass, then runs
+#      release-it on main to stamp a calendar-date CalVer tag (YYYY.MM.DD) + a
+#      GitHub Release whose body is the generated changelog.
 #      Promotion is PR-BASED (not a direct `git push origin main`) so `main` can
 #      stay fully protected against direct pushes. TAG CADENCE = per
 #      content-bearing promotion (frequent). This job NEVER drafts or posts
@@ -43,7 +44,19 @@
 #     threshold. That is gone. The gate is SUBSTANCE: is there ≥1 feat/fix
 #     unreleased on develop? Quiet days are quiet — no tag, no release, no post,
 #     clean no-op exit. The heuristic is a Conventional-Commit scan of the
-#     main..develop range (see the "Content gate" step).
+#     <last-release-tag>..develop range (see the "Content gate" step).
+#
+#   * THE GATE IS TAG-RELATIVE, NOT main-RELATIVE — THIS IS LOAD-BEARING.
+#     "Unreleased" means "not covered by a release tag", NOT "not on main".
+#     Promotion and stamping are two separate remote operations, so a run can
+#     legitimately die in between: the promotion PR merges, then release-it
+#     fails, and `main` now equals `develop` with nothing tagged. If the gate
+#     asked "is main behind develop?" that half-done state would read as "nothing
+#     to do" and the release would be silently stranded forever — a real incident
+#     that happened on 2026-08-05. Comparing against the last tag instead makes
+#     the job RESUMABLE: the next run sees the untagged content, skips the
+#     already-done promotion, and stamps the release. Do not "simplify" this back
+#     to a main..develop diff.
 #
 #   * AUTO-PROMOTE ON GREEN — SAFE BECAUSE DEVELOP IS ALREADY REVIEWED.
 #     develop is the canonical, human-reviewed integration line; every change
@@ -80,6 +93,21 @@
 #     See docs/RELEASE_PROCESS.md for the App setup an admin applies and the two
 #     secret names required.
 #
+#   * NO CHANGELOG.md COMMIT — THE RELEASE NEVER WRITES TO A BRANCH.
+#     `main` is protected with `enforce_admins: true` and no bot bypass, so any
+#     branch push from this job is rejected (GH006). release-it therefore runs
+#     with `git.commit: false` and the conventional-changelog plugin with
+#     `infile: false`: the generated changelog becomes the GITHUB RELEASE BODY
+#     and no `chore(release): <version>` commit is ever created. Because there is
+#     no local commit, release-it's `git push --follow-tags` sends no branch
+#     update at all — only the annotated tag, which branch protection does not
+#     govern. Tags and releases are the changelog of record.
+#     The alternative (generate CHANGELOG.md on `develop` so it rides the
+#     promotion PR) is NOT viable here: `develop` requires a PR plus one
+#     approving code-owner review, so the release App can neither push to it nor
+#     self-approve — it would put a human gate in front of every tag. Do NOT
+#     "fix" this by granting the automation a protection bypass.
+#
 #   * NO NEW ROOT DEPENDENCIES. The repo root is intentionally dependency-free.
 #     release-it and its plugins are installed on demand with
 #     `npm install --no-save` (into gitignored node_modules, so package.json and
@@ -104,7 +132,7 @@ on:
           - promote
           - digest
       dry_run:
-        description: "promote only: preview the gate + promotion + release without pushing, tagging, or publishing."
+        description: "promote only: run the gates, skip opening/merging the promotion PR, and run release-it with --dry-run so the version/changelog/tag path is exercised without tagging or publishing."
         type: boolean
         required: false
         default: false
@@ -127,8 +155,9 @@ jobs:
       (github.event_name == 'schedule' && github.event.schedule == '0 6 * * *') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.job == 'promote')
     permissions:
-      # Push the post-merge changelog commit + CalVer tag, and create the GitHub
-      # Release. (The develop -> main promotion itself goes through a PR, below.)
+      # Push the CalVer tag and create the GitHub Release. No branch write is
+      # made — see the "NO CHANGELOG.md COMMIT" note in the file header. (The
+      # develop -> main promotion itself goes through a PR, below.)
       contents: write
       # Open / reuse / auto-merge the develop -> main promotion PR.
       pull-requests: write
@@ -166,9 +195,9 @@ jobs:
           node --version
           npm --version
 
-      # release-it authors the changelog commit and the annotated tag, and the
-      # promotion may author a merge commit — both need a git identity. Use the
-      # GitHub Actions bot identity, never a human's.
+      # release-it authors the annotated CalVer tag, and the promotion may author
+      # a merge commit — both need a git identity. Use the GitHub Actions bot
+      # identity, never a human's.
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
@@ -178,10 +207,10 @@ jobs:
       # STEP 1 — CONTENT GATE (the heart of this model)
       # ---------------------------------------------------------------------
       # Decide whether there is anything USER-FACING to release. The heuristic:
-      # scan the Conventional Commit subjects in the main..develop range (the
-      # commits on develop not yet on main — i.e. everything since the last
-      # promotion) and count those of type `feat` or `fix`, including scoped and
-      # breaking (`!`) forms: e.g. `feat: ...`, `fix(x): ...`, `feat(x)!: ...`.
+      # scan the Conventional Commit subjects in the <last-release-tag>..develop
+      # range (everything on develop not covered by the last tag) and count those
+      # of type `feat` or `fix`, including scoped and breaking (`!`) forms: e.g.
+      # `feat: ...`, `fix(x): ...`, `feat(x)!: ...`.
       #
       #   * ≥1 feat/fix  -> there is user-facing substance; proceed.
       #   * 0 feat/fix   -> nothing to release; clean no-op exit (quiet days are
@@ -190,20 +219,45 @@ jobs:
       # This is CONTENT, not COUNT: one feat is enough; a hundred chore/docs/ci
       # commits are not. `docs`, `chore`, `refactor`, `test`, `ci`, `build`,
       # `style`, and merge commits are intentionally NOT release triggers.
+      #
+      # The baseline is the LAST RELEASE TAG, not `main` — see the "TAG-RELATIVE"
+      # design note in the file header. That is what lets a run whose promotion
+      # merged but whose stamping failed be picked up and finished by the next
+      # run instead of being stranded. Tags are ordered by creation date rather
+      # than name because CalVer `YYYY.MM.DD[.N]` is not SemVer-sortable.
       - name: Content gate — any unreleased feat/fix on develop?
         id: gate
         run: |
           set -euo pipefail
           git fetch origin develop main --tags
 
-          echo "::group::Unreleased commit subjects (main..develop)"
-          git log --no-merges --pretty=format:'%s' origin/main..origin/develop || true
+          # Only CalVer-shaped tags (YYYY.MM.DD[.N]) count as releases, so an
+          # unrelated tag someone pushes by hand cannot silently redefine "the
+          # last release" and swallow a release window. `|| true` absorbs both a
+          # no-match grep and a SIGPIPE from `head` closing the pipe early.
+          LAST_TAG=$(git tag --list --sort=-creatordate \
+            | grep -E '^[0-9]{4}\.[0-9]{2}\.[0-9]{2}(\.[0-9]+)?$' \
+            | head -n1 || true)
+          if [ -z "${LAST_TAG}" ]; then
+            echo "No release tag yet — treating all of develop as unreleased."
+            RANGE="origin/develop"
+          else
+            echo "Last release tag: ${LAST_TAG}"
+            RANGE="${LAST_TAG}..origin/develop"
+          fi
+          echo "last_tag=${LAST_TAG}" >> "$GITHUB_OUTPUT"
+
+          echo "::group::Unreleased commit subjects (${RANGE})"
+          git log --no-merges --pretty=format:'%s' "${RANGE}" || true
           echo ""
           echo "::endgroup::"
 
           # Count Conventional-Commit feat/fix subjects (scoped/breaking allowed).
-          FEATFIX=$(git log --no-merges --pretty=format:'%s' origin/main..origin/develop \
-            | grep -E '^(feat|fix)(\([^)]+\))?!?:' | wc -l | tr -d ' ')
+          # `grep -c` exits 1 on no match, which `set -e` would treat as fatal, so
+          # the count is forced to 0 rather than failing the gate.
+          FEATFIX=$(git log --no-merges --pretty=format:'%s' "${RANGE}" \
+            | grep -cE '^(feat|fix)(\([^)]+\))?!?:' || true)
+          FEATFIX=${FEATFIX:-0}
 
           echo "Unreleased feat/fix commits: ${FEATFIX}"
           if [ "${FEATFIX}" -eq 0 ]; then
@@ -249,6 +303,33 @@ jobs:
             echo "develop is green."
             echo "green=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # ---------------------------------------------------------------------
+      # STEP 2b — IS A PROMOTION ACTUALLY NEEDED?
+      # ---------------------------------------------------------------------
+      # Separate "does main need develop's content?" from "is there something to
+      # release?" (STEP 1 already answered the latter). They are NOT the same
+      # question, and conflating them is what stranded the 2026-08-05 release:
+      # `main` had already been promoted, so a main..develop check said "nothing
+      # to do" even though the content was still untagged.
+      #
+      #   behind > 0  -> main is missing develop's content; open the promotion PR.
+      #   behind = 0  -> main already carries it (either promoted earlier in this
+      #                  run's history, or by a previous run that then failed to
+      #                  stamp). Skip straight to stamping the release.
+      - name: Is main behind develop?
+        id: behind
+        if: ${{ steps.gate.outputs.release == 'true' && steps.ci.outputs.green == 'true' }}
+        run: |
+          set -euo pipefail
+          BEHIND=$(git rev-list --count origin/main..origin/develop)
+          echo "main is ${BEHIND} commit(s) behind develop."
+          if [ "${BEHIND}" = "0" ]; then
+            echo "main already carries develop's content — no promotion PR needed."
+            echo "Unreleased content exists but is untagged, so this run resumes at the"
+            echo "release-stamping step (see the TAG-RELATIVE note in the file header)."
+          fi
+          echo "count=${BEHIND}" >> "$GITHUB_OUTPUT"
 
       # ---------------------------------------------------------------------
       # STEP 3 — PROMOTE develop -> main VIA AN AUTO-MERGED PULL REQUEST
@@ -298,24 +379,28 @@ jobs:
       # secrets are absent this step is SKIPPED (not failed), its token output is
       # empty, and the PR step below is gated on that output being non-empty — so
       # the job cleanly no-ops instead of crashing.
+      #
+      # Only minted when a promotion is actually needed (`behind.count != 0`). A
+      # resume run that only has to stamp an already-promoted main never opens a
+      # PR, so it needs no App token and works even before the App is configured.
       - name: Mint GitHub App token for promotion PR
         id: app-token
         if: >-
           ${{ steps.gate.outputs.release == 'true' && steps.ci.outputs.green == 'true' &&
-              env.HAS_APP_SECRETS == 'true' }}
+              steps.behind.outputs.count != '0' && env.HAS_APP_SECRETS == 'true' }}
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      # GRACEFUL DEGRADATION: if the content gate and CI-green gate both passed
-      # but no App token was minted (the App secrets are not configured), say so
-      # loudly and exit the job cleanly. This is a no-op, NOT a failure — the
-      # release infrastructure is simply not wired up yet.
+      # GRACEFUL DEGRADATION: if a promotion is needed but no App token was minted
+      # (the App secrets are not configured), say so loudly and exit the job
+      # cleanly. This is a no-op, NOT a failure — the release infrastructure is
+      # simply not wired up yet.
       - name: Note skipped promotion when App secrets are absent
         if: >-
           ${{ steps.gate.outputs.release == 'true' && steps.ci.outputs.green == 'true' &&
-              env.HAS_APP_SECRETS != 'true' }}
+              steps.behind.outputs.count != '0' && env.HAS_APP_SECRETS != 'true' }}
         run: |
           echo "::warning::RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY are not set."
           echo "There is unreleased user-facing change and develop is green, but the"
@@ -328,10 +413,11 @@ jobs:
         id: promote
         # Gate on the App token being present too: if STEP 3a was skipped (App
         # secrets not set) its token output is empty, so this whole step is
-        # skipped and the job cleanly no-ops instead of erroring.
+        # skipped and the job cleanly no-ops instead of erroring. Also skipped
+        # when main already carries develop's content — nothing to promote.
         if: >-
           ${{ steps.gate.outputs.release == 'true' && steps.ci.outputs.green == 'true' &&
-              steps.app-token.outputs.token != '' }}
+              steps.behind.outputs.count != '0' && steps.app-token.outputs.token != '' }}
         env:
           # Use the App-minted token so the promotion PR triggers on: pull_request
           # required checks (a GITHUB_TOKEN-opened PR does not trigger them).
@@ -341,19 +427,12 @@ jobs:
           set -euo pipefail
           git fetch origin develop main --tags
 
-          BEHIND=$(git rev-list --count origin/main..origin/develop)
-          echo "main is ${BEHIND} commit(s) behind develop."
-          if [ "${BEHIND}" = "0" ]; then
-            echo "main already up to date with develop — nothing to promote."
-            echo "promoted=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           if [ "${DRY_RUN}" = "true" ]; then
-            echo ">>> DRY RUN: would open (or reuse) a develop -> main PR, enable"
-            echo "    auto-merge (--merge), and after it merges run release-it on"
-            echo "    main. No PR is opened, nothing is merged, nothing is stamped."
-            echo "promoted=false" >> "$GITHUB_OUTPUT"
+            echo ">>> DRY RUN: would open (or reuse) a develop -> main PR and enable"
+            echo "    auto-merge (--merge). No PR is opened and nothing is merged."
+            echo "    The release-it step still runs below with --dry-run so the"
+            echo "    version/changelog/tag path is genuinely exercised."
+            echo "merged=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -367,7 +446,7 @@ jobs:
           if [ -z "$PR_NUM" ]; then
             printf '%s\n\n%s\n' \
               'Automated content-gated promotion of `develop` into `main`.' \
-              "There is at least one unreleased \`feat\`/\`fix\` on develop and develop's CI is green. develop is the reviewed integration line, so no second review is required by default; this PR exists so \`main\` can stay protected against direct pushes. It auto-merges once main's required checks pass; release-it then stamps the CalVer \`YYYY.MM.DD\` tag + GitHub Release + changelog on main. See docs/RELEASE_PROCESS.md." \
+              "There is at least one unreleased \`feat\`/\`fix\` on develop and develop's CI is green. develop is the reviewed integration line, so no second review is required by default; this PR exists so \`main\` can stay protected against direct pushes. It auto-merges once main's required checks pass; release-it then stamps the CalVer \`YYYY.MM.DD\` tag and a GitHub Release (whose body is the generated changelog) on main — no commit is ever pushed to \`main\`. See docs/RELEASE_PROCESS.md." \
               > /tmp/promotion-pr-body.md
             gh pr create --repo "$GITHUB_REPOSITORY" --base main --head develop \
               --title "chore(release): promote develop into main" \
@@ -410,21 +489,60 @@ jobs:
             echo "open; auto-merge (if enabled) may still complete later, and the next scheduled"
             echo "run will re-check it. NO release is stamped this run — a safe no-op rather than"
             echo "a half-done promotion."
-            echo "promoted=false" >> "$GITHUB_OUTPUT"
+            echo "merged=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "Promotion PR #${PR_NUM} merged. Proceeding to stamp the release on main."
-          echo "promoted=true" >> "$GITHUB_OUTPUT"
+          echo "merged=true" >> "$GITHUB_OUTPUT"
 
       # ---------------------------------------------------------------------
-      # STEP 3b — SYNC local main to the merged promotion
+      # STEP 3b — DECIDE WHETHER TO STAMP
       # ---------------------------------------------------------------------
-      # The merge happened server-side (via the PR), so the local `main` checked
-      # out at job start is stale. Re-sync it to the merged origin/main before
-      # release-it stamps the tag/changelog on it.
-      - name: Sync local main to merged origin/main
-        if: ${{ steps.promote.outputs.promoted == 'true' }}
+      # Stamping is warranted when there is unreleased content (STEP 1) AND main
+      # now carries it. Two ways that second condition is met:
+      #
+      #   * this run merged the promotion PR (`promote.merged == true`), or
+      #   * main already carried it (`behind.count == 0`) — the RESUME path for a
+      #     previous run that promoted but died before tagging.
+      #
+      # A dry run always stamps (with --dry-run) so the release tooling path is
+      # genuinely exercised rather than skipped. Before this step existed, a dry
+      # run exited at the promote step and proved nothing about release-it — which
+      # is exactly why the 2026-08-05 real run failed on a path a "successful" dry
+      # run had never touched.
+      - name: Decide whether to stamp a release
+        id: stamp
+        if: ${{ steps.gate.outputs.release == 'true' && steps.ci.outputs.green == 'true' }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "DRY RUN: exercising the release path against the current main."
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.promote.outputs.merged }}" = "true" ]; then
+            echo "Promotion merged in this run — stamping the release."
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.behind.outputs.count }}" = "0" ]; then
+            echo "main already carries the unreleased content — resuming and stamping it."
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No promotion landed this run — not stamping (safe no-op)."
+            echo "go=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ---------------------------------------------------------------------
+      # STEP 3c — SYNC local main to origin/main
+      # ---------------------------------------------------------------------
+      # Any merge happened server-side (via the PR), so the local `main` checked
+      # out at job start may be stale. Re-sync before release-it tags it.
+      #
+      # `reset --hard` is also what guarantees the local branch is IDENTICAL to
+      # the remote, which is what makes release-it's `git push --follow-tags`
+      # push the tag ONLY — see the "NO CHANGELOG.md COMMIT" header note.
+      - name: Sync local main to origin/main
+        if: ${{ steps.stamp.outputs.go == 'true' }}
         run: |
           set -euo pipefail
           git fetch origin main --tags
@@ -440,7 +558,7 @@ jobs:
       # `npx -p`) is required so the local CalVer plugin can
       # `import { Plugin } from 'release-it'`.
       - name: Install release-it and plugins (on demand, --no-save)
-        if: ${{ steps.promote.outputs.promoted == 'true' }}
+        if: ${{ steps.stamp.outputs.go == 'true' }}
         run: |
           npm install --no-save --no-package-lock \
             release-it @release-it/conventional-changelog
@@ -449,29 +567,28 @@ jobs:
       # STEP 5 — RELEASE: stamp the CalVer date on main
       # ---------------------------------------------------------------------
       # --ci makes release-it non-interactive. The CalVer plugin supplies the
-      # YYYY.MM.DD version (with .N same-day disambiguation);
-      # conventional-changelog only writes CHANGELOG.md. NO social posting here —
-      # that is the weekly-digest job's concern.
+      # YYYY.MM.DD version (with .N same-day disambiguation); the
+      # conventional-changelog plugin renders the changelog straight into the
+      # GitHub Release body. NO social posting here — that is the weekly-digest
+      # job's concern.
       #
-      # BRANCH-PROTECTION NOTE: this stamping runs AFTER the promotion PR merged.
-      # The annotated tag and the GitHub Release are tag/release refs and are NOT
-      # governed by branch-protection rules, so they land regardless of how
-      # locked-down `main` is. The one write release-it makes to the `main`
-      # BRANCH is the `chore(release): ${version}` CHANGELOG commit (git.push).
-      # If main's protection is configured to block ALL direct branch writes
-      # including this automation (the "no bot bypass" posture in
-      # docs/RELEASE_PROCESS.md), that commit push will be rejected; the fix is to
-      # generate CHANGELOG.md on develop so it flows through the promotion PR —
-      # do NOT grant the bot a protection bypass. See docs/RELEASE_PROCESS.md.
-      # TOKEN CHOICE: release-it keeps using the default GITHUB_TOKEN. The tag and
-      # GitHub Release are tag/release refs (not governed by branch protection) and
-      # the changelog commit is a plain push to main — none of this needs the App
-      # token's on: pull_request-triggering property (that only mattered for the
-      # promotion PR). Keeping GITHUB_TOKEN here avoids widening the App token's
-      # blast radius and works even in the App-not-configured path (it never
-      # reaches this step, but the default token is always available regardless).
-      - name: Run release-it (CalVer tag + changelog + GitHub Release)
-        if: ${{ steps.promote.outputs.promoted == 'true' }}
+      # BRANCH-PROTECTION: this step writes NOTHING to the `main` branch. With
+      # `git.commit: false` and `infile: false` there is no `chore(release):`
+      # commit and no CHANGELOG.md, so `git push --follow-tags` carries only the
+      # annotated tag — and tags/releases are not governed by branch protection.
+      # This is the fix for the GH006 failure on 2026-08-05, where the changelog
+      # commit was rejected by main's protection and took the tag down with it.
+      # Do NOT re-enable `git.commit` without also granting a protection bypass,
+      # which this repository deliberately refuses to do.
+      #
+      # TOKEN CHOICE: release-it uses the default GITHUB_TOKEN. Creating a tag and
+      # a Release needs no App token — the App token's only special property is
+      # triggering `on: pull_request` checks, which mattered solely for the
+      # promotion PR. Keeping GITHUB_TOKEN here avoids widening the App token's
+      # blast radius, and lets the resume path stamp a release even when the App
+      # is not configured at all.
+      - name: Run release-it (CalVer tag + GitHub Release)
+        if: ${{ steps.stamp.outputs.go == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.release-it.json
+++ b/.release-it.json
@@ -2,8 +2,7 @@
   "$schema": "https://unpkg.com/release-it/schema/release-it.json",
   "npm": false,
   "git": {
-    "commit": true,
-    "commitMessage": "chore(release): ${version}",
+    "commit": false,
     "tag": true,
     "tagName": "${version}",
     "tagAnnotation": "NoéMI ${version}",
@@ -18,7 +17,7 @@
     "web": false
   },
   "hooks": {
-    "before:init": "echo \"[calver] release date target = $(date -u +'%Y.%m.%d') — scheme: calendar-date CalVer YYYY.MM.DD, UTC, with a .N suffix for same-day releases (see docs/RELEASE_PROCESS.md and scripts/release-it-calver.mjs). CalVer owns the version; conventional-changelog only writes CHANGELOG.md.\"",
+    "before:init": "echo \"[calver] release date target = $(date -u +'%Y.%m.%d') — scheme: calendar-date CalVer YYYY.MM.DD, UTC, with a .N suffix for same-day releases (see docs/RELEASE_PROCESS.md and scripts/release-it-calver.mjs). CalVer owns the version; conventional-changelog only renders the GitHub Release body.\"",
     "after:release": "echo '[release-herald] Release ${version} stamped. Tag cadence is per content-bearing promotion; the user-facing digest is a SEPARATE, WEEKLY, human-approved job — this release job never drafts or posts social. See skills/reporting/release-herald.md and the weekly-digest job in .github/workflows/release.yml. This echo is a deliberate stub, not a poster.'"
   },
   "plugins": {
@@ -27,7 +26,7 @@
       "preset": {
         "name": "conventionalcommits"
       },
-      "infile": "CHANGELOG.md",
+      "infile": false,
       "ignoreRecommendedBump": true
     }
   }

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -62,9 +62,14 @@ A date-based scheme could become theatre — a tag a day with nothing behind it.
 It does not, because promotion is **content-gated**:
 
 - A release happens **only when `develop` carries an unreleased user-facing
-  change** vs `main` — concretely, **at least one Conventional Commit of type
-  `feat` or `fix`** in the `main..develop` range (everything since the last
-  promotion). One is enough.
+  change** — concretely, **at least one Conventional Commit of type `feat` or
+  `fix`** in the `<last-release-tag>..develop` range (everything not yet covered
+  by a tag). One is enough.
+- The baseline is the **last release tag, not `main`.** "Unreleased" means "not
+  covered by a tag", which is what makes the job resumable: if a run promotes
+  `develop` into `main` and then dies before tagging, the next run still sees the
+  untagged content and finishes the job. A `main..develop` baseline would read
+  that half-done state as "nothing to do" and strand the release permanently.
 - If there is none, the promotion job **exits cleanly as a no-op** — it logs
   "nothing to release" and does not tag, release, or post. **Quiet days are
   quiet.** No noise, no empty tag.
@@ -214,16 +219,40 @@ short-lived (per run, auto-expiring — nothing to rotate); the only stored
 material is the private key. If either secret is missing, the promotion step is
 skipped and the job no-ops cleanly rather than failing.
 
-### A note on release-it's changelog commit
+### Where the changelog lives: the GitHub Release, not a committed file
 
-After the promotion PR merges, release-it stamps the release on `main`. The
-annotated tag and the GitHub Release are **tag/release refs**, which
-branch-protection rules do **not** govern — they land regardless of how
-locked-down `main` is. The one write release-it makes to the `main` *branch* is
-the `chore(release): <version>` **CHANGELOG.md commit**. If your protection is
-strict enough to block even that automation write (consistent with the "no bot
-bypass" posture), move `CHANGELOG.md` generation onto `develop` so it flows
-through the promotion PR — **do not** grant the bot a protection bypass.
+**The release never writes to a branch.** There is no `CHANGELOG.md` in this
+repository and no `chore(release): <version>` commit. The generated
+conventional-changelog output becomes the **body of the GitHub Release**, and
+the tag plus that Release are the changelog of record.
+
+That is a consequence of taking "no bot bypass" seriously. `main` is protected
+with `enforce_admins: true` and no bypass allowance, so any branch push from the
+release job is rejected with `GH006: Protected branch update failed`. Because
+`git push --follow-tags` pushes the branch and the tag together, a rejected
+changelog commit also **takes the tag down with it** — release-it rolls the tag
+back and the whole job fails. That is exactly what happened on 2026-08-05:
+promotion PR #360 merged, then stamping failed and no `2026.08.05` tag existed.
+
+The fix is to make the release genuinely branch-write-free:
+
+- `.release-it.json` sets **`git.commit: false`** — nothing is committed, so the
+  local branch stays byte-identical to `origin/main` and `git push --follow-tags`
+  sends **no branch update at all**, only the annotated tag. Tags and releases
+  are not governed by branch protection, so they land on a fully locked `main`.
+- The `@release-it/conventional-changelog` plugin runs with **`infile: false`**,
+  so it renders the changelog into the Release body instead of writing a file.
+- The workflow's sync step (`git reset --hard origin/main`) is what guarantees
+  the branch cannot diverge, and `requireCleanWorkingDir: true` is the backstop
+  that aborts the release if anything unexpectedly dirties the tree.
+
+**Why not generate `CHANGELOG.md` on `develop`** so it rides the promotion PR
+(an earlier revision of this document suggested exactly that)? Because `develop`
+requires a pull request plus **one approving code-owner review**. The release App
+can neither push to `develop` directly nor approve its own PR, so that route puts
+a human review gate in front of every tag — it turns an automated release into a
+manual one. **Do not** "solve" this by granting the automation a protection
+bypass on either branch.
 
 ## Decoupled cadences: versions per promotion, social weekly
 
@@ -231,7 +260,7 @@ The two rhythms are deliberately separate:
 
 | | Cadence | What it does | Human gate |
 |---|---|---|---|
-| **Tagging / release** | Per content-bearing promotion (daily check; fires only when there's a feat/fix) | Auto-merge a `develop → main` PR, then stamp `YYYY.MM.DD` tag + CHANGELOG + GitHub Release on main | On develop review (upstream); green-CI gate |
+| **Tagging / release** | Per content-bearing promotion (daily check; fires only when there's a feat/fix) | Auto-merge a `develop → main` PR, then stamp a `YYYY.MM.DD` tag + a GitHub Release (changelog as its body) on main | On develop review (upstream); green-CI gate |
 | **Digest / social** | Weekly (Monday) | Draft the week's feature highlights + LinkedIn/social post | **Yes — human approves before any post** |
 
 Why decouple them? Versions should track *reality*: mint one whenever real change
@@ -245,14 +274,17 @@ each run at its natural rhythm.
 
 The moving parts:
 
-- **`.release-it.json`** — the release configuration. It sets the
-  tag/commit/release naming to plain date CalVer (`${version}` → `YYYY.MM.DD`,
-  no `v` prefix), disables npm entirely (`"npm": false`), and keeps the
-  `@release-it/conventional-changelog` plugin **only** to maintain `CHANGELOG.md`.
-  That plugin runs with `ignoreRecommendedBump: true`, so it does **not** compute
-  a SemVer bump — CalVer owns the version. The `after:release` hook is an `echo`
-  stub for the release-herald seam — no real poster, and it re-states that social
-  is the weekly job's job, never the release job's.
+- **`.release-it.json`** — the release configuration. It sets the tag/release
+  naming to plain date CalVer (`${version}` → `YYYY.MM.DD`, no `v` prefix),
+  disables npm entirely (`"npm": false`), and keeps the
+  `@release-it/conventional-changelog` plugin **only** to render the GitHub
+  Release body (`infile: false` — no committed changelog file). That plugin runs
+  with `ignoreRecommendedBump: true`, so it does **not** compute a SemVer bump —
+  CalVer owns the version. `git.commit: false` is load-bearing: it is what keeps
+  the release from writing to the protected `main` branch (see the changelog note
+  above). The `after:release` hook is an `echo` stub for the release-herald seam —
+  no real poster, and it re-states that social is the weekly job's job, never the
+  release job's.
 - **`scripts/release-it-calver.mjs`** — a tiny local release-it plugin that
   supplies the version as `YYYY.MM.DD` (UTC), checking existing tags to add a
   `.N` suffix for same-day releases. It exists because release-it is
@@ -262,14 +294,19 @@ The moving parts:
   Supplying the version from a plugin sidesteps the SemVer increment path
   entirely; `"npm": false` means the non-SemVer version is never written into
   `package.json` (npm would reject it). The tag, the GitHub Release, and the
-  changelog header all end up carrying a clean `YYYY.MM.DD`.
+  changelog heading in its body all end up carrying a clean `YYYY.MM.DD`.
+  (release-it's console preview prints the changelog heading as `[null]` before
+  the plugin's `bump()` re-renders it — a cosmetic log artifact; the published
+  Release body carries the real version.)
 - **`.github/workflows/release.yml`** — the two jobs:
   - **`promote-and-release`** runs on a **daily `schedule:` cron** and on manual
     `workflow_dispatch` (with a `dry_run` input). It applies the **content gate**
-    (≥1 unreleased feat/fix), checks develop's CI is **green**, opens (or reuses)
-    an **auto-merged `develop → main` PR**, and — once that PR merges — runs
-    release-it **on `main`** to stamp the CalVer tag, update the changelog, and
-    publish the GitHub Release. The PR is opened with a **GitHub App token minted
+    (≥1 unreleased feat/fix since the last tag), checks develop's CI is
+    **green**, opens (or reuses) an **auto-merged `develop → main` PR**, and —
+    once that PR merges — runs release-it **on `main`** to stamp the CalVer tag
+    and publish the GitHub Release. If `main` already carries the unreleased
+    content (a previous run promoted but failed to stamp), it skips the PR and
+    resumes at the stamping step. The PR is opened with a **GitHub App token minted
     at runtime** (from `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY`) so its
     `on: pull_request` checks run; if the App is not configured the job no-ops
     cleanly. release-it itself keeps using `GITHUB_TOKEN`. It **never** drafts or
@@ -327,10 +364,16 @@ into communication teams can trust.
    nothing happens, and that is fine.
 3. If there **is** unreleased user-facing change and develop's CI is green, the
    job opens (or reuses) a `develop → main` pull request and enables auto-merge;
-   once `main`'s required checks pass, the PR merges. release-it then runs on the
+   once `main`'s required checks pass, the PR merges. (If `main` already carries
+   that content, this step is skipped — see step 3b.) release-it then runs on the
    merged `main`: it computes the CalVer date (`YYYY.MM.DD`, with `.N` if the date
-   is already taken), updates `CHANGELOG.md`, creates the annotated tag, pushes,
-   and publishes the GitHub Release.
+   is already taken), creates and pushes the annotated tag, and publishes the
+   GitHub Release with the generated changelog as its body. No commit is pushed
+   to `main`.
+   - **3b — resume.** If a previous run merged the promotion PR but failed before
+     tagging, `main` already equals `develop` while the content is still
+     untagged. Because the content gate measures against the last **tag**, the
+     next run still fires, skips the promotion, and stamps the missing release.
 4. **Weekly** (Monday, or via manual dispatch), the separate digest job collects
    the week's changes and drafts the release-herald digest (highlights + a social
    post) as an artifact and an issue — for a human to review, approve, and post.
@@ -342,3 +385,11 @@ choose the `promote` job, and enable `dry_run` to see the content-gate decision
 and the promotion plan **without** opening a PR, merging into `main`, tagging, or
 publishing anything. Use it whenever you want to confirm what the next promotion
 would do before it runs for real.
+
+A dry run **also runs `release-it --dry-run`** against the current `main`, so the
+version resolution, changelog rendering, tag, and Release steps are genuinely
+exercised. This matters: the original dry run exited before release-it ever ran,
+so it reported success while the real run failed on a code path the dry run had
+never touched. A dry run that skips the risky step is not a rehearsal. Note that
+when `main` is still behind `develop`, the dry run's changelog preview reflects
+`main` as it stands today, not the post-promotion state.


### PR DESCRIPTION
## Summary

- Fix the `GH006: Protected branch update failed for refs/heads/main` failure that killed the first real promotion run after its PR had already merged.
- `.release-it.json`: `git.commit: false` and conventional-changelog `infile: false` — the release now writes nothing to any branch. The changelog renders into the GitHub Release body; only the annotated CalVer tag is pushed.
- Content gate now measures against the last CalVer tag instead of `main`, making the job resumable when promotion succeeds but stamping fails.
- Split "is a promotion needed" from "is there something to release", and added an explicit stamp decision covering both the promote and resume paths.
- Dry runs now actually execute `release-it --dry-run` instead of exiting before it.

## Why This Change

`release-it` pushes with `git push --follow-tags`, which carries the branch and the tag in one operation. With `git.commit: true` that meant the `chore(release): <version>` CHANGELOG.md commit was pushed to `main` — and `main` is protected with `enforce_admins: true` and no bypass allowance, so it was rejected:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 2 of 2 required status checks are expected.
 ! [remote rejected] main -> main (protected branch hook declined)
```

Because the push failed as a unit, `release-it` rolled the tag back too and exited 1. Promotion PR #360 had already merged, so `main` was left carrying the content with no `2026.08.05` tag — and the old `main..develop` content gate then read that state as "nothing to do", stranding the release permanently. Both halves are fixed here.

`docs/RELEASE_PROCESS.md` previously suggested moving CHANGELOG.md generation onto `develop` so it rides the promotion PR. That is not viable: `develop` requires a pull request plus one approving code-owner review, so the release App can neither push there nor approve its own PR — it would put a human gate in front of every tag. No protection bypass is granted on either branch; the doc has been corrected.

The dry run passed before the real run failed because it exited at the promote step and never reached `release-it` at all. A rehearsal that skips the risky step is not a rehearsal, so dry runs now exercise the full version/changelog/tag path.

## Audience Impact

- [ ] Client / Buyer path
- [ ] MSP / MSSP path
- [x] Builder / Accelerator path
- [x] Internal repo contract only

Release notes move from a committed `CHANGELOG.md` (which never actually landed in the repo) to GitHub Release bodies. Tags and Releases are now the changelog of record.

## Validation

- [x] `npm run validate`
- [ ] `npm run test:e2e`
- [ ] `node scripts/generate_all.js`
- [x] Not applicable

`npm run audit` passes and all 71 tests pass. `generate_all.js` was not needed — no agent, skill, or MCP inputs changed. Beyond the suite, the fix was verified against a local bare repository with a `pre-receive` hook rejecting every `refs/heads/main` update, which reproduces GitHub's protection behaviour:

- old config → reproduces the `GH006` rejection, rolls the tag back, exits non-zero;
- new config → exits 0, leaves the remote `main` ref byte-identical, pushes the annotated tag, writes no `CHANGELOG.md`, leaves the tree clean.

The gate logic was exercised against the repository's real history for the resume case (`main == develop`, 10 untagged feat/fix → release), the quiet-day case (tag at develop's head → clean no-op), the no-tags-yet case, and a decoy non-CalVer tag (correctly ignored).

## Security and Secrets

- [x] No real secrets were added to the repo
- [x] Fetch-on-Demand patterns were preserved (`infisical run` / `op run`)
- [x] `.env.template` / `.env.example` files remain inventories or vault references only

No change to secret handling. The release step keeps using the default `GITHUB_TOKEN`; the App token's blast radius is narrowed rather than widened — it is now minted only when a promotion PR is actually needed.

## Docs and Generated Outputs

- [x] README or docs were updated when behavior changed
- [x] Generated outputs were refreshed when inputs changed
- [x] Golden fixtures were updated intentionally when generated sections changed

`docs/RELEASE_PROCESS.md` updated: where the changelog lives and why, the tag-relative gate and its resume path, and what a dry run now covers. No generated outputs or golden fixtures were affected.

## Notes for Reviewers

The load-bearing subtlety is worth confirming: with `git.commit: false`, the local branch stays byte-identical to `origin/main`, so `git push --follow-tags` sends no branch ref update and protection is never evaluated. Two things enforce that invariant — the sync step's `git reset --hard origin/main`, and `requireCleanWorkingDir: true` as the backstop that aborts if anything dirties the tree. Re-enabling `git.commit` would reintroduce the failure.

After this merges, the stranded `2026.08.05` release can be recovered by re-running the workflow: the tag-relative gate sees the untagged content, skips the already-merged promotion, and stamps the release.

One cosmetic artifact is left as-is and documented: `release-it`'s console preview prints the changelog heading as `[null]` before the plugin's `bump()` re-renders it. The published Release body carries the correct version — verified locally.
