### PR TITLE
fix(governance): ADC auth for review — org policy disallows API keys

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -9,8 +9,10 @@
 # block a merge is a gate; phase 1 is an advisory signal being calibrated. Do
 # not add it to branch protection contexts before phase 2.
 #
-# Secrets come from Infisical at runtime via GitHub's OIDC identity, so no
-# credential is stored in GitHub. Only non-secret IDs live in Variables.
+# No credential is stored in GitHub. The GitHub token comes from Infisical via
+# OIDC, and Google access comes from Workload Identity Federation — required
+# here, since org policy disallows API keys and service-account keys alike.
+# Only non-secret IDs live in Variables.
 #
 # The carve-out, gate ordering, and severity rubric are enforced inside
 # scripts/review-pr.js — deliberately not duplicated here. Two copies of a
@@ -52,13 +54,33 @@ jobs:
         env:
           PROJECT_ID: ${{ vars.INFISICAL_PROJECT_ID }}
           IDENTITY_ID: ${{ vars.INFISICAL_IDENTITY_ID }}
+          WIF_PROVIDER: ${{ vars.GCP_WIF_PROVIDER }}
+          GCP_SA: ${{ vars.GCP_SERVICE_ACCOUNT }}
         run: |
-          if [[ -z "${PROJECT_ID}" || -z "${IDENTITY_ID}" ]]; then
+          missing=()
+          [[ -z "${PROJECT_ID}"   ]] && missing+=(INFISICAL_PROJECT_ID)
+          [[ -z "${IDENTITY_ID}"  ]] && missing+=(INFISICAL_IDENTITY_ID)
+          [[ -z "${WIF_PROVIDER}" ]] && missing+=(GCP_WIF_PROVIDER)
+          [[ -z "${GCP_SA}"       ]] && missing+=(GCP_SERVICE_ACCOUNT)
+          if (( ${#missing[@]} )); then
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=AI review skipped::Set the INFISICAL_PROJECT_ID and INFISICAL_IDENTITY_ID repository variables to enable. See docs/examples/cross-model-review-setup.md."
+            echo "::notice title=AI review skipped::Missing repository variables: ${missing[*]}. See docs/examples/cross-model-review-setup.md."
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # Federation, not a key. This organization's policy disallows both API
+      # keys and service-account keys, so a short-lived federated token is the
+      # only available mechanism — and the strongest one: nothing durable to
+      # leak or rotate.
+      - name: Authenticate to Google Cloud (Workload Identity Federation)
+        if: steps.config.outputs.configured == 'true'
+        id: gcpauth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          token_format: access_token
 
       - name: Install Infisical CLI
         if: steps.config.outputs.configured == 'true'
@@ -96,6 +118,11 @@ jobs:
           GEMINI_REVIEW_FLOOR: ${{ vars.GEMINI_REVIEW_FLOOR || 'flash' }}
           INFISICAL_PROJECT_ID: ${{ vars.INFISICAL_PROJECT_ID }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Short-lived, federated. Never a stored credential.
+          GCP_ACCESS_TOKEN: ${{ steps.gcpauth.outputs.access_token }}
+          GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT || 'project-noemi' }}
+          GOOGLE_CLOUD_LOCATION: ${{ vars.GOOGLE_CLOUD_LOCATION || 'us-central1' }}
+          GEMINI_BACKEND: ${{ vars.GEMINI_BACKEND || 'vertex' }}
         run: |
           # Exit 1 means a deliberate halt (carve-out, or no model met the
           # floor). That is a correct outcome, not a failure of the job.

--- a/docs/examples/cross-model-review-setup.md
+++ b/docs/examples/cross-model-review-setup.md
@@ -35,7 +35,7 @@ So the setup below does three things:
 |---|---|
 | `noemi-agent` | GitHub account the writing AI uses. Can push code, cannot approve |
 | `noemi-reviewer` | GitHub account the reviewing AI uses. **Cannot** push code |
-| A Gemini API key | Lets the reviewing AI actually run |
+| Google Cloud access via ADC | Lets the reviewing AI run. **No API key** — org policy disallows them |
 | Infisical secrets | Where those credentials live. Never in files, never in chat |
 | A GitHub workflow | Runs the review automatically on each pull request |
 
@@ -47,7 +47,7 @@ You need:
 - **An Infisical account** with a project created ([infisical.com](https://infisical.com))
 - **The `gh` CLI** installed and logged in (`gh auth login`)
 - **The `infisical` CLI** installed and logged in (`infisical login`)
-- **A Google account** for the Gemini key
+- **Google Cloud access** to `project-noemi`, and the `gcloud` CLI installed
 
 Check the CLIs are working:
 
@@ -58,120 +58,158 @@ infisical user get
 
 ---
 
-# Part 1 — Choosing your Gemini key
+# Part 1 — Google Cloud access (no API key)
 
-This is the decision most people get wrong, so it comes first.
+If your Google Cloud organization allows API keys, you have choices here. **If it
+does not, this section is not a decision — it is the only path.**
 
-There are three ways to get Gemini access. They differ in setup effort, and — the
-part that matters — in **whether Google may use your code to train their
-models**.
+`project-noemi` is in the second category. The console reports:
 
-| | Setup time | Long-lived key? | Your code used for training? | Code changes needed |
-|---|---|---|---|---|
-| **A. AI Studio, free tier** | 5 minutes | Yes | **Likely yes** | None |
-| **B. Gemini API, billed project** | ~30 minutes | Yes | No | None |
-| **C. Vertex AI + federation** | Half a day | **No** | No | Yes |
+> API Keys are Disallowed — Your organization's security policy disallows API
+> keys. Please use Application Default Credentials (ADC) instead.
 
-## Option A — AI Studio free key
+Service-account **key** creation is disallowed too. So both of the usual
+static-credential mechanisms are unavailable, and every option that begins
+"create a key and store it" is off the table.
 
-**How:** Go to [aistudio.google.com](https://aistudio.google.com) → *Get API
-key* → *Create API key*. Done in about a minute.
+## Why this is good news
 
-**Good:** Fastest possible start. Works immediately with this repository's code.
+The mechanism you are forced onto is the one a security review would have asked
+for anyway:
 
-**Bad:** Free-tier terms have historically allowed Google to use your prompts to
-improve their products. **Your reviewer reads entire code diffs.** For a public
-repository that is tolerable. The moment you point this at a private or client
-repository, it is a data-governance problem. Free quotas are also low, and a
-thorough review uses the expensive models.
+| | Static key in a vault | ADC / federation |
+|---|---|---|
+| Credential lifetime | months | minutes |
+| Can leak in a log | yes | expires before it matters |
+| Rotation burden | yours, forever | none |
+| Audit attribution | "the key" | the identity that used it |
 
-**Use it for:** proving the pipeline works. Not for real operation.
+There is nothing durable to steal, so there is nothing to rotate.
 
-## Option B — Gemini API key on a billed Google Cloud project
+**And it simplifies the vault story.** Infisical stores *nothing* for Gemini,
+because there is no secret to store. That is the correct reading of "use the
+vault wherever possible" — a vault protects static secrets, and federation
+removes them.
 
-**Recommended starting point.**
+## The two authentication paths
 
-**How:**
+They are different, and a common mistake is assuming the first covers the
+second. It does not.
 
-1. Go to [console.cloud.google.com](https://console.cloud.google.com)
-2. Create a new project (name it something like `noemi-ai-review`)
-3. Link a billing account: **Billing** → *Link a billing account*
-4. Enable the API: **APIs & Services** → *Enable APIs* → search
-   "Generative Language API" → **Enable**
-5. Create the key: **APIs & Services** → *Credentials* → *Create Credentials* →
-   *API key*
-6. **Restrict it** — click the new key → *API restrictions* → *Restrict key* →
-   select only **Generative Language API** → *Save*
+### Local development — user ADC
 
-Step 6 matters. An unrestricted key works for every Google API your project can
-reach; a restricted one only does the job you created it for.
+One command, opens a browser:
 
-**Good:** Paid tier means your code is not used for training. Real quotas. Usage
-and cost visible in Cloud Billing, so you can see what review costs per pull
-request. No code changes — the repository already targets this API.
+```bash
+gcloud auth application-default login
+```
 
-**Bad:** Still a long-lived key, so it must live in a vault and be rotated.
+The `setup_adc.sh` helper the console offers is a wrapper around this.
 
-> **Note on IP restrictions:** you may be tempted to lock the key to an IP
-> address. GitHub's hosted runners use changing IPs, so this will break. API
-> restriction is the meaningful control here.
+Confirm it worked without printing the credential:
 
-## Option C — Vertex AI with Workload Identity Federation
+```bash
+node scripts/gcp-token.js        # expect: ADC token obtained via gcloud-adc
+```
 
-**The eventual target, not the starting point.**
+This credential expires and needs re-running periodically. When it lapses, the
+tooling tells you exactly that rather than failing obscurely.
 
-GitHub proves its identity to Google directly, and Google hands back a
-short-lived token. **No key exists anywhere** — nothing to leak, nothing to
-rotate.
+### GitHub Actions — Workload Identity Federation
 
-**Good:** No long-lived credential. Full Google Cloud IAM, audit logs, data
-residency controls, and per-identity attribution of every review call. This is
-what a regulated environment will ask for.
+**`gcloud auth application-default login` cannot work in CI.** There is no
+browser and no user. And you cannot fall back to a service-account key, because
+those are disallowed.
 
-**Bad:** Vertex uses a different API endpoint than options A and B, so
-[`scripts/resolve-gemini-model.js`](../../scripts/resolve-gemini-model.js) needs
-a new code path. Also requires configuring workload identity pools and pinning a
-region.
+So GitHub proves its own identity to Google and receives a short-lived token.
+One-time setup:
 
-> **A note that sounds contradictory but isn't:** this project's rule is "use
-> Infisical wherever possible." With Option C, Infisical stores *nothing* for
-> Gemini — because there is no secret to store. That is the stronger version of
-> the rule, not an exception to it. A vault protects static secrets; federation
-> removes them.
+```bash
+# 1. A pool to hold external identities
+gcloud iam workload-identity-pools create github \
+  --location=global --project=project-noemi \
+  --display-name="GitHub Actions"
 
-## Recommendation
+# 2. A provider that trusts GitHub's OIDC issuer
+gcloud iam workload-identity-pools providers create-oidc github-provider \
+  --location=global --workload-identity-pool=github --project=project-noemi \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
+  --attribute-condition="assertion.repository=='project-noemi/agents'"
 
-**Start with B. Move to C before pointing this at any client repository.**
+# 3. A service account for the workflow to act as
+gcloud iam service-accounts create noemi-reviewer \
+  --project=project-noemi --display-name="NoeMI AI reviewer"
 
-⚠️ **Verify the current terms yourself.** Google revises Gemini API tiers and
-data-use policy often, and the free-versus-paid training distinction is the
-single fact this recommendation depends on. Read the current terms before
-choosing A.
+# 4. Let Vertex AI be called by it
+gcloud projects add-iam-policy-binding project-noemi \
+  --member="serviceAccount:noemi-reviewer@project-noemi.iam.gserviceaccount.com" \
+  --role="roles/aiplatform.user"
+
+# 5. Let only this repository impersonate it
+PROJECT_NUMBER=$(gcloud projects describe project-noemi --format='value(projectNumber)')
+gcloud iam service-accounts add-iam-policy-binding \
+  noemi-reviewer@project-noemi.iam.gserviceaccount.com --project=project-noemi \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository/project-noemi/agents"
+```
+
+⚠️ **Step 2's `--attribute-condition` is the security boundary.** Without it,
+*any* GitHub repository anywhere could request a token for your service account.
+Do not omit it.
+
+Then set these repository **Variables** (Settings → Secrets and variables →
+Actions → Variables). None is a secret:
+
+| Variable | Value |
+|---|---|
+| `GCP_WIF_PROVIDER` | `projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/github/providers/github-provider` |
+| `GCP_SERVICE_ACCOUNT` | `noemi-reviewer@project-noemi.iam.gserviceaccount.com` |
+| `GOOGLE_CLOUD_PROJECT` | `project-noemi` |
+| `GOOGLE_CLOUD_LOCATION` | `us-central1` (or your region) |
+
+## Enable the API
+
+```bash
+gcloud services enable aiplatform.googleapis.com --project=project-noemi
+```
+
+Vertex AI requires billing to be linked to the project.
+
+## Which backend
+
+`GEMINI_BACKEND` selects between two Google surfaces:
+
+- **`vertex`** (default) — `aiplatform.googleapis.com`, ADC's native home and
+  the surface your org policy points you at
+- **`generativelanguage`** — the Gemini API surface, historically API-key first
+
+The default is `vertex` because ADC is mandated here. If you find the
+Generative Language API accepts an ADC bearer token in your project, either
+works; flip the variable rather than changing code.
 
 ---
 
-# Part 2 — Store the key in Infisical
+# Part 2 — Link the repository to Infisical
 
-Never paste a secret into a chat window, a file, or a commit. Type it in your own
-terminal only.
+Infisical holds the **GitHub** credentials. It holds nothing for Gemini — there
+is no Gemini secret to hold.
 
-Link the repository to your Infisical project (creates `.infisical.json`):
+`.infisical.json` is gitignored because a workspace ID is organization-specific
+and would follow forks that cannot use it. So each clone creates its own:
 
 ```bash
 infisical init
 ```
 
-Store the key:
+For CI and non-interactive runs, where `init` is impractical, set the ID
+directly instead:
 
 ```bash
-infisical secrets set GEMINI_API_KEY="paste-your-key-here" --env=dev
+export INFISICAL_PROJECT_ID=<your-workspace-id>
 ```
 
-Confirm it is retrievable without printing it:
-
-```bash
-infisical secrets get GEMINI_API_KEY --env=dev >/dev/null && echo "stored OK"
-```
+A project ID is not a secret.
 
 ---
 
@@ -417,7 +455,9 @@ editing the merge gate to unblock its own pull requests.
 | `Token resolves to 'yourname', expected 'noemi-agent'` | Your own token is in the environment | The guard is working — unset `AGENT_GH_TOKEN` |
 | `Could not resolve the machine-identity token` | Secret missing from the vault | Re-store it (Part 2 / Part 3) |
 | `Infisical is installed but no project link was found` | `.infisical.json` is gitignored, so a fresh clone has none | `infisical init`, or set `INFISICAL_PROJECT_ID` for CI |
-| Workflow skips with a notice | `GEMINI_API_KEY` not reachable | Complete Part 4 |
+| Workflow skips with a notice | A required repository Variable is unset — the notice names it | Complete Part 1 and Part 4 |
+| `Application Default Credentials are missing or expired` | Local ADC lapsed | `gcloud auth application-default login` |
+| `GOOGLE_CLOUD_PROJECT is required` | Vertex backend without a project set | Set the variable, or use `GEMINI_BACKEND=generativelanguage` |
 | `No available model meets the floor` | Your key lacks access to strong models | Check your tier; the failure is intentional |
 | Reviewer's write probe **succeeds** | Token over-scoped | Set Contents to Read-only and re-probe |
 

--- a/scripts/gcp-token.js
+++ b/scripts/gcp-token.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Obtain a short-lived Google Cloud access token via Application Default
+ * Credentials. No static credential is read, stored, or logged.
+ *
+ * WHY THERE IS NO API KEY PATH
+ *   The `project-noemi` organization policy disallows API keys outright
+ *   ("Your organization's security policy disallows API keys. Please use
+ *   Application Default Credentials instead") AND disallows service-account
+ *   key creation. So the two usual static-credential mechanisms are both
+ *   unavailable, and ADC is not merely preferred — it is the only option.
+ *
+ *   This is a stronger posture than a vaulted key: the credential is
+ *   short-lived, so there is nothing durable to leak or rotate. It also means
+ *   Infisical stores nothing for Gemini, which is the correct reading of
+ *   "use the vault wherever possible" rather than an exception to it.
+ *
+ * RESOLUTION ORDER
+ *   1. $GCP_ACCESS_TOKEN — pre-injected. In GitHub Actions this comes from
+ *      google-github-actions/auth with `token_format: access_token`, which
+ *      obtains it through Workload Identity Federation (no key involved).
+ *   2. `gcloud auth application-default print-access-token` — local
+ *      development, after `gcloud auth application-default login`.
+ *
+ * The token is returned to the caller and never written to disk or stderr.
+ */
+
+'use strict';
+
+const { execFile } = require('node:child_process');
+
+/** Tokens are short-lived; cache within a process run only. */
+let cached = null;
+
+function fromGcloud() {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'gcloud',
+      ['auth', 'application-default', 'print-access-token'],
+      { timeout: 30_000 },
+      (err, stdout, stderr) => {
+        if (err) {
+          const detail = String(stderr || err.message).trim();
+          // Reauthentication is the common case and is not self-explanatory
+          // from gcloud's message alone in a CI-style log.
+          if (/[Rr]eauthentication|credentials/.test(detail)) {
+            reject(new Error(
+              'Application Default Credentials are missing or expired.\n'
+              + '  Local:  gcloud auth application-default login\n'
+              + '  CI:     use google-github-actions/auth (Workload Identity Federation)\n'
+              + `  gcloud said: ${detail.split('\n')[0]}`,
+            ));
+            return;
+          }
+          reject(new Error(`Could not obtain an ADC access token: ${detail.split('\n')[0]}`));
+          return;
+        }
+        const token = String(stdout).trim();
+        if (!token) {
+          reject(new Error('gcloud returned an empty access token.'));
+          return;
+        }
+        resolve(token);
+      },
+    );
+  });
+}
+
+/**
+ * @returns {Promise<string>} a short-lived OAuth2 access token
+ * @throws if no ADC source is available — deliberately loud, since silently
+ *         proceeding without credentials produces a confusing 401 later.
+ */
+async function getAccessToken() {
+  if (cached) return cached;
+
+  if (process.env.GCP_ACCESS_TOKEN) {
+    cached = process.env.GCP_ACCESS_TOKEN.trim();
+    return cached;
+  }
+
+  cached = await fromGcloud();
+  return cached;
+}
+
+/** Test seam: clear the in-process cache. */
+function resetTokenCache() {
+  cached = null;
+}
+
+/** Which source getAccessToken() will use, for diagnostics. Never the value. */
+function tokenSource() {
+  return process.env.GCP_ACCESS_TOKEN ? 'GCP_ACCESS_TOKEN' : 'gcloud-adc';
+}
+
+module.exports = { getAccessToken, resetTokenCache, tokenSource };
+
+if (require.main === module) {
+  // Reports the SOURCE, never the token — printing a credential to stdout is
+  // how it ends up in a log.
+  getAccessToken()
+    .then(() => {
+      process.stdout.write(`ADC token obtained via ${tokenSource()}\n`);
+    })
+    .catch((err) => {
+      process.stderr.write(`✖ ${err.message}\n`);
+      process.exit(2);
+    });
+}

--- a/scripts/resolve-gemini-model.js
+++ b/scripts/resolve-gemini-model.js
@@ -44,6 +44,8 @@
 
 'use strict';
 
+const { getAccessToken, tokenSource } = require('./gcp-token.js');
+
 const TIER_RANK = { pro: 300, flash: 200, 'flash-lite': 100 };
 const DEFAULT_FLOOR = process.env.GEMINI_REVIEW_FLOOR || 'flash';
 const API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
@@ -76,7 +78,9 @@ function parseArgs(argv) {
  * this script exists to avoid, silently ignoring any future generation.
  */
 function classify(id) {
-  const name = id.replace(/^models\//, '');
+  // Strip both shapes: `models/x` (Generative Language API) and
+  // `publishers/google/models/x` (Vertex AI).
+  const name = id.replace(/^publishers\/[^/]+\/models\//, '').replace(/^models\//, '');
   if (!/^gemini-/.test(name)) return null;
 
   const versionMatch = name.match(/gemini-(\d+(?:\.\d+)?)/);
@@ -117,23 +121,68 @@ function meetsFloor(model, floor) {
   return (TIER_RANK[model.tier] || 0) >= floorRank;
 }
 
-async function listModels(apiKey) {
+/** Backend config. Vertex is the default because ADC is its native auth path
+ *  and this organization's policy mandates ADC. See docs. */
+function backendConfig() {
+  const backend = process.env.GEMINI_BACKEND || 'vertex';
+  const project = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || '';
+  const location = process.env.GOOGLE_CLOUD_LOCATION || 'us-central1';
+  if (backend !== 'vertex' && backend !== 'generativelanguage') {
+    throw new Error(`Unknown GEMINI_BACKEND '${backend}'. Use 'vertex' or 'generativelanguage'.`);
+  }
+  if (backend === 'vertex' && !project) {
+    throw new Error('GOOGLE_CLOUD_PROJECT is required for the vertex backend.');
+  }
+  return { backend, project, location };
+}
+
+/** Base URL for generateContent against a resolved model id. */
+function generateUrl(modelId, cfg) {
+  if (cfg.backend === 'generativelanguage') return `${API_BASE}/${modelId}:generateContent`;
+  const bare = modelId.replace(/^publishers\/[^/]+\/models\//, '').replace(/^models\//, '');
+  return `https://${cfg.location}-aiplatform.googleapis.com/v1/projects/${cfg.project}`
+    + `/locations/${cfg.location}/publishers/google/models/${bare}:generateContent`;
+}
+
+/**
+ * List models that can serve generateContent.
+ *
+ * Authenticated with an ADC bearer token — never an API key, which this
+ * organization's policy disallows.
+ */
+async function listModels(token, cfg = backendConfig()) {
+  const headers = { Authorization: `Bearer ${token}` };
   const out = [];
   let pageToken = '';
+
   // Paginate: assuming one page is how you silently miss the newest model.
   do {
-    const url = `${API_BASE}/models?pageSize=200${pageToken ? `&pageToken=${pageToken}` : ''}`;
-    const res = await fetch(url, { headers: { 'x-goog-api-key': apiKey } });
+    const url = cfg.backend === 'generativelanguage'
+      ? `${API_BASE}/models?pageSize=200${pageToken ? `&pageToken=${pageToken}` : ''}`
+      : `https://${cfg.location}-aiplatform.googleapis.com/v1/publishers/google/models`
+        + `?pageSize=200&filter=name:gemini*${pageToken ? `&pageToken=${pageToken}` : ''}`;
+
+    const res = await fetch(url, { headers });
     if (!res.ok) {
-      throw new Error(`ListModels failed: HTTP ${res.status} ${await res.text()}`);
+      throw new Error(`ListModels (${cfg.backend}) failed: HTTP ${res.status} ${await res.text()}`);
     }
     const body = await res.json();
-    for (const m of body.models || []) {
-      const methods = m.supportedGenerationMethods || [];
-      if (methods.includes('generateContent')) out.push(m.name);
+
+    if (cfg.backend === 'generativelanguage') {
+      for (const m of body.models || []) {
+        if ((m.supportedGenerationMethods || []).includes('generateContent')) out.push(m.name);
+      }
+    } else {
+      // Vertex publisher models do not advertise supportedGenerationMethods
+      // uniformly; ranking filters non-Gemini entries anyway.
+      for (const m of body.publisherModels || body.models || []) {
+        if (m.name) out.push(m.name);
+      }
     }
+
     pageToken = body.nextPageToken || '';
   } while (pageToken);
+
   return out;
 }
 
@@ -155,16 +204,22 @@ async function main() {
     return;
   }
 
-  const apiKey = process.env.GEMINI_API_KEY;
-  if (!apiKey) {
-    process.stderr.write('✖ GEMINI_API_KEY not present in the environment.\n');
-    process.stderr.write('  Resolve it at runtime: infisical run --env=dev -- node scripts/resolve-gemini-model.js\n');
+  // ADC only. This organization's policy disallows API keys and
+  // service-account keys, so there is no static-credential path to fall back
+  // to — see scripts/gcp-token.js.
+  let token;
+  let cfg;
+  try {
+    cfg = backendConfig();
+    token = await getAccessToken();
+  } catch (err) {
+    process.stderr.write(`✖ ${err.message}\n`);
     process.exit(2);
   }
 
   let available;
   try {
-    available = await listModels(apiKey);
+    available = await listModels(token, cfg);
   } catch (err) {
     process.stderr.write(`✖ Could not list models: ${err.message}\n`);
     process.exit(2);
@@ -187,13 +242,14 @@ async function main() {
     reasoning: chosen.reasoning,
     resolved_at: new Date().toISOString(),
     floor: args.floor,
+    backend: cfg.backend,
     considered: ranked.length,
   };
 
   // Audit log to stderr, payload to stdout, per CLAUDE.md.
   process.stderr.write(`${JSON.stringify({
     task: 'Resolve highest-capability Gemini model for review',
-    inputs: [`floor=${args.floor}`, `allow_preview=${args.allowPreview}`],
+    inputs: [`floor=${args.floor}`, `allow_preview=${args.allowPreview}`, `backend=${cfg.backend}`, `auth=${tokenSource()}`],
     actions: [`listed ${available.length} models`, `ranked ${ranked.length} candidates`, `selected ${chosen.id}`],
     risks: chosen.preview ? ['selected a preview build'] : [],
     result: chosen.id,
@@ -204,7 +260,10 @@ async function main() {
 
 // Importable as a module so the review runner can reuse the ranking logic
 // without shelling out; still runs as a CLI when invoked directly.
-module.exports = { classify, scoreOf, rank, meetsFloor, listModels, TIER_RANK };
+module.exports = {
+  classify, scoreOf, rank, meetsFloor, listModels,
+  backendConfig, generateUrl, TIER_RANK,
+};
 
 if (require.main === module) {
   main().catch((err) => {

--- a/scripts/review-pr.js
+++ b/scripts/review-pr.js
@@ -33,7 +33,13 @@
  *   --no-post   run the real review, print the comment instead of posting it.
  *
  * ENVIRONMENT
- *   GEMINI_API_KEY       required unless --dry-run
+ *   ADC                  required unless --dry-run. No API key exists: this
+ *                        organization's policy disallows API keys AND
+ *                        service-account keys, so ADC is the only path.
+ *                        Local: gcloud auth application-default login
+ *                        CI:    google-github-actions/auth (federation)
+ *   GOOGLE_CLOUD_PROJECT required for the vertex backend
+ *   GEMINI_BACKEND       vertex (default) | generativelanguage
  *   REVIEWER_GH_TOKEN    always required — pull-request context is read over
  *                        the API in every mode
  *   GITHUB_REPOSITORY    owner/repo (Actions sets this)
@@ -47,7 +53,10 @@
 
 'use strict';
 
-const { rank, meetsFloor, listModels } = require('./resolve-gemini-model.js');
+const {
+  rank, meetsFloor, listModels, backendConfig, generateUrl,
+} = require('./resolve-gemini-model.js');
+const { getAccessToken, tokenSource } = require('./gcp-token.js');
 
 const GH_API = 'https://api.github.com';
 const GEMINI_API = 'https://generativelanguage.googleapis.com/v1beta';
@@ -297,10 +306,10 @@ async function gh(path, { token, accept = 'application/vnd.github+json', method 
   return accept.includes('diff') ? res.text() : res.json();
 }
 
-async function callGemini(model, prompt, apiKey) {
-  const res = await fetch(`${GEMINI_API}/${model}:generateContent`, {
+async function callGemini(model, prompt, token, cfg) {
+  const res = await fetch(generateUrl(model, cfg), {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify({
       contents: [{ parts: [{ text: prompt }] }],
       generationConfig: { responseMimeType: 'application/json', temperature: 0 },
@@ -326,10 +335,17 @@ async function main() {
   }
 
   const ghToken = process.env.REVIEWER_GH_TOKEN;
-  const apiKey = process.env.GEMINI_API_KEY;
-  if (!args.dryRun && !apiKey) {
-    process.stderr.write('✖ GEMINI_API_KEY not set. Use: infisical run --env=dev -- node scripts/review-pr.js --pr N\n');
-    process.exit(2);
+  // No API-key path exists by design — see scripts/gcp-token.js.
+  let token = null;
+  let cfg = null;
+  if (!args.dryRun) {
+    try {
+      cfg = backendConfig();
+      token = await getAccessToken();
+    } catch (err) {
+      process.stderr.write(`✖ ${err.message}\n`);
+      process.exit(2);
+    }
   }
   // Needed in every mode: pull-request context is read over the API even on a
   // dry run, so there is no offline path here.
@@ -365,7 +381,7 @@ async function main() {
   // --- model -------------------------------------------------------------
   let model = 'models/(dry-run)';
   if (!args.dryRun) {
-    const ranked = rank(await listModels(apiKey), { allowPreview: false });
+    const ranked = rank(await listModels(token, cfg), { allowPreview: false });
     const chosen = ranked.find((m) => meetsFloor(m, args.floor));
     if (!chosen) {
       process.stderr.write(`✖ No available model meets the '${args.floor}' floor. Refusing to review on an under-capability model.\n`);
@@ -389,7 +405,7 @@ async function main() {
       continue;
     }
 
-    const reply = await callGemini(model, buildGatePrompt(gate, ctx), apiKey);
+    const reply = await callGemini(model, buildGatePrompt(gate, ctx), token, cfg);
     const gateFindings = validateFindings(reply.findings, gate.id);
     const { verdict } = gateVerdict(gateFindings);
     gates[gate.id] = { verdict, rationale: reply.rationale || '' };
@@ -419,7 +435,7 @@ async function main() {
 
   process.stderr.write(`${JSON.stringify({
     task: 'Three-gate cross-model review',
-    inputs: [`pr=${repo}#${args.pr}`, `files=${files.length}`, `model=${model}`],
+    inputs: [`pr=${repo}#${args.pr}`, `files=${files.length}`, `model=${model}`, `backend=${cfg ? cfg.backend : 'dry-run'}`, `auth=${args.dryRun ? 'none' : tokenSource()}`],
     actions: GATES.map((g) => `${g.id}: ${gates[g.id].verdict}`),
     risks: findings.filter((f) => BLOCKING_SEVERITIES.includes(f.severity)).map((f) => `${f.severity}: ${f.claim}`),
     result: review.recommendation,

--- a/tests/review-runner.test.js
+++ b/tests/review-runner.test.js
@@ -234,3 +234,82 @@ test('model floor: a flash model does not satisfy a pro floor', () => {
     assert.equal(meetsFloor(flash, 'pro'), false);
     assert.equal(meetsFloor(flash, 'flash'), true);
 });
+
+// --- backend + ADC auth ----------------------------------------------------
+// The organization disallows API keys AND service-account keys, so ADC is the
+// only mechanism. These cover the config and URL shaping that depends on it.
+
+const { backendConfig, generateUrl } = require('../scripts/resolve-gemini-model.js');
+const { tokenSource, resetTokenCache } = require('../scripts/gcp-token.js');
+
+function withEnv(vars, fn) {
+    const saved = {};
+    for (const [k, v] of Object.entries(vars)) {
+        saved[k] = process.env[k];
+        if (v === undefined) delete process.env[k]; else process.env[k] = v;
+    }
+    try { return fn(); } finally {
+        for (const [k, v] of Object.entries(saved)) {
+            if (v === undefined) delete process.env[k]; else process.env[k] = v;
+        }
+    }
+}
+
+test('backend defaults to vertex, since ADC is its native auth path', () => {
+    withEnv({ GEMINI_BACKEND: undefined, GOOGLE_CLOUD_PROJECT: 'project-noemi', GCP_PROJECT: undefined }, () => {
+        const cfg = backendConfig();
+        assert.equal(cfg.backend, 'vertex');
+        assert.equal(cfg.project, 'project-noemi');
+        assert.equal(cfg.location, 'us-central1');
+    });
+});
+
+test('backend: vertex requires a project rather than guessing one', () => {
+    withEnv({ GEMINI_BACKEND: 'vertex', GOOGLE_CLOUD_PROJECT: undefined, GCP_PROJECT: undefined }, () => {
+        assert.throws(() => backendConfig(), /GOOGLE_CLOUD_PROJECT is required/);
+    });
+});
+
+test('backend: an unknown value fails loudly instead of defaulting', () => {
+    withEnv({ GEMINI_BACKEND: 'openai' }, () => {
+        assert.throws(() => backendConfig(), /Unknown GEMINI_BACKEND/);
+    });
+});
+
+test('generateUrl: vertex uses the regional endpoint and strips the publisher prefix', () => {
+    const url = generateUrl('publishers/google/models/gemini-3.6-pro', {
+        backend: 'vertex', project: 'project-noemi', location: 'europe-west4',
+    });
+    assert.equal(
+        url,
+        'https://europe-west4-aiplatform.googleapis.com/v1/projects/project-noemi'
+        + '/locations/europe-west4/publishers/google/models/gemini-3.6-pro:generateContent',
+    );
+});
+
+test('generateUrl: generativelanguage keeps the models/ form', () => {
+    assert.match(
+        generateUrl('models/gemini-3.6-pro', { backend: 'generativelanguage' }),
+        /generativelanguage\.googleapis\.com\/v1beta\/models\/gemini-3\.6-pro:generateContent$/,
+    );
+});
+
+test('classify: Vertex publisher-prefixed ids rank identically to models/ ids', () => {
+    const vertex = classify('publishers/google/models/gemini-3.6-pro-thinking');
+    const gl = classify('models/gemini-3.6-pro-thinking');
+    assert.equal(vertex.tier, gl.tier);
+    assert.equal(vertex.generation, gl.generation);
+    assert.equal(vertex.reasoning, gl.reasoning);
+    assert.equal(vertex.name, 'gemini-3.6-pro-thinking');
+});
+
+test('token source is reported without exposing the token value', () => {
+    resetTokenCache();
+    withEnv({ GCP_ACCESS_TOKEN: 'ya29.fake-token-value' }, () => {
+        assert.equal(tokenSource(), 'GCP_ACCESS_TOKEN');
+    });
+    withEnv({ GCP_ACCESS_TOKEN: undefined }, () => {
+        assert.equal(tokenSource(), 'gcloud-adc');
+    });
+    resetTokenCache();
+});


### PR DESCRIPTION
## Premise

The `project-noemi` org policy disallows API keys:

> API Keys are Disallowed — Your organization's security policy disallows API keys. Please use Application Default Credentials (ADC) instead.

Service-account **key** creation is disallowed too. So both static-credential mechanisms are gone — and #354 shipped a review path authenticating with `x-goog-api-key`. **That code provably cannot run in this organization.** This replaces it.

There is deliberately **no API-key fallback.** A fallback to a mechanism policy forbids is dead code that invites someone to re-enable it later.

## Why the constraint improves the design

| | Static key in a vault | ADC / federation |
|---|---|---|
| Lifetime | months | minutes |
| Leaks in a log | permanent problem | expires first |
| Rotation burden | yours, forever | none |
| Audit attribution | "the key" | the identity that used it |

And it resolves the vault question cleanly: **Infisical now stores nothing for Gemini**, because there is no Gemini secret. That's the "use the vault wherever possible" rule working correctly, not an exception to it.

## Changes

- **`scripts/gcp-token.js`** — short-lived tokens from `$GCP_ACCESS_TOKEN` (federation, in CI) or gcloud ADC (local). Reports its *source*, never the value. Expired credentials produce guidance naming both the local and the CI remedy, because gcloud's own message names neither.
- Both scripts send `Authorization: Bearer`.
- **`GEMINI_BACKEND`** selects `vertex` (default) or `generativelanguage`.
- **`classify()`** accepts Vertex `publishers/google/models/...` ids, so ranking is identical across both surfaces.
- **Workflow** authenticates via Workload Identity Federation, and now fails closed on any missing variable while naming which one.
- **Setup guide** credential section rewritten — it recommended a billed API key, which cannot exist here.

### Why `vertex` is a variable, not a hardcoded choice

ADC's native home is Vertex, and your policy mandates ADC, so `vertex` is the reasoned default. But whether `generativelanguage` accepts an ADC bearer token *in this project* is **untested** — so it stays a config flip rather than a rewrite. One live call settles it.

## The security boundary worth reviewing

The WIF provider's `--attribute-condition`:

```
--attribute-condition="assertion.repository=='project-noemi/agents'"
```

**Without this, any GitHub repository anywhere could request a token for your service account.** It's called out with a warning in the guide rather than buried in a command block.

## Verification

- `npm test` — **78/78 pass** (34 in the review suite, 7 new covering backend config, URL shaping, and cross-surface id classification)
- `node scripts/audit-repo.js` — passes
- Workflow YAML parses; all guide links resolve
- Failure paths confirmed actionable — expired ADC yields the local *and* CI remedy, not just gcloud's raw error
- `--dry-run` still works fully offline

## ⚠️ Not verified end-to-end

**No live model call has been made.** Local ADC is currently unauthenticated and `aiplatform.googleapis.com` is not yet enabled on the project, so gate prompts, response parsing, Vertex model discovery, and cost per PR remain untested against the real API. The workflow skips cleanly while unconfigured, so merging cannot break CI.

Expect a follow-up correcting the Vertex model-listing call specifically — `publisherModels` response shaping is the part I could least verify from here.

## Out of scope, but flagged

`scripts/verify-env.sh` and `verify-env.ps1` still check for `GEMINI_API_KEY`, which can never be set under this policy. Left alone deliberately — they gate the whole onboarding flow and deserve their own change.