### PR TITLE
fix(governance): recover stranded review fixes, org-scoped WIF, dispatch input

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -123,6 +123,10 @@ jobs:
           GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT || 'project-noemi' }}
           GOOGLE_CLOUD_LOCATION: ${{ vars.GOOGLE_CLOUD_LOCATION || 'us-central1' }}
           GEMINI_BACKEND: ${{ vars.GEMINI_BACKEND || 'vertex' }}
+          # prefer_pro_tier: opt-in. Off by default so selection follows the
+          # newest-stable-generation rule rather than silently regressing a
+          # generation to satisfy a tier preference.
+          GEMINI_PREFER_PRO: ${{ vars.GEMINI_PREFER_PRO || '' }}
         run: |
           # Exit 1 means a deliberate halt (carve-out, or no model met the
           # floor). That is a correct outcome, not a failure of the job.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -23,6 +23,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
+    inputs:
+      pr:
+        description: 'Pull request number to review'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -30,7 +35,7 @@ permissions:
   id-token: write          # required to mint the OIDC token for Infisical
 
 concurrency:
-  group: ai-review-${{ github.event.pull_request.number || github.ref }}
+  group: ai-review-${{ github.event.pull_request.number || inputs.pr || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -117,7 +122,8 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GEMINI_REVIEW_FLOOR: ${{ vars.GEMINI_REVIEW_FLOOR || 'flash' }}
           INFISICAL_PROJECT_ID: ${{ vars.INFISICAL_PROJECT_ID }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Resolves on both triggers: the event on pull_request, the input on dispatch.
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
           # Short-lived, federated. Never a stored credential.
           GCP_ACCESS_TOKEN: ${{ steps.gcpauth.outputs.access_token }}
           GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT || 'project-noemi' }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -102,9 +102,14 @@ jobs:
         if: steps.config.outputs.configured == 'true'
         env:
           IDENTITY_ID: ${{ vars.INFISICAL_IDENTITY_ID }}
+          # Must match the audience configured on the Infisical identity's OIDC
+          # auth method. A mismatch fails with 401 "OIDC audience not allowed",
+          # which names the cause but not which side to change — it is this
+          # value, or the identity's allowed-audience field.
+          OIDC_AUDIENCE: ${{ vars.INFISICAL_OIDC_AUDIENCE || 'infisical' }}
         run: |
           JWT=$(curl -sH "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=infisical" | jq -r .value)
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${OIDC_AUDIENCE}" | jq -r .value)
           if [[ -z "$JWT" || "$JWT" == "null" ]]; then
             echo "::error title=OIDC token unavailable::Could not mint a GitHub identity token. Confirm 'id-token: write' permission."
             exit 1

--- a/docs/examples/cross-model-review-setup.md
+++ b/docs/examples/cross-model-review-setup.md
@@ -426,10 +426,29 @@ Instead, GitHub proves its identity to Infisical and receives temporary access.
 
 ## Create an Infisical machine identity
 
-In Infisical: **Organization Settings** → *Identities* → *Create identity*. Give
-it OIDC auth configured to trust GitHub Actions, then grant it read access to
-your project. Follow Infisical's current OIDC documentation for the exact trust
-fields — they are specific to your organization and repository.
+In Infisical: **Organization Settings** → *Identities* → *Create identity*, then
+add **OIDC Auth** as its authentication method and grant the identity read access
+to your project.
+
+Verified settings for GitHub Actions:
+
+| Field | Value |
+|---|---|
+| Issuer / Discovery URL | `https://token.actions.githubusercontent.com` |
+| **Audience** | must equal what the workflow requests — `infisical` by default |
+| Subject / claim filter | scope to your repositories, e.g. `repo:project-noemi/agents:*` |
+
+⚠️ **The audience is the field that fails first.** A mismatch produces:
+
+```
+401 Access denied: OIDC audience not allowed.
+```
+
+That names the cause but not which side to change. Either set the identity's
+allowed audience to `infisical`, or set the `INFISICAL_OIDC_AUDIENCE` repository
+variable to whatever the identity expects. They must match exactly.
+
+The identity's ID goes in the `INFISICAL_IDENTITY_ID` variable.
 
 ## In the workflow
 

--- a/docs/examples/cross-model-review-setup.md
+++ b/docs/examples/cross-model-review-setup.md
@@ -122,9 +122,45 @@ browser and no user. And you cannot fall back to a service-account key, because
 those are disallowed.
 
 So GitHub proves its own identity to Google and receives a short-lived token.
-One-time setup:
+
+#### Decide the scope first
+
+Federation can be scoped to one repository or to whole organizations. Widening it
+is a real decision: **anyone who can push a workflow file to an included
+repository can mint a token for the service account.** The blast radius is
+bounded by the service account's roles — with `roles/aiplatform.user` the
+realistic worst case is unauthorized Vertex usage billed to your project.
+
+Forks are excluded either way: a fork's `repository_owner` is the forker, and
+fork pull requests do not receive `id-token` permission by default.
+
+Project NoéMI's own deployment covers three organizations:
+
+| Organization | Login | Immutable ID |
+|---|---|---|
+| NewPush | `newpush` | `6222293` |
+| Project NoéMI | `project-noemi` | `271349740` |
+| NewPush Labs | `newpush-labs` | `183727677` |
+
+⚠️ **Bind on the numeric ID, not the name.** Organization logins are mutable: if
+one were renamed or deleted, someone could register the freed name and inherit
+impersonation rights. IDs cannot be reassigned.
+
+⚠️ **Logins are case-normalized and comparison is case-sensitive.** `newpush-Labs`
+is really `newpush-labs`. A condition written with the wrong casing never matches
+and authentication fails with nothing pointing at capitalization as the cause.
+Confirm the canonical login and ID before writing either:
 
 ```bash
+gh api orgs/<org> --jq '"login=\(.login) id=\(.id)"'
+```
+
+#### One-time setup
+
+```bash
+# 0. Prerequisite API. Missing, token exchange fails without mentioning STS.
+gcloud services enable sts.googleapis.com --project=project-noemi
+
 # 1. A pool to hold external identities
 gcloud iam workload-identity-pools create github \
   --location=global --project=project-noemi \
@@ -134,39 +170,71 @@ gcloud iam workload-identity-pools create github \
 gcloud iam workload-identity-pools providers create-oidc github-provider \
   --location=global --workload-identity-pool=github --project=project-noemi \
   --issuer-uri="https://token.actions.githubusercontent.com" \
-  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
-  --attribute-condition="assertion.repository=='project-noemi/agents'"
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner,attribute.repository_owner_id=assertion.repository_owner_id" \
+  --attribute-condition="assertion.repository_owner_id in ['6222293','271349740','183727677']"
 
 # 3. A service account for the workflow to act as
 gcloud iam service-accounts create noemi-reviewer \
   --project=project-noemi --display-name="NoeMI AI reviewer"
 
-# 4. Let Vertex AI be called by it
+# 4. Vertex access, and nothing else. Not aiplatform.admin.
 gcloud projects add-iam-policy-binding project-noemi \
   --member="serviceAccount:noemi-reviewer@project-noemi.iam.gserviceaccount.com" \
   --role="roles/aiplatform.user"
 
-# 5. Let only this repository impersonate it
+# 5. Let each organization impersonate it — one binding per org ID
 PROJECT_NUMBER=$(gcloud projects describe project-noemi --format='value(projectNumber)')
-gcloud iam service-accounts add-iam-policy-binding \
-  noemi-reviewer@project-noemi.iam.gserviceaccount.com --project=project-noemi \
-  --role="roles/iam.workloadIdentityUser" \
-  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository/project-noemi/agents"
+for ORG_ID in 6222293 271349740 183727677; do
+  gcloud iam service-accounts add-iam-policy-binding \
+    noemi-reviewer@project-noemi.iam.gserviceaccount.com --project=project-noemi \
+    --role="roles/iam.workloadIdentityUser" \
+    --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository_owner_id/${ORG_ID}"
+done
 ```
 
-⚠️ **Step 2's `--attribute-condition` is the security boundary.** Without it,
-*any* GitHub repository anywhere could request a token for your service account.
-Do not omit it.
+#### The two halves must agree
 
-Then set these repository **Variables** (Settings → Secrets and variables →
-Actions → Variables). None is a secret:
+Step 2's **attribute mapping and condition** and step 5's **bindings** are a
+matched pair, and a mismatch fails closed in a way that is hard to read:
+
+- The condition controls who may enter the pool. Leave it scoped to one
+  repository and no other repo can authenticate, regardless of the bindings.
+- The bindings reference a mapped attribute. Bind on
+  `attribute.repository_owner_id` without mapping it in step 2 and **the
+  attribute does not exist on any token, so no principal matches any binding** —
+  nothing authenticates at all, including the repository you intended to allow.
+
+This exact combination broke the first rollout. Verify both after setup:
+
+```bash
+gcloud iam workload-identity-pools providers describe github-provider \
+  --location=global --workload-identity-pool=github --project=project-noemi \
+  --format='value(attributeCondition,attributeMapping)'
+
+gcloud iam service-accounts get-iam-policy \
+  noemi-reviewer@project-noemi.iam.gserviceaccount.com --project=project-noemi
+```
+
+#### Repository Variables
+
+Settings → Secrets and variables → Actions → **Variables** tab. None is a
+secret, and the tab matters: Secrets are masked and write-only, which makes
+non-secrets harder to audit.
 
 | Variable | Value |
 |---|---|
 | `GCP_WIF_PROVIDER` | `projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/github/providers/github-provider` |
 | `GCP_SERVICE_ACCOUNT` | `noemi-reviewer@project-noemi.iam.gserviceaccount.com` |
 | `GOOGLE_CLOUD_PROJECT` | `project-noemi` |
-| `GOOGLE_CLOUD_LOCATION` | `us-central1` (or your region) |
+| `GOOGLE_CLOUD_LOCATION` | `us-central1` |
+| `INFISICAL_PROJECT_ID` | your Infisical workspace ID |
+| `INFISICAL_IDENTITY_ID` | your Infisical machine identity ID |
+
+⚠️ `GCP_WIF_PROVIDER` takes the project **number**, not the project ID. Using the
+ID fails with a message that does not mention which field is wrong.
+
+The workflow requires **all six** and skips with a notice naming the missing
+ones — so a partial rollout is safe, but a green job does not mean a review ran.
 
 ## Enable the API
 

--- a/docs/examples/cross-model-review-setup.md
+++ b/docs/examples/cross-model-review-setup.md
@@ -176,17 +176,56 @@ gcloud services enable aiplatform.googleapis.com --project=project-noemi
 
 Vertex AI requires billing to be linked to the project.
 
+## Which model gets chosen
+
+Not a name in a config file — names go stale. The resolver asks Google what
+exists and applies this rule:
+
+> Prefer the newest **stable** model of the highest available generation. Pro is
+> elevated only when a stable Pro exists in that generation; otherwise take the
+> best stable model of the latest generation.
+
+Generation dominates; tier orders *within* a generation. That matters because a
+hard tier preference looks sensible and quietly does the wrong thing: at the time
+of writing, every 3.x Pro is preview-only, so "always prefer Pro" would select a
+2.5-generation model while a stable 3.6 was available.
+
+Also filtered out: image, speech, embedding, robotics, and computer-use variants.
+Their names still contain "pro" and "flash", so a naive rank will cheerfully
+choose an *image* model to review your code. Most published Gemini models are
+wrong for this job.
+
+### The Pro toggle
+
+If you want Pro regardless, it is an explicit switch rather than a hidden weight:
+
+```bash
+node scripts/resolve-gemini-model.js --prefer-pro
+# or set the GEMINI_PREFER_PRO repository variable to 1
+```
+
+When the toggle costs you a generation, it tells you:
+
+```
+⚠ prefer_pro_tier selected gemini-2.5-pro (gen 2.5); without it the newest
+  stable choice is gemini-3.6-flash (gen 3.6).
+```
+
+Combine with `--allow-preview` to reach a newer Pro that is still in preview —
+accepting an unstable model inside a governance control.
+
 ## Which backend
 
 `GEMINI_BACKEND` selects between two Google surfaces:
 
-- **`vertex`** (default) — `aiplatform.googleapis.com`, ADC's native home and
-  the surface your org policy points you at
-- **`generativelanguage`** — the Gemini API surface, historically API-key first
+- **`vertex`** (default) — `aiplatform.googleapis.com`. **The only one that
+  works here.** Verified: an ADC bearer token against
+  `generativelanguage.googleapis.com` returns
+  `403 ACCESS_TOKEN_SCOPE_INSUFFICIENT`, because that surface expects an API key
+  — which your org policy disallows.
+- **`generativelanguage`** — retained for organizations that permit API keys.
 
-The default is `vertex` because ADC is mandated here. If you find the
-Generative Language API accepts an ADC bearer token in your project, either
-works; flip the variable rather than changing code.
+So on `project-noemi` this is not a choice. Leave it at `vertex`.
 
 ---
 

--- a/scripts/resolve-gemini-model.js
+++ b/scripts/resolve-gemini-model.js
@@ -21,13 +21,23 @@
  *   review's audit log, so a verdict is always attributable to what produced
  *   it. See docs/AI_REVIEW_GOVERNANCE.md.
  *
- * RANKING
- *   Capability tier first, then generation, then variant:
- *     tier:       pro > flash > flash-lite
- *     reasoning:  thinking/reasoning variants outrank their base model
- *     generation: higher version number wins
- *   Preview and experimental builds are eligible only with --allow-preview,
- *   since an unstable model behind a merge gate is its own risk.
+ * SELECTION RULE (owner decision 2026-08-11)
+ *   Prefer the newest stable model of the highest available generation. Pro is
+ *   elevated only when a stable Pro exists in that generation; otherwise take
+ *   the best stable model of the latest generation.
+ *
+ *   So generation dominates and tier orders within a generation. A hard-coded
+ *   tier weight looks like "prefer Pro" but drags selection backwards whenever
+ *   the newest generation has no stable Pro — which is the live situation.
+ *
+ *   --prefer-pro / GEMINI_PREFER_PRO=1 (`prefer_pro_tier` / `force_pro`) makes
+ *   Pro dominant instead. Selection may then fall back to an older stable Pro,
+ *   or with --allow-preview a preview Pro. Any generation regression caused by
+ *   the toggle is reported explicitly, because the rule requires the trade-off
+ *   to be visible rather than implicit.
+ *
+ *   Preview builds need --allow-preview: an unstable model inside a governance
+ *   control is its own risk.
  *
  * USAGE
  *   infisical run --env=dev -- node scripts/resolve-gemini-model.js
@@ -51,15 +61,21 @@ const DEFAULT_FLOOR = process.env.GEMINI_REVIEW_FLOOR || 'flash';
 const API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 
 function parseArgs(argv) {
-  const args = { floor: DEFAULT_FLOOR, json: false, allowPreview: false, dryRun: false };
+  const args = {
+    floor: DEFAULT_FLOOR, json: false, allowPreview: false, dryRun: false,
+    // `prefer_pro_tier` / `force_pro`: an explicit toggle, not a hidden weight.
+    preferPro: /^(1|true|yes)$/i.test(process.env.GEMINI_PREFER_PRO || ''),
+  };
   for (let i = 0; i < argv.length; i += 1) {
     switch (argv[i]) {
       case '--floor': args.floor = argv[++i]; break;
       case '--json': args.json = true; break;
       case '--allow-preview': args.allowPreview = true; break;
+      case '--prefer-pro':
+      case '--force-pro': args.preferPro = true; break;
       case '--dry-run': args.dryRun = true; break;
       case '--help':
-        process.stdout.write('Usage: resolve-gemini-model.js [--floor pro|flash|flash-lite] [--json] [--allow-preview] [--dry-run]\n');
+        process.stdout.write('Usage: resolve-gemini-model.js [--floor pro|flash|flash-lite] [--json] [--allow-preview] [--prefer-pro] [--dry-run]\n');
         process.exit(0);
         break;
       default:
@@ -73,6 +89,18 @@ function parseArgs(argv) {
 }
 
 /**
+ * Model families that cannot do the job. Reviewing code is a text task, but the
+ * Gemini family also publishes image, speech, embedding, robotics, and
+ * computer-use variants whose names still contain "pro" or "flash" — so a
+ * tier-based ranking will happily select `gemini-3-pro-image` to review a diff.
+ *
+ * Found by ranking the real published list rather than by reasoning: synthetic
+ * test names had no modality suffixes, so the defect was invisible until the
+ * live catalogue was ranked.
+ */
+const NON_TEXT_MODALITY = /(?:^|-)(?:image|tts|audio|embedding|robotics|omni)|computer-use|live-|-info$/;
+
+/**
  * Classify a model ID into ranking components. Deliberately pattern-based, not
  * an allowlist of known names — an allowlist would reintroduce the staleness
  * this script exists to avoid, silently ignoring any future generation.
@@ -82,6 +110,7 @@ function classify(id) {
   // `publishers/google/models/x` (Vertex AI).
   const name = id.replace(/^publishers\/[^/]+\/models\//, '').replace(/^models\//, '');
   if (!/^gemini-/.test(name)) return null;
+  if (NON_TEXT_MODALITY.test(name)) return null;
 
   const versionMatch = name.match(/gemini-(\d+(?:\.\d+)?)/);
   const generation = versionMatch ? parseFloat(versionMatch[1]) : 0;
@@ -97,19 +126,74 @@ function classify(id) {
   return { id, name, generation, tier, reasoning, preview };
 }
 
-function scoreOf(m) {
-  // Tier dominates, then generation, then a reasoning bonus that can lift a
-  // thinking variant above its own base model but never above a higher tier.
-  return (TIER_RANK[m.tier] || 0) * 1000 + m.generation * 10 + (m.reasoning ? 5 : 0);
+/**
+ * Selection rule (owner decision 2026-08-11):
+ *
+ *   Prefer the newest stable model of the highest available generation. Pro is
+ *   elevated only when a stable Pro exists in that generation; otherwise take
+ *   the best stable model of the latest generation.
+ *
+ * Generation therefore dominates, and tier orders *within* a generation — so a
+ * Pro is naturally chosen when one exists at the newest generation, without a
+ * hard-coded weight that drags selection backwards when one does not.
+ *
+ * The earlier tier-dominant weighting had exactly that flaw: with the live
+ * catalogue, every 3.x Pro is preview-only, so tier-dominance selected
+ * `gemini-2.5-pro` — a full generation behind the newest stable model — while
+ * appearing to honour "prefer Pro".
+ *
+ * `preferPro` makes that trade-off an explicit, caller-visible choice rather
+ * than a silent property of the weights.
+ */
+function compareModels(a, b, preferPro) {
+  if (preferPro) {
+    const aPro = a.tier === 'pro' ? 1 : 0;
+    const bPro = b.tier === 'pro' ? 1 : 0;
+    if (aPro !== bPro) return bPro - aPro;
+  }
+  if (a.generation !== b.generation) return b.generation - a.generation;
+  const tier = (TIER_RANK[b.tier] || 0) - (TIER_RANK[a.tier] || 0);
+  if (tier !== 0) return tier;
+  return (b.reasoning ? 1 : 0) - (a.reasoning ? 1 : 0);
 }
 
-function rank(models, { allowPreview }) {
+/**
+ * @param {string[]} models raw model ids
+ * @param {{allowPreview?: boolean, preferPro?: boolean}} opts
+ *        preferPro — the `prefer_pro_tier` / `force_pro` toggle. When on, Pro
+ *        outranks everything, so selection may fall back to an older stable Pro
+ *        or (with allowPreview) a preview Pro. The caller accepts that.
+ */
+function rank(models, { allowPreview = false, preferPro = false } = {}) {
   return models
     .map(classify)
     .filter(Boolean)
     .filter((m) => allowPreview || !m.preview)
-    .map((m) => ({ ...m, score: scoreOf(m) }))
-    .sort((a, b) => b.score - a.score || b.generation - a.generation);
+    .sort((a, b) => compareModels(a, b, preferPro));
+}
+
+/**
+ * Resolve one model and describe what the choice cost.
+ *
+ * The rule requires the Pro preference to be *user-visible*, so when the toggle
+ * selects an older generation than the default rule would, that regression is
+ * reported rather than left for someone to discover in an audit log.
+ */
+function selectModel(models, { allowPreview = false, preferPro = false, floor = 'flash' } = {}) {
+  const eligible = (opts) => rank(models, opts).filter((m) => meetsFloor(m, floor));
+
+  const chosen = eligible({ allowPreview, preferPro })[0] || null;
+  if (!chosen) return { chosen: null, tradeoff: null };
+
+  let tradeoff = null;
+  if (preferPro) {
+    const withoutToggle = eligible({ allowPreview, preferPro: false })[0];
+    if (withoutToggle && withoutToggle.generation > chosen.generation) {
+      tradeoff = `prefer_pro_tier selected ${chosen.name} (gen ${chosen.generation}); `
+        + `without it the newest stable choice is ${withoutToggle.name} (gen ${withoutToggle.generation}).`;
+    }
+  }
+  return { chosen, tradeoff };
 }
 
 function meetsFloor(model, floor) {
@@ -151,7 +235,14 @@ function generateUrl(modelId, cfg) {
  * organization's policy disallows.
  */
 async function listModels(token, cfg = backendConfig()) {
-  const headers = { Authorization: `Bearer ${token}` };
+  // The publisher-models list is NOT project-scoped in its path, so it requires
+  // an explicit quota project; generateContent carries the project in its URL
+  // and does not. Verified empirically: without this header the same request
+  // returns 403 "requires a quota project".
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    ...(cfg.project ? { 'x-goog-user-project': cfg.project } : {}),
+  };
   const out = [];
   let pageToken = '';
 
@@ -159,8 +250,11 @@ async function listModels(token, cfg = backendConfig()) {
   do {
     const url = cfg.backend === 'generativelanguage'
       ? `${API_BASE}/models?pageSize=200${pageToken ? `&pageToken=${pageToken}` : ''}`
-      : `https://${cfg.location}-aiplatform.googleapis.com/v1/publishers/google/models`
-        + `?pageSize=200&filter=name:gemini*${pageToken ? `&pageToken=${pageToken}` : ''}`;
+      // v1beta1, not v1 — v1 returns 404 for this collection. Verified against
+      // the live API. No name filter: the server-side filter is unreliable
+      // here and classify() discards non-Gemini entries anyway.
+      : `https://${cfg.location}-aiplatform.googleapis.com/v1beta1/publishers/google/models`
+        + `?pageSize=200${pageToken ? `&pageToken=${pageToken}` : ''}`;
 
     const res = await fetch(url, { headers });
     if (!res.ok) {
@@ -226,7 +320,7 @@ async function main() {
   }
 
   const ranked = rank(available, args);
-  const chosen = ranked.find((m) => meetsFloor(m, args.floor));
+  const { chosen, tradeoff } = selectModel(available, args);
 
   if (!chosen) {
     process.stderr.write(`✖ No available model meets the '${args.floor}' floor.\n`);
@@ -243,26 +337,32 @@ async function main() {
     resolved_at: new Date().toISOString(),
     floor: args.floor,
     backend: cfg.backend,
+    prefer_pro_tier: args.preferPro,
+    ...(tradeoff ? { tradeoff } : {}),
     considered: ranked.length,
   };
 
   // Audit log to stderr, payload to stdout, per CLAUDE.md.
   process.stderr.write(`${JSON.stringify({
     task: 'Resolve highest-capability Gemini model for review',
-    inputs: [`floor=${args.floor}`, `allow_preview=${args.allowPreview}`, `backend=${cfg.backend}`, `auth=${tokenSource()}`],
+    inputs: [`floor=${args.floor}`, `allow_preview=${args.allowPreview}`, `prefer_pro_tier=${args.preferPro}`, `backend=${cfg.backend}`, `auth=${tokenSource()}`],
     actions: [`listed ${available.length} models`, `ranked ${ranked.length} candidates`, `selected ${chosen.id}`],
-    risks: chosen.preview ? ['selected a preview build'] : [],
+    risks: [
+      ...(chosen.preview ? ['selected a preview build'] : []),
+      ...(tradeoff ? [tradeoff] : []),
+    ],
     result: chosen.id,
   })}\n`);
 
+  if (tradeoff) process.stderr.write(`⚠ ${tradeoff}\n`);
   process.stdout.write(args.json ? `${JSON.stringify(result, null, 2)}\n` : `${chosen.id}\n`);
 }
 
 // Importable as a module so the review runner can reuse the ranking logic
 // without shelling out; still runs as a CLI when invoked directly.
 module.exports = {
-  classify, scoreOf, rank, meetsFloor, listModels,
-  backendConfig, generateUrl, TIER_RANK,
+  classify, rank, compareModels, selectModel, meetsFloor, listModels,
+  backendConfig, generateUrl, TIER_RANK, NON_TEXT_MODALITY,
 };
 
 if (require.main === module) {

--- a/scripts/review-pr.js
+++ b/scripts/review-pr.js
@@ -54,7 +54,7 @@
 'use strict';
 
 const {
-  rank, meetsFloor, listModels, backendConfig, generateUrl,
+  selectModel, listModels, backendConfig, generateUrl,
 } = require('./resolve-gemini-model.js');
 const { getAccessToken, tokenSource } = require('./gcp-token.js');
 
@@ -280,13 +280,19 @@ function renderComment(review) {
 // ---------------------------------------------------------------------------
 
 function parseArgs(argv) {
-  const args = { pr: null, dryRun: false, post: true, floor: process.env.GEMINI_REVIEW_FLOOR || 'flash' };
+  const args = {
+    pr: null, dryRun: false, post: true,
+    floor: process.env.GEMINI_REVIEW_FLOOR || 'flash',
+    // `prefer_pro_tier` / `force_pro` — explicit toggle, see resolve-gemini-model.js
+    preferPro: /^(1|true|yes)$/i.test(process.env.GEMINI_PREFER_PRO || ''),
+  };
   for (let i = 0; i < argv.length; i += 1) {
     if (argv[i] === '--pr') args.pr = argv[++i];
     else if (argv[i] === '--dry-run') { args.dryRun = true; args.post = false; }
     else if (argv[i] === '--no-post') args.post = false;
     else if (argv[i] === '--floor') args.floor = argv[++i];
-    else if (argv[i] === '--help') { process.stdout.write('Usage: review-pr.js --pr <number> [--dry-run] [--no-post] [--floor tier]\n'); process.exit(0); }
+    else if (argv[i] === '--prefer-pro' || argv[i] === '--force-pro') args.preferPro = true;
+    else if (argv[i] === '--help') { process.stdout.write('Usage: review-pr.js --pr <number> [--dry-run] [--no-post] [--floor tier] [--prefer-pro]\n'); process.exit(0); }
   }
   return args;
 }
@@ -311,7 +317,9 @@ async function callGemini(model, prompt, token, cfg) {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify({
-      contents: [{ parts: [{ text: prompt }] }],
+      // `role` is mandatory on Vertex ("Please use a valid role: user, model")
+      // even though the Generative Language API tolerates omitting it.
+      contents: [{ role: 'user', parts: [{ text: prompt }] }],
       generationConfig: { responseMimeType: 'application/json', temperature: 0 },
     }),
   });
@@ -381,12 +389,15 @@ async function main() {
   // --- model -------------------------------------------------------------
   let model = 'models/(dry-run)';
   if (!args.dryRun) {
-    const ranked = rank(await listModels(token, cfg), { allowPreview: false });
-    const chosen = ranked.find((m) => meetsFloor(m, args.floor));
+    const { chosen, tradeoff } = selectModel(await listModels(token, cfg), {
+      allowPreview: false, preferPro: args.preferPro, floor: args.floor,
+    });
     if (!chosen) {
       process.stderr.write(`✖ No available model meets the '${args.floor}' floor. Refusing to review on an under-capability model.\n`);
       process.exit(1);
     }
+    // The Pro toggle's cost must be visible, not buried in an audit log.
+    if (tradeoff) process.stderr.write(`⚠ ${tradeoff}\n`);
     model = chosen.id;
   }
 

--- a/tests/review-runner.test.js
+++ b/tests/review-runner.test.js
@@ -14,7 +14,9 @@ const {
     GATES,
 } = require('../scripts/review-pr.js');
 
-const { classify, rank, meetsFloor } = require('../scripts/resolve-gemini-model.js');
+const {
+    classify, rank, selectModel, meetsFloor,
+} = require('../scripts/resolve-gemini-model.js');
 
 // These tests assert the properties that must hold no matter what the reviewing
 // model returns. The model is untrusted input; anything the review's integrity
@@ -205,21 +207,75 @@ test('comment: states plainly that the review does not approve or block', () => 
 
 // --- model resolution ------------------------------------------------------
 
-test('model ranking: tier dominates, reasoning breaks ties within a tier', () => {
-    const ranked = rank([
-        'models/gemini-2.5-flash',
-        'models/gemini-2.5-pro',
-        'models/gemini-3.6-pro-thinking',
-    ], { allowPreview: false });
-    assert.equal(ranked[0].name, 'gemini-3.6-pro-thinking');
-    assert.equal(ranked[0].tier, 'pro');
-    assert.equal(ranked[0].reasoning, true);
+test('selection: newest stable generation wins, per the owner rule', () => {
+    // Real published names. Every 3.x Pro is preview-only, so a tier-dominant
+    // rule would select gemini-2.5-pro — a full generation behind.
+    const live = [
+        'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-3.5-flash',
+        'gemini-3.6-flash', 'gemini-3.1-pro-preview',
+    ].map((n) => `publishers/google/models/${n}`);
+    const { chosen, tradeoff } = selectModel(live, { floor: 'flash' });
+    assert.equal(chosen.name, 'gemini-3.6-flash');
+    assert.equal(tradeoff, null, 'no trade-off when the toggle is off');
 });
 
-test('model ranking: preview builds are excluded unless allowed', () => {
-    const ids = ['models/gemini-9.9-pro-preview', 'models/gemini-2.5-pro'];
-    assert.equal(rank(ids, { allowPreview: false }).length, 1);
-    assert.equal(rank(ids, { allowPreview: true }).length, 2);
+test('selection: Pro is elevated when a stable Pro exists in the newest generation', () => {
+    const live = ['gemini-3.6-flash', 'gemini-3.6-pro', 'gemini-2.5-pro']
+        .map((n) => `publishers/google/models/${n}`);
+    const { chosen } = selectModel(live, { floor: 'flash' });
+    assert.equal(chosen.name, 'gemini-3.6-pro', 'tier orders within a generation');
+});
+
+test('selection: prefer_pro_tier falls back to an older stable Pro and reports the cost', () => {
+    const live = ['gemini-3.6-flash', 'gemini-2.5-pro']
+        .map((n) => `publishers/google/models/${n}`);
+    const { chosen, tradeoff } = selectModel(live, { floor: 'flash', preferPro: true });
+    assert.equal(chosen.name, 'gemini-2.5-pro');
+    assert.match(tradeoff, /prefer_pro_tier selected gemini-2\.5-pro \(gen 2\.5\)/);
+    assert.match(tradeoff, /gemini-3\.6-flash \(gen 3\.6\)/);
+});
+
+test('selection: prefer_pro_tier plus previews reaches the newest Pro', () => {
+    const live = ['gemini-3.6-flash', 'gemini-2.5-pro', 'gemini-3.1-pro-preview']
+        .map((n) => `publishers/google/models/${n}`);
+    const { chosen } = selectModel(live, { floor: 'flash', preferPro: true, allowPreview: true });
+    assert.equal(chosen.name, 'gemini-3.1-pro-preview');
+});
+
+test('selection: previews stay excluded unless explicitly allowed', () => {
+    const live = ['gemini-9.9-pro-preview', 'gemini-2.5-pro']
+        .map((n) => `publishers/google/models/${n}`);
+    assert.equal(selectModel(live, { floor: 'flash' }).chosen.name, 'gemini-2.5-pro');
+    assert.equal(
+        selectModel(live, { floor: 'flash', allowPreview: true }).chosen.name,
+        'gemini-9.9-pro-preview',
+    );
+});
+
+test('classify: non-text modalities are rejected outright', () => {
+    // Found only by ranking the live catalogue: image/tts/embedding variants
+    // still contain "pro" or "flash", so a tier rank would select them to
+    // review code. 18 of 25 published Gemini models are wrong for this job.
+    for (const n of [
+        'gemini-3-pro-image', 'gemini-2.5-pro-tts', 'gemini-embedding-001',
+        'gemini-live-2.5-flash-native-audio', 'gemini-robotics-er-2-preview-info',
+        'gemini-2.5-computer-use-preview-10-2025', 'gemini-omni-flash-preview',
+        'gemini-3.1-flash-image',
+    ]) {
+        assert.equal(classify(`publishers/google/models/${n}`), null, `${n} must be rejected`);
+    }
+});
+
+test('classify: legitimate text models survive the modality filter', () => {
+    for (const n of ['gemini-3.6-flash', 'gemini-2.5-pro', 'gemini-3.5-flash-lite']) {
+        assert.ok(classify(`publishers/google/models/${n}`), `${n} must be kept`);
+    }
+});
+
+test('selection: an image model never wins even when it is the newest Pro', () => {
+    const live = ['gemini-3-pro-image', 'gemini-2.5-flash']
+        .map((n) => `publishers/google/models/${n}`);
+    assert.equal(selectModel(live, { floor: 'flash' }).chosen.name, 'gemini-2.5-flash');
 });
 
 test('model ranking: non-Gemini models are ignored', () => {


### PR DESCRIPTION
## ⚠️ First: this recovers work that never reached `develop`

Commit `fd70766` was pushed to the `fix/adc-auth-no-api-keys` branch **after #377 had already been merged**. Pushing to a merged PR's branch does nothing, so all of it was stranded. My earlier report implied those fixes had landed; they hadn't.

`develop` is therefore currently **broken for live review**, in three independent ways:

| Missing from develop | Consequence |
|---|---|
| `v1beta1` listing endpoint | model listing returns **404** |
| `x-goog-user-project` header | listing returns **403** even on the right endpoint |
| `role: 'user'` on contents | generateContent returns **400** |
| Non-text modality filter | an **image model** could be selected to review code |
| Generation-first selection rule | your 2026-08-11 rule not implemented |

Cherry-picked here as `9228e72`, unmodified.

## Then: two fixes of its own

**`workflow_dispatch` was broken.** The workflow declared the trigger but read `github.event.pull_request.number`, which is empty on a manual run — so dispatch called the runner with `--pr ""` and errored. Adds a required `pr` input and resolves from either trigger. Manual dispatch is the first thing anyone reaches for when testing, so this would have been hit immediately.

**The setup guide documented single-repository federation.** Rewritten for the org-scoped deployment now in use (`newpush`, `project-noemi`, `newpush-labs`), recording three traps that cost real time:

1. **Casing.** Org logins are case-normalized and CEL comparison is case-sensitive — `newpush-Labs` is really `newpush-labs`. Wrong casing fails with nothing pointing at capitalization.
2. **Bind on the immutable numeric ID, not the login.** Logins can be renamed or released; a freed name could be re-registered by someone else to inherit impersonation.
3. **The provider mapping/condition and the SA bindings are a matched pair.** Binding on an attribute that isn't mapped means the attribute doesn't exist on any token, so *nothing* authenticates — not even the intended repository. **This exact mismatch broke the first rollout.**

Also records that `GCP_WIF_PROVIDER` takes the project **number** not the ID, and that widening federation scope is a real decision with a stated blast radius (~20 repos; anyone who can push a workflow to any of them can mint a token, bounded by `roles/aiplatform.user`).

## This PR is the live test

All six repository variables are now set and the WIF chain verified end to end — STS enabled, pool ACTIVE, provider condition matching all three org IDs with `repository_owner_id` mapped, service account holding `roles/aiplatform.user`, and three impersonation bindings.

So the `Cross-Model PR Review` job on **this** PR is the first real CI review. Note the fixes it needs to succeed are *in* this PR, which means the job runs the workflow from the merge ref — if it fails on listing or generation, that is the develop-side breakage, not a new defect.

## Verification

- `npm test` — **84/84** (78 on develop, confirming 6 tests were stranded with the rest)
- `node scripts/audit-repo.js` passes; workflow YAML parses; all guide links resolve
- Locally verified against the live API: default → `gemini-3.6-flash`, `--prefer-pro` → `gemini-2.5-pro` with the trade-off reported