### PR TITLE
chore(governance): add co-owners to CODEOWNERS default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,21 +15,23 @@
 #
 # See docs/AI_REVIEW_GOVERNANCE.md.
 #
-# ⚠ CONSEQUENCE: with `require_code_owner_reviews` enabled, a PR authored by the
-# sole owner below cannot be approved by that owner (GitHub blocks
-# self-approval) and will need either a second owner or an admin bypass. Since
-# the fleet direction is bot-authored PRs, that case should be rare — but if
-# human-authored PRs remain common, add co-owners here:
+# Any ONE listed owner satisfies the requirement. Co-owners therefore remove the
+# self-approval deadlock — a PR authored by one owner can be approved by another,
+# since GitHub blocks only self-approval — without weakening the gate against
+# agent approvals, because no agent identity appears on this list.
 #
-#     * @WSwarm @second-admin @third-admin
-#
-# Any ONE listed owner satisfies the requirement, so co-owners remove the
-# self-approval deadlock without weakening the gate against agent approvals.
-* @WSwarm
+# All listed accounts hold write access or above (admin or maintain), which
+# CODEOWNERS requires; an entry without it is silently ignored, which would make
+# the gate look enforced while satisfying nothing.
+* @WSwarm @thakivagyok @maxalbanese @viktorjavor @beresb98 @to-eszti
 
 # --- Carve-out: repository owner only ----------------------------------------
-# These paths stay restricted to the owner even if co-owners are added above.
-# Later rules win in CODEOWNERS, so these override the default.
+# These paths stay restricted to the owner despite the co-owners above. Later
+# rules win in CODEOWNERS, so these override the default line entirely — a
+# change here needs @WSwarm specifically, not any one of the six.
+#
+# These are the files that constrain the agents. Widening who can approve
+# changes to them would widen who can loosen the constraints themselves.
 /.github/workflows/require-develop-source.yml @WSwarm
 /.github/CODEOWNERS @WSwarm
 /docs/MACHINE_IDENTITY.md @WSwarm


### PR DESCRIPTION
## What

Five co-owners alongside `@WSwarm` on the default path, per owner decision:

```
* @WSwarm @thakivagyok @maxalbanese @viktorjavor @beresb98 @to-eszti
```

## Why this unblocks the gate

Any **one** listed owner satisfies a code-owner requirement. So this removes the deadlock `require_code_owner_reviews` would otherwise create: a PR authored by one owner can be approved by another, because GitHub blocks only *self*-approval.

It does not weaken the gate against agent approvals — **no agent identity appears on this list**, which is precisely the property the code-owner requirement exists to supply. `noemi-reviewer` holds `Pull requests: write` and could technically approve, but its approval can never satisfy a code-owner rule.

## Eligibility verified, not assumed

CODEOWNERS **silently ignores** entries without write access, which would leave the gate looking enforced while satisfying nothing. All six were checked against the API:

| Account | Access | Eligible |
|---|---|---|
| `@WSwarm` | admin | ✓ |
| `@thakivagyok` | admin | ✓ |
| `@maxalbanese` | admin | ✓ |
| `@viktorjavor` | admin | ✓ |
| `@beresb98` | maintain | ✓ |
| `@to-eszti` | maintain | ✓ |

(`peteri14` has read access only and was excluded — an entry would have been ignored.)

## Carve-out paths stay owner-only

Unchanged, and deliberately so:

```
/.github/workflows/require-develop-source.yml @WSwarm
/.github/CODEOWNERS                          @WSwarm
/docs/MACHINE_IDENTITY.md                    @WSwarm
/docs/AI_REVIEW_GOVERNANCE.md                @WSwarm
```

Later rules win in CODEOWNERS, so these override the default entirely — a change to any of them needs `@WSwarm` specifically, not any one of the six. These are the files that constrain the agents; widening who can approve changes to them would widen who can loosen the constraints themselves.

## ⚠️ This PR does not enable the gate

`require_code_owner_reviews` is still `false` on both branches. It takes effect only when `scripts/setup-branch-protection.sh` runs, and **that must happen after this merges** — enabling it while `@WSwarm` is the sole owner would immediately block every human-authored PR, including the release train.

Sequence: merge this → then I run the script.

## Verification

- `node scripts/audit-repo.js` passes (including the merge-gate invariant)
- `npm test` — 71/71
- All six owners confirmed eligible via the collaborators API

## Reviewer

Touches `.github/CODEOWNERS`, a carve-out path — needs `@WSwarm` specifically.