### PR TITLE
feat(governance): fleet deployment of the cross-model reviewer

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -9,10 +9,18 @@
 # block a merge is a gate; phase 1 is an advisory signal being calibrated. Do
 # not add it to branch protection contexts before phase 2.
 #
+# FLEET DEPLOYMENT: this is a REUSABLE workflow (workflow_call). Other
+# repositories run the reviewer through a thin caller — see
+# templates/ci/ai-review-caller.yml — so the review logic exists in exactly one
+# place. Reviewer scripts are always checked out from the tooling repository at
+# a pinned ref, never from the pull request under review: a PR must not be able
+# to rewrite the reviewer that judges it.
+#
+# Configuration comes from Actions VARIABLES resolved in the caller's context —
+# set them at the ORGANIZATION level so member repos need none of their own.
 # No credential is stored in GitHub. The GitHub token comes from Infisical via
 # OIDC, and Google access comes from Workload Identity Federation — required
 # here, since org policy disallows API keys and service-account keys alike.
-# Only non-secret IDs live in Variables.
 #
 # The carve-out, gate ordering, and severity rubric are enforced inside
 # scripts/review-pr.js — deliberately not duplicated here. Two copies of a
@@ -28,6 +36,17 @@ on:
         description: 'Pull request number to review'
         required: true
         type: string
+  workflow_call:
+    inputs:
+      pr:
+        description: 'Pull request number (defaults to the triggering PR)'
+        required: false
+        type: string
+      tooling-ref:
+        description: 'Ref of project-noemi/agents to take reviewer scripts from'
+        required: false
+        type: string
+        default: develop
 
 permissions:
   contents: read
@@ -35,7 +54,9 @@ permissions:
   id-token: write          # required to mint the OIDC token for Infisical
 
 concurrency:
-  group: ai-review-${{ github.event.pull_request.number || inputs.pr || github.ref }}
+  # Repository-qualified: many repos call this workflow, and PR numbers collide
+  # across them.
+  group: ai-review-${{ github.repository }}-${{ github.event.pull_request.number || inputs.pr || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -43,9 +64,15 @@ jobs:
     name: Cross-Model PR Review
     runs-on: ubuntu-latest
     steps:
+      # ALWAYS the tooling repo at a pinned ref — never the PR head. The runner
+      # fetches the diff over the API, so nothing from the reviewed PR's working
+      # tree is needed or wanted: scripts taken from the PR would let a PR
+      # rewrite its own reviewer. (The caller's thin workflow file remains the
+      # caller's responsibility; the carve-out halts on changes to it.)
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          repository: project-noemi/agents
+          ref: ${{ inputs.tooling-ref || 'develop' }}
 
       - uses: actions/setup-node@v4
         with:
@@ -69,7 +96,7 @@ jobs:
           [[ -z "${GCP_SA}"       ]] && missing+=(GCP_SERVICE_ACCOUNT)
           if (( ${#missing[@]} )); then
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=AI review skipped::Missing repository variables: ${missing[*]}. See docs/examples/cross-model-review-setup.md."
+            echo "::notice title=AI review skipped::Missing Actions variables: ${missing[*]}. Set them at the organization level. See docs/examples/cross-model-review-setup.md."
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
@@ -121,18 +148,24 @@ jobs:
 
       # review-pr.js owns the carve-out check and refuses to invoke a model on a
       # governance-critical diff, so no model call happens before that decision.
+      # It also selects the reviewer token for this repository's organization —
+      # fine-grained PATs are scoped to a single resource owner, so each org has
+      # its own (REVIEWER_GH_TOKEN_<ORG>), all resolved from the same vault.
       - name: Run three-gate review
         if: steps.config.outputs.configured == 'true'
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GEMINI_REVIEW_FLOOR: ${{ vars.GEMINI_REVIEW_FLOOR || 'flash' }}
           INFISICAL_PROJECT_ID: ${{ vars.INFISICAL_PROJECT_ID }}
-          # Resolves on both triggers: the event on pull_request, the input on dispatch.
+          # Resolves on all triggers: the event on pull_request, the input on
+          # dispatch and on workflow_call.
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
           # Short-lived, federated. Never a stored credential.
           GCP_ACCESS_TOKEN: ${{ steps.gcpauth.outputs.access_token }}
           GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT || 'project-noemi' }}
-          GOOGLE_CLOUD_LOCATION: ${{ vars.GOOGLE_CLOUD_LOCATION || 'us-central1' }}
+          # global, not a region: the publisher catalogue is global and regional
+          # availability lags it (gemini-3.x 404s in us-central1).
+          GOOGLE_CLOUD_LOCATION: ${{ vars.GOOGLE_CLOUD_LOCATION || 'global' }}
           GEMINI_BACKEND: ${{ vars.GEMINI_BACKEND || 'vertex' }}
           # prefer_pro_tier: opt-in. Off by default so selection follows the
           # newest-stable-generation rule rather than silently regressing a

--- a/docs/examples/cross-model-review-setup.md
+++ b/docs/examples/cross-model-review-setup.md
@@ -573,6 +573,76 @@ editing the merge gate to unblock its own pull requests.
 
 ---
 
+# Fleet deployment — every repository, one reviewer
+
+One repository proves the loop; the fleet is where it pays. The design keeps
+review logic in exactly one place:
+
+- **`.github/workflows/ai-review.yml` in the tooling repo** is a *reusable
+  workflow* (`workflow_call`). All logic, auth, and honesty rules live here.
+- **Every other repo** gets a ~15-line caller
+  (`templates/ci/ai-review-caller.yml`) that delegates to it. Callers should
+  almost never change.
+- **Reviewer scripts are always checked out from the tooling repo at a pinned
+  ref, never from the PR under review.** A pull request must not be able to
+  rewrite the reviewer that judges it. For the same reason,
+  `.github/workflows/ai-review.yml` is itself in the carve-out: a PR editing
+  the review workflow halts and goes to a human, in every repo.
+
+## One-time prerequisites (human)
+
+**1. Organization-level Actions variables** — set once per org so member repos
+need no configuration of their own (Org Settings → Secrets and variables →
+Actions → Variables, or `gh variable set NAME --org ORG --visibility all`,
+which requires `admin:org` scope):
+
+`GCP_WIF_PROVIDER`, `GCP_SERVICE_ACCOUNT`, `GOOGLE_CLOUD_PROJECT`,
+`INFISICAL_PROJECT_ID`, `INFISICAL_IDENTITY_ID` — same values as the
+repository-level ones documented above. (`GOOGLE_CLOUD_LOCATION` defaults to
+`global` and can be omitted.)
+
+**2. Widen the Infisical identity's claim filter.** If its OIDC subject filter
+is scoped to one repository, workflows in other repos will authenticate to
+GitHub fine and then fail Infisical login. Widen it to the organizations, e.g.
+`repo:newpush/*`, `repo:project-noemi/*`, `repo:newpush-labs/*`.
+
+**3. Per-organization reviewer tokens.** A fine-grained PAT is scoped to a
+single resource owner, so one token cannot span three orgs. Signed in as
+`noemi-reviewer`, mint one per org (same scoping as before: Contents read,
+Pull requests read/write, all repositories in that org — the account needs
+access to the org's private repos), then store each in Infisical:
+
+```bash
+infisical secrets set REVIEWER_GH_TOKEN_NEWPUSH="github_pat_..." --env=dev
+infisical secrets set REVIEWER_GH_TOKEN_NEWPUSH_LABS="github_pat_..." --env=dev
+```
+
+The runner selects `REVIEWER_GH_TOKEN_<ORG>` (uppercased, dashes →
+underscores) by the repository's owner, falling back to `REVIEWER_GH_TOKEN`.
+`infisical run` injects the whole project's secrets, so no per-repo secret
+wiring exists anywhere.
+
+## Rolling out
+
+```bash
+bash scripts/deploy-ai-review.sh --dry-run   # preview: who gets a PR, who is skipped
+gh auth refresh -s workflow                  # pushing workflow files needs this scope
+bash scripts/deploy-ai-review.sh             # open one PR per repository
+```
+
+The script is deliberately **PR-based**: it never pushes to a default branch.
+Each repository's maintainers accept the reviewer by merging — the merge is the
+consent step. It is idempotent: re-running skips repos that already have the
+workflow, so partial rollouts recover cleanly.
+
+## Cost note
+
+Every deployed repo sends up to three model calls per PR update to Vertex,
+billed to the shared project. Set a budget alert before, not after, the fleet
+merge wave.
+
+---
+
 # Troubleshooting
 
 | Symptom | Cause | Fix |

--- a/scripts/deploy-ai-review.sh
+++ b/scripts/deploy-ai-review.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Roll the cross-model AI reviewer out across the fleet.
+#
+# For every active, non-fork repository in the target organizations, this opens
+# a pull request adding the thin caller workflow
+# (templates/ci/ai-review-caller.yml → .github/workflows/ai-review.yml), which
+# delegates to the reusable reviewer in the tooling repository.
+#
+# DELIBERATELY PR-BASED. This script never pushes to a default branch: each
+# repository's humans accept the reviewer by merging, which is itself the
+# consent step. A reviewer imposed silently would be a strange way to deploy a
+# governance control.
+#
+# Usage:
+#   bash scripts/deploy-ai-review.sh --dry-run     # list what would happen
+#   bash scripts/deploy-ai-review.sh               # open the PRs
+#   ORGS="newpush-labs" bash scripts/deploy-ai-review.sh   # subset
+#
+# Env (all optional):
+#   ORGS          space-separated organizations
+#                 (default: "newpush project-noemi newpush-labs")
+#   TOOLING_REPO  repository hosting the reusable workflow
+#                 (default: project-noemi/agents)
+#   BRANCH        branch name to open PRs from (default: chore/ai-review-caller)
+#
+# Requires:
+#   - gh authenticated with `repo` AND `workflow` scope. Pushing workflow files
+#     is rejected without `workflow`; grant it with:  gh auth refresh -s workflow
+#   - the caller template at templates/ci/ai-review-caller.yml
+#
+# Per-repo behaviour: skip if archived, a fork, a `.github` meta-repo, the
+# tooling repo itself, or if .github/workflows/ai-review.yml already exists on
+# the default branch (idempotent — safe to re-run after partial rollouts).
+
+set -euo pipefail
+
+ORGS="${ORGS:-newpush project-noemi newpush-labs}"
+TOOLING_REPO="${TOOLING_REPO:-project-noemi/agents}"
+BRANCH="${BRANCH:-chore/ai-review-caller}"
+TEMPLATE="templates/ci/ai-review-caller.yml"
+WORKFLOW_PATH=".github/workflows/ai-review.yml"
+DRY_RUN=0
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+
+log() { printf '%s\n' "$*" >&2; }
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  log "✖ Caller template not found at ${TEMPLATE}. Run from the tooling repo root."
+  exit 1
+fi
+
+# Fail before doing anything if the token cannot push workflow files: without
+# the `workflow` scope every push below is rejected, one repo at a time.
+# A dry run pushes nothing, so it is exempt — previewing must not require scopes.
+if [[ $DRY_RUN -eq 0 ]] && ! gh auth status 2>&1 | grep -q "workflow"; then
+  log "✖ The gh token lacks the 'workflow' scope, which pushing ${WORKFLOW_PATH} requires."
+  log "  Fix:  gh auth refresh -s workflow"
+  exit 1
+fi
+
+CONTENT_B64=$(base64 < "$TEMPLATE" | tr -d '\n')
+PR_BODY="Adds the cross-model AI reviewer as a thin caller of the reusable workflow in ${TOOLING_REPO}.
+
+**Advisory only.** It posts three-gate findings (premise → framing → code) as a PR comment. It never approves, merges, or blocks, and it must not be added to required status checks.
+
+Merging this PR is the consent step: it enables the reviewer for this repository. Configuration comes from organization-level Actions variables — this repo needs no secrets and no further setup.
+
+Framework: ${TOOLING_REPO} \`docs/AI_REVIEW_GOVERNANCE.md\`. Deployed by \`scripts/deploy-ai-review.sh\`."
+
+created=0; skipped=0; failed=0
+
+for org in $ORGS; do
+  log "── ${org} ──"
+  repos=$(gh repo list "$org" --limit 200 \
+    --json name,isArchived,isFork,defaultBranchRef \
+    --jq '.[] | select(.isArchived|not) | select(.isFork|not) | "\(.name)\t\(.defaultBranchRef.name)"')
+
+  while IFS=$'\t' read -r name default_branch; do
+    [[ -z "$name" ]] && continue
+    repo="${org}/${name}"
+
+    if [[ "$name" == ".github" || "$repo" == "$TOOLING_REPO" ]]; then
+      log "  ⏭  ${repo} (meta or tooling repo)"; skipped=$((skipped+1)); continue
+    fi
+    if [[ -z "$default_branch" || "$default_branch" == "null" ]]; then
+      log "  ⏭  ${repo} (empty repository)"; skipped=$((skipped+1)); continue
+    fi
+    if gh api "repos/${repo}/contents/${WORKFLOW_PATH}?ref=${default_branch}" >/dev/null 2>&1; then
+      log "  ⏭  ${repo} (already has ${WORKFLOW_PATH})"; skipped=$((skipped+1)); continue
+    fi
+
+    if [[ $DRY_RUN -eq 1 ]]; then
+      log "  ▶  would deploy to ${repo} (default: ${default_branch})"
+      created=$((created+1)); continue
+    fi
+
+    if head_sha=$(gh api "repos/${repo}/git/ref/heads/${default_branch}" --jq .object.sha 2>/dev/null) \
+       && gh api --method POST "repos/${repo}/git/refs" \
+            -f ref="refs/heads/${BRANCH}" -f sha="$head_sha" >/dev/null 2>&1 \
+       && gh api --method PUT "repos/${repo}/contents/${WORKFLOW_PATH}" \
+            -f message="ci: add cross-model AI review (advisory)" \
+            -f content="$CONTENT_B64" -f branch="$BRANCH" >/dev/null 2>&1 \
+       && url=$(gh pr create --repo "$repo" --base "$default_branch" --head "$BRANCH" \
+            --title "ci: add cross-model AI review (advisory)" --body "$PR_BODY" 2>/dev/null); then
+      log "  ✔  ${repo} → ${url}"
+      created=$((created+1))
+    else
+      log "  ✖  ${repo} — failed (permissions, or branch ${BRANCH} already exists)"
+      failed=$((failed+1))
+    fi
+  done <<< "$repos"
+done
+
+# Structured audit log to stderr, per CLAUDE.md.
+printf '%s\n' "{\"task\":\"Deploy AI reviewer caller workflow across fleet\",\"inputs\":[\"orgs: ${ORGS}\",\"dry_run: ${DRY_RUN}\"],\"actions\":[\"opened ${created} PRs\",\"skipped ${skipped}\"],\"risks\":[\"each PR enables Gemini review costs for that repo\"],\"result\":\"created=${created} skipped=${skipped} failed=${failed}\"}" >&2
+
+log ""
+log "Done: ${created} PR(s) opened, ${skipped} skipped, ${failed} failed."
+[[ $failed -gt 0 ]] && exit 1 || exit 0

--- a/scripts/review-pr.js
+++ b/scripts/review-pr.js
@@ -81,6 +81,10 @@ const BLOCKING_SEVERITIES = ['critical', 'high'];
 const CARVE_OUT = [
   '.github/CODEOWNERS',
   '.github/workflows/require-develop-source.yml',
+  // The review workflow itself — in the tooling repo AND in every fleet repo,
+  // where the caller lives at the same path. A PR that edits the workflow that
+  // reviews it must be judged by a human, not by the reviewer it is editing.
+  '.github/workflows/ai-review.yml',
   'docs/MACHINE_IDENTITY.md',
   'docs/AI_REVIEW_GOVERNANCE.md',
 ];
@@ -361,7 +365,14 @@ async function main() {
     process.exit(2);
   }
 
-  const ghToken = process.env.REVIEWER_GH_TOKEN;
+  // Fine-grained PATs are scoped to a single resource owner, so the fleet has
+  // one reviewer token per organization: REVIEWER_GH_TOKEN_<ORG> (uppercased,
+  // dashes to underscores — REVIEWER_GH_TOKEN_NEWPUSH_LABS). `infisical run`
+  // injects the whole project's secrets, so selection is just an env lookup.
+  // The bare REVIEWER_GH_TOKEN remains the fallback for the home org.
+  const owner = (repo || '').split('/')[0];
+  const perOrgKey = `REVIEWER_GH_TOKEN_${owner.toUpperCase().replace(/-/g, '_')}`;
+  const ghToken = process.env[perOrgKey] || process.env.REVIEWER_GH_TOKEN;
   // No API-key path exists by design — see scripts/gcp-token.js.
   let token = null;
   let cfg = null;
@@ -377,7 +388,7 @@ async function main() {
   // Needed in every mode: pull-request context is read over the API even on a
   // dry run, so there is no offline path here.
   if (!ghToken) {
-    process.stderr.write('✖ REVIEWER_GH_TOKEN not set. Pull-request context is read over the API in every mode, including --dry-run.\n');
+    process.stderr.write(`✖ Neither ${perOrgKey} nor REVIEWER_GH_TOKEN is set. Pull-request context is read over the API in every mode, including --dry-run.\n`);
     process.exit(2);
   }
 

--- a/templates/ci/ai-review-caller.yml
+++ b/templates/ci/ai-review-caller.yml
@@ -1,0 +1,26 @@
+# Cross-model AI review — fleet caller.
+#
+# This thin workflow delegates to the reusable reviewer in project-noemi/agents,
+# so the review logic lives in exactly one place and this file should almost
+# never change. Deployed by scripts/deploy-ai-review.sh; documented in
+# docs/examples/cross-model-review-setup.md (Fleet deployment).
+#
+# Requires only organization-level Actions VARIABLES (no secrets in this repo):
+#   GCP_WIF_PROVIDER, GCP_SERVICE_ACCOUNT, GOOGLE_CLOUD_PROJECT,
+#   INFISICAL_PROJECT_ID, INFISICAL_IDENTITY_ID
+#
+# The review is ADVISORY: it posts findings as a comment and never approves,
+# merges, or blocks. Do not add it to required status checks.
+name: AI Review (advisory)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    uses: project-noemi/agents/.github/workflows/ai-review.yml@develop
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write

--- a/tests/review-runner.test.js
+++ b/tests/review-runner.test.js
@@ -419,3 +419,12 @@ test('generateUrl: global omits the region prefix from the host', () => {
     });
     assert.match(url, /^https:\/\/aiplatform\.googleapis\.com\/v1\/projects\/p\/locations\/global\//);
 });
+
+// --- fleet deployment --------------------------------------------------------
+
+test('carve-out: the review workflow itself is protected in every repo', () => {
+    // A PR that edits the workflow that reviews it must be judged by a human,
+    // not by the reviewer it is editing. Same path in tooling and caller repos.
+    assert.deepEqual(detectCarveOut(['.github/workflows/ai-review.yml']),
+        ['.github/workflows/ai-review.yml']);
+});


### PR DESCRIPTION
## The fourth item: deploy the reviewer on every repo

Review logic stays in exactly one place; every other repo gets a ~15-line caller.

| Piece | Role |
|---|---|
| `.github/workflows/ai-review.yml` | Now a **reusable workflow** (`workflow_call`) — all logic, auth, honesty rules |
| `templates/ci/ai-review-caller.yml` | The thin caller each fleet repo receives |
| `scripts/deploy-ai-review.sh` | Opens one PR per target repo — **the merge is each repo's consent step** |
| `review-pr.js` | Selects `REVIEWER_GH_TOKEN_<ORG>` by repo owner (fine-grained PATs are single-resource-owner) |

## Two security properties worth reviewing

**1. A PR can no longer rewrite its own reviewer.** Scripts are now always checked out from this repo at a pinned ref — never from the PR under review. Previously, a PR to this repo that edited `review-pr.js` would have been reviewed by *its own modified code*.

**2. The review workflow joins the carve-out.** Same reasoning, one level up: a PR that edits `.github/workflows/ai-review.yml` — here or in any fleet repo, where the caller lives at the same path — halts and escalates to a human. Note this means future PRs touching that file in this repo will halt AI review; that is correct behaviour, not a bug.

## Dry-run verified against the live fleet

**33 targets, 6 skips, 0 failures** — skips are the three `.github` meta-repos, this repo, one empty repo, and `newpush/newpush-agents`, which **already has a file at that path** (pre-existing; worth a look — the script treats it as deployed).

Deployment is idempotent and PR-based; it never touches a default branch. Dry-run needs no extra scopes; a live run refuses to start without the `workflow` scope, failing once with the fix named rather than 33 times cryptically.

## Human prerequisites before the fleet works (documented in the guide)

1. **Org-level Actions variables** × 3 orgs (`gh variable set NAME --org ORG --visibility all` — needs `admin:org`)
2. **Widen the Infisical identity claim filter** to the three orgs — CI auth in other repos fails at Infisical login until then
3. **Per-org reviewer tokens** minted as `noemi-reviewer`, stored as `REVIEWER_GH_TOKEN_NEWPUSH` / `REVIEWER_GH_TOKEN_NEWPUSH_LABS`

Until (1)–(2) are done, fleet callers **skip cleanly with a notice** — merging this PR and even the caller PRs breaks nothing.

## Also in here

- Fixed the stale `us-central1` fallback still in the workflow env (the repo variable masked it; a caller repo without the variable would have regressed)
- Concurrency group now repo-qualified — PR numbers collide across a fleet
- Cost note in the guide: ~33 repos × 3 model calls per PR update, one billing project. **Set the budget alert before the merge wave, not after.**

## Verification

- 90/90 tests (new: carve-out covers the workflow itself), audit passes, both YAML files parse, guide links resolve
- Live dry-run output in the PR is reproducible: `bash scripts/deploy-ai-review.sh --dry-run`

## Reviewer

Touches the review workflow — which is now in its own carve-out, so: human review. Fittingly, the first PR halted by the rule it introduces.