### PR TITLE
fix(governance): distinct exit code for by-design halt

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -139,15 +139,24 @@ jobs:
           # generation to satisfy a tier preference.
           GEMINI_PREFER_PRO: ${{ vars.GEMINI_PREFER_PRO || '' }}
         run: |
-          # Exit 1 means a deliberate halt (carve-out, or no model met the
-          # floor). That is a correct outcome, not a failure of the job.
+          # ONLY exit 3 means "halted by design" (carve-out, or no model met the
+          # floor). Every other non-zero code is a real failure and must stay
+          # red.
+          #
+          # This previously accepted exit 1, which `infisical run` also returns
+          # on its own auth/permission errors. A broken run therefore reported
+          # success and posted nothing — the exact "looks like success but is
+          # not" outcome this pipeline exists to prevent.
           set +e
           infisical run --projectId="$INFISICAL_PROJECT_ID" --env=dev -- \
             node scripts/review-pr.js --pr "$PR_NUMBER"
           code=$?
           set -e
-          if [[ $code -eq 1 ]]; then
+          if [[ $code -eq 3 ]]; then
             echo "::notice title=Review halted::Escalated to human review by design. See the PR comment."
             exit 0
+          fi
+          if [[ $code -ne 0 ]]; then
+            echo "::error title=Review failed::review-pr.js or its wrapper exited ${code}. No review was performed."
           fi
           exit $code

--- a/scripts/resolve-gemini-model.js
+++ b/scripts/resolve-gemini-model.js
@@ -205,12 +205,28 @@ function meetsFloor(model, floor) {
   return (TIER_RANK[model.tier] || 0) >= floorRank;
 }
 
+/**
+ * Host for a Vertex location. `global` is NOT a region prefix — it is served by
+ * the bare host, so `global-aiplatform.googleapis.com` does not resolve.
+ */
+function vertexHost(location) {
+  return location === 'global'
+    ? 'aiplatform.googleapis.com'
+    : `${location}-aiplatform.googleapis.com`;
+}
+
 /** Backend config. Vertex is the default because ADC is its native auth path
- *  and this organization's policy mandates ADC. See docs. */
+ *  and this organization's policy mandates ADC. See docs.
+ *
+ *  Location defaults to `global` because the publisher catalogue is global while
+ *  regional availability lags it: gemini-3.5 and 3.6 are listed everywhere but
+ *  return 404 in us-central1, where only the 2.5 generation is served. Verified
+ *  empirically. Defaulting to a region therefore made discovery select a model
+ *  that could not answer. */
 function backendConfig() {
   const backend = process.env.GEMINI_BACKEND || 'vertex';
   const project = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || '';
-  const location = process.env.GOOGLE_CLOUD_LOCATION || 'us-central1';
+  const location = process.env.GOOGLE_CLOUD_LOCATION || 'global';
   if (backend !== 'vertex' && backend !== 'generativelanguage') {
     throw new Error(`Unknown GEMINI_BACKEND '${backend}'. Use 'vertex' or 'generativelanguage'.`);
   }
@@ -224,7 +240,7 @@ function backendConfig() {
 function generateUrl(modelId, cfg) {
   if (cfg.backend === 'generativelanguage') return `${API_BASE}/${modelId}:generateContent`;
   const bare = modelId.replace(/^publishers\/[^/]+\/models\//, '').replace(/^models\//, '');
-  return `https://${cfg.location}-aiplatform.googleapis.com/v1/projects/${cfg.project}`
+  return `https://${vertexHost(cfg.location)}/v1/projects/${cfg.project}`
     + `/locations/${cfg.location}/publishers/google/models/${bare}:generateContent`;
 }
 
@@ -253,7 +269,7 @@ async function listModels(token, cfg = backendConfig()) {
       // v1beta1, not v1 — v1 returns 404 for this collection. Verified against
       // the live API. No name filter: the server-side filter is unreliable
       // here and classify() discards non-Gemini entries anyway.
-      : `https://${cfg.location}-aiplatform.googleapis.com/v1beta1/publishers/google/models`
+      : `https://${vertexHost(cfg.location)}/v1beta1/publishers/google/models`
         + `?pageSize=200${pageToken ? `&pageToken=${pageToken}` : ''}`;
 
     const res = await fetch(url, { headers });
@@ -362,7 +378,7 @@ async function main() {
 // without shelling out; still runs as a CLI when invoked directly.
 module.exports = {
   classify, rank, compareModels, selectModel, meetsFloor, listModels,
-  backendConfig, generateUrl, TIER_RANK, NON_TEXT_MODALITY,
+  backendConfig, generateUrl, vertexHost, TIER_RANK, NON_TEXT_MODALITY,
 };
 
 if (require.main === module) {

--- a/scripts/review-pr.js
+++ b/scripts/review-pr.js
@@ -47,8 +47,14 @@
  *
  * EXIT CODES
  *   0 review completed (findings may exist — this is advisory in phase 1)
- *   1 halted: carve-out, or no model met the floor
  *   2 configuration or API error
+ *   3 halted BY DESIGN: carve-out, or no model met the floor
+ *
+ *   Code 3 is deliberately not 1. This process runs wrapped by `infisical run`,
+ *   which exits 1 on its own auth and permission failures — so a wrapper failure
+ *   and an intentional halt were indistinguishable, and CI treated a broken run
+ *   as a successful one. A distinct code cannot be produced by a wrapper that
+ *   never reached this script.
  */
 
 'use strict';
@@ -383,7 +389,7 @@ async function main() {
     if (args.post) await gh(`/repos/${repo}/issues/${args.pr}/comments`, { token: ghToken, method: 'POST', body: { body } });
     process.stderr.write(`${JSON.stringify({ task: 'AI review', result: 'halted: carve-out', carved })}\n`);
     process.stdout.write(`${body}\n`);
-    process.exit(1);
+    process.exit(3);
   }
 
   // --- model -------------------------------------------------------------
@@ -394,7 +400,7 @@ async function main() {
     });
     if (!chosen) {
       process.stderr.write(`✖ No available model meets the '${args.floor}' floor. Refusing to review on an under-capability model.\n`);
-      process.exit(1);
+      process.exit(3);
     }
     // The Pro toggle's cost must be visible, not buried in an audit log.
     if (tradeoff) process.stderr.write(`⚠ ${tradeoff}\n`);

--- a/scripts/review-pr.js
+++ b/scripts/review-pr.js
@@ -329,7 +329,20 @@ async function callGemini(model, prompt, token, cfg) {
       generationConfig: { responseMimeType: 'application/json', temperature: 0 },
     }),
   });
-  if (!res.ok) throw new Error(`Gemini ${model} → ${res.status} ${await res.text()}`);
+  if (!res.ok) {
+    const body = await res.text();
+    if (res.status === 404 && cfg.backend === 'vertex' && cfg.location !== 'global') {
+      // The publisher catalogue is global; regional availability lags it. A
+      // listed-but-unservable model is the likely cause, so say so instead of
+      // leaving a bare 404. Not auto-retried elsewhere: silently falling back to
+      // an older model would downgrade review depth without telling anyone.
+      throw new Error(
+        `Gemini ${model} → 404 in location '${cfg.location}'. The model is listed globally `
+        + `but may not be served in this region. Set GOOGLE_CLOUD_LOCATION=global.\n${body}`,
+      );
+    }
+    throw new Error(`Gemini ${model} → ${res.status} ${body}`);
+  }
   const body = await res.json();
   const text = body?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
   try {

--- a/tests/review-runner.test.js
+++ b/tests/review-runner.test.js
@@ -314,11 +314,15 @@ function withEnv(vars, fn) {
 }
 
 test('backend defaults to vertex, since ADC is its native auth path', () => {
-    withEnv({ GEMINI_BACKEND: undefined, GOOGLE_CLOUD_PROJECT: 'project-noemi', GCP_PROJECT: undefined }, () => {
+    withEnv({
+        GEMINI_BACKEND: undefined, GOOGLE_CLOUD_PROJECT: 'project-noemi',
+        GCP_PROJECT: undefined, GOOGLE_CLOUD_LOCATION: undefined,
+    }, () => {
         const cfg = backendConfig();
         assert.equal(cfg.backend, 'vertex');
         assert.equal(cfg.project, 'project-noemi');
-        assert.equal(cfg.location, 'us-central1');
+        // global, not a region — see the location tests below for why.
+        assert.equal(cfg.location, 'global');
     });
 });
 
@@ -389,4 +393,29 @@ test('workflow accepts only exit 3 as a by-design halt', () => {
     );
     assert.match(wf, /code -eq 3/, 'must treat 3 as the halt signal');
     assert.doesNotMatch(wf, /code -eq 1/, 'must not treat 1 as a halt');
+});
+
+// --- location handling -----------------------------------------------------
+// `global` is not a region prefix. The publisher catalogue is global while
+// regional availability lags it, so defaulting to a region made discovery pick
+// models that returned 404.
+
+test('vertexHost: global uses the bare host, regions are prefixed', () => {
+    const { vertexHost } = require('../scripts/resolve-gemini-model.js');
+    assert.equal(vertexHost('global'), 'aiplatform.googleapis.com');
+    assert.equal(vertexHost('us-central1'), 'us-central1-aiplatform.googleapis.com');
+    assert.doesNotMatch(vertexHost('global'), /global-/, 'global-aiplatform does not resolve');
+});
+
+test('backendConfig defaults location to global, not a region', () => {
+    withEnv({ GEMINI_BACKEND: undefined, GOOGLE_CLOUD_PROJECT: 'p', GOOGLE_CLOUD_LOCATION: undefined }, () => {
+        assert.equal(backendConfig().location, 'global');
+    });
+});
+
+test('generateUrl: global omits the region prefix from the host', () => {
+    const url = generateUrl('publishers/google/models/gemini-3.6-flash', {
+        backend: 'vertex', project: 'p', location: 'global',
+    });
+    assert.match(url, /^https:\/\/aiplatform\.googleapis\.com\/v1\/projects\/p\/locations\/global\//);
 });

--- a/tests/review-runner.test.js
+++ b/tests/review-runner.test.js
@@ -1,5 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
 
 const {
     detectCarveOut,
@@ -368,4 +370,23 @@ test('token source is reported without exposing the token value', () => {
         assert.equal(tokenSource(), 'gcloud-adc');
     });
     resetTokenCache();
+});
+
+// --- exit-code contract ----------------------------------------------------
+// A deliberate halt must be distinguishable from a wrapper failure. `infisical
+// run` wraps this process and exits 1 on its own auth/permission errors, so
+// reusing 1 for "halted by design" made a broken run report success.
+
+test('halt uses exit code 3, never 1, so a wrapper failure cannot masquerade as a halt', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'review-pr.js'), 'utf8');
+    assert.match(src, /process\.exit\(3\)/, 'deliberate halts must exit 3');
+    assert.doesNotMatch(src, /process\.exit\(1\)/, 'exit 1 collides with infisical run failures');
+});
+
+test('workflow accepts only exit 3 as a by-design halt', () => {
+    const wf = fs.readFileSync(
+        path.join(__dirname, '..', '.github', 'workflows', 'ai-review.yml'), 'utf8',
+    );
+    assert.match(wf, /code -eq 3/, 'must treat 3 as the halt signal');
+    assert.doesNotMatch(wf, /code -eq 1/, 'must not treat 1 as a halt');
 });


### PR DESCRIPTION
## What happened

A live CI run **reported success while performing no review and posting no comment.**

`infisical run` failed with `403` — the machine identity authenticated fine but was not a member of the Infisical project — and exited `1`. The workflow treated exit `1` as *"halted by design: carve-out, or no eligible model"* and converted it to a green check.

This is the exact failure mode this pipeline exists to prevent: **a result that looks like a passing review but is not a review at all.** It is worse than a red build, because a red build gets investigated.

## Cause

The exit-code contract was ambiguous. `review-pr.js` runs wrapped by `infisical run`, which exits `1` on its own auth and permission errors — so a wrapper failure and an intentional halt were indistinguishable from the workflow's side.

## Fix

| Code | Meaning |
|---|---|
| 0 | review completed |
| 2 | configuration or API error |
| **3** | **halted by design** — carve-out, or no model met the floor |

`3` cannot be produced by a wrapper that never reached the script, so the cases are now disjoint. The workflow accepts only `3`, and annotates any other non-zero code with an error stating plainly that no review was performed.

Tests assert the contract from both sides — the script must not use `exit 1`, and the workflow must not accept it — so the collision cannot be reintroduced silently. **86/86 passing.**

## Still blocked on the Infisical project membership

This PR fixes the *reporting* of that failure, not the failure. The identity needs adding to the Infisical project (ID `61ee586e-…`) with read permission; org-level creation alone is insufficient.

Once that is done, the run should complete and post findings as `noemi-reviewer`.

## Progress worth recording

The audience fix worked. Current live status:

| Step | Result |
|---|---|
| All six repository variables | ✅ |
| Google Cloud WIF | ✅ |
| Infisical OIDC authentication | ✅ |
| Fetch secrets from Infisical project | ❌ identity not a project member |
| Three-gate review | pending |

`workflow_dispatch` with a `pr` input also verified working against #379.