### PR TITLE
docs(governance): phase-1-operational status, calibration log, close develop bypass

### DIFF
--- a/docs/AI_REVIEW_GOVERNANCE.md
+++ b/docs/AI_REVIEW_GOVERNANCE.md
@@ -206,24 +206,46 @@ judgment enters, and the only place the framework can be observed adapting.
 
 ## Rollout status
 
-Current as of 2026-08-02. Update this table when an item changes — it is the
+Current as of 2026-08-11. Update this table when an item changes — it is the
 handoff point for anyone picking the work up.
+
+**Phase 1 is operational.** The first fully automated cross-model review ran in
+CI on 2026-08-11 against PR #379: Workload Identity Federation to Google, OIDC
+to Infisical, `gemini-3.6-flash` resolved at runtime, all three gates executed,
+findings posted by `noemi-reviewer`. No static credential is stored in GitHub.
 
 | Item | State | Blocked on |
 |---|---|---|
 | `noemi-agent` producer identity | ✅ provisioned, verified | — |
+| `noemi-reviewer` identity | ✅ provisioned, capabilities verified (cannot write code) | — |
 | Bot-authored PR loop (author → human approve → merge, no bypass) | ✅ proven on #340, #341 | — |
-| `scripts/agent-gh.sh` wrapper + identity guard | ✅ working | — |
-| `scripts/resolve-gemini-model.js` | ✅ working, tested offline | live API call unverified |
-| Reviewer persona + governance framework | ✅ merged (#341) | — |
-| `.github/workflows/ai-review.yml` | ⚠️ skips cleanly; runner not implemented | `GEMINI_API_KEY` + runner |
-| `noemi-reviewer` identity | ✅ provisioned 2026-08-03, capabilities verified | — |
-| `GEMINI_API_KEY` repo secret | ❌ not set | human |
-| CODEOWNERS + `require_code_owner_reviews` | ✅ on `develop` via `setup-branch-protection.sh` (main leaves code-owner reviews off) | re-run script after policy changes |
-| Three-gate review runner | ❌ not written | follow-up PR |
-| `enforce_admins: true` on `main` | ✅ required by promotion policy (no direct push / no bot bypass) | — |
-| `enforce_admins: true` on `develop` | ❌ still `false` (escape hatch for integration) | bot-only integration path |
-| Both bot identities' effective permission | ✅ `maintain` accepted by decision 2026-08-03 — token scoping is the boundary | — |
+| Three-gate review runner (`scripts/review-pr.js`) | ✅ live in CI; first review posted 2026-08-11 | — |
+| Model resolution (`scripts/resolve-gemini-model.js`) | ✅ live; generation-first rule, Pro toggle, modality filter | — |
+| Google auth | ✅ Workload Identity Federation, org-scoped (no API key — org policy disallows them) | — |
+| Infisical auth in CI | ✅ OIDC, no stored secret | — |
+| Exit-code honesty (halt=3, failures stay red) | ✅ after a live run reported success while doing nothing | — |
+| Vertex location | ✅ `global` (regional availability lags the catalogue) | — |
+| CODEOWNERS + `require_code_owner_reviews` | ✅ six owners on `develop`; carve-out stays owner-only | — |
+| `enforce_admins: true` on `main` | ✅ promotion policy | — |
+| `enforce_admins: true` on `develop` | ⚠️ authorized 2026-08-11, application pending | admin runs the protection call |
+| Calibration log | ✅ `docs/reviews/CALIBRATION.md` — deliberately outside the carve-out | humans recording overrides |
+| Phase 2 (reviewer approvals) | ❌ not authorized | override-rate evidence from phase 1 |
+| Multi-repo deployment (all `newpush`, `project-noemi`, `newpush-labs` repos) | 🔄 in progress | reusable workflow + per-org reviewer tokens + org variables |
+
+### Calibration: the evidence phase 2 requires
+
+Every human decision that disagrees with the reviewer — a finding dismissed, a
+severity overridden, a "no findings" verdict contradicted by a later bug — is
+recorded in [`docs/reviews/CALIBRATION.md`](reviews/CALIBRATION.md).
+
+That file lives **outside the governance carve-out on purpose**: appending an
+override record must not require owner review, or the log will silently stop
+being kept. The rules about the log live here (carved out); the data lives
+there (not).
+
+Advancing to phase 2 requires citing the log: the override rate over a stated
+window, and the direction of the overrides. "It feels reliable" does not
+advance a phase.
 
 ### Applying branch protection
 

--- a/docs/reviews/CALIBRATION.md
+++ b/docs/reviews/CALIBRATION.md
@@ -1,0 +1,58 @@
+# AI Review Calibration Log
+
+The override record for the cross-model review loop. Governed by
+`docs/AI_REVIEW_GOVERNANCE.md`; this file deliberately sits **outside** the
+governance carve-out so that recording an override never requires owner review.
+
+## Why this file decides phase 2
+
+Phase 1 posts advisory findings; a human decides. Phase 2 lets the reviewer
+approve clean PRs on its own. The only honest evidence for that promotion is
+**how often, and in which direction, humans disagree with the reviewer** — and
+that evidence only exists if disagreements are written down when they happen.
+
+Record an entry whenever:
+
+- a finding is **dismissed** — the human judged it wrong or not worth fixing
+- a severity is **overridden** in either direction
+- a **premise/framing verdict is rejected** — the reviewer said "stop" and the
+  human proceeded (or vice versa)
+- a **miss surfaces later** — a bug or premise problem in a PR the reviewer
+  passed clean. These are the most valuable entries and the least fun to write.
+
+A review you simply agreed with needs no entry. Silence means agreement, which
+is why the entries that do exist carry weight.
+
+## Entry format
+
+One row per disagreement. Keep reasons short and concrete.
+
+| Date | PR | Model | Gate | Reviewer said | Human did | Direction | Reason |
+|---|---|---|---|---|---|---|---|
+| _example:_ 2026-08-12 | #385 | gemini-3.6-flash | code | high: missing test on new logic | dismissed | reviewer too strict | covered by integration suite the reviewer cannot see |
+
+**Direction** is one of:
+
+- `reviewer too strict` — finding dismissed or severity lowered
+- `reviewer too lenient` — severity raised, or a miss found later
+- `reviewer wrong domain` — finding factually incorrect about the code
+
+## Log
+
+| Date | PR | Model | Gate | Reviewer said | Human did | Direction | Reason |
+|---|---|---|---|---|---|---|---|
+
+## Reading the log
+
+When considering phase 2, compute over a stated window (e.g. the last 30
+reviewed PRs):
+
+- **Override rate** — entries ÷ reviews. High is not automatically bad; a high
+  rate of `too strict` with zero `too lenient` is a tunable prompt, not an
+  untrustworthy reviewer.
+- **Lenient misses** — any `too lenient` entry on a `critical`/`high` matter is
+  disqualifying for phase 2 until understood, because phase 2 removes the human
+  who caught it.
+- **Model drift** — the model column exists because runtime discovery means the
+  reviewer changes underneath the log. A rate computed across different models
+  is a blended number; say so when citing it.

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -153,7 +153,7 @@ DEVELOP_PAYLOAD=$(cat <<'JSON'
       "Audit, Generate, and Fast Tests"
     ]
   },
-  "enforce_admins": false,
+  "enforce_admins": true,
   "required_pull_request_reviews": {
     "required_approving_review_count": 1,
     "dismiss_stale_reviews": true,


### PR DESCRIPTION
## Three of the four items from today's directive

**1. Rollout table refreshed.** It still said the runner was unwritten and `GEMINI_API_KEY` was pending — materially wrong since this morning's first live CI review. Now records phase 1 as operational with the full verified chain, and lists the multi-repo deployment as in progress.

**2. Calibration log created** — `docs/reviews/CALIBRATION.md`, the override record phase 2 promotion must cite. Design choice worth reviewing: it sits **outside the governance carve-out on purpose.** Appending an override must not require owner review, or the log silently stops being kept. The rules about the log stay in the carved-out doc; the data lives in the log. Conventions: silence means agreement; three-value direction taxonomy (`too strict` / `too lenient` / `wrong domain`); a model column because runtime discovery changes the reviewer underneath the log; and `too lenient` on critical/high is disqualifying for phase 2 until understood.

**3. `enforce_admins: true` on develop** — script payload flipped per owner authorization. **Not yet applied to the live branch**: the protection API call was blocked by the session's permission classifier, so it needs an admin to run:

```
gh api --method POST repos/project-noemi/agents/branches/develop/protection/enforce_admins
```

Recorded as pending in the table. Note the consequence: once applied, **nobody** can push directly to develop or bypass-merge — including admins. Every change goes through a PR with a code-owner approval. That is the point, and it is also why the six co-owners had to land first.

## Reviewer

Touches `docs/AI_REVIEW_GOVERNANCE.md` — carve-out, needs @WSwarm.

The fourth item (deploy the reviewer to every repo) is a separate PR — different concern, and it should not ride on a carve-out review.