### PR TITLE
docs(reviews): calibration entry — #392 merged over a failing review

### DIFF
--- a/docs/reviews/CALIBRATION.md
+++ b/docs/reviews/CALIBRATION.md
@@ -41,6 +41,7 @@ One row per disagreement. Keep reasons short and concrete.
 
 | Date | PR | Model | Gate | Reviewer said | Human did | Direction | Reason |
 |---|---|---|---|---|---|---|---|
+| 2026-08-14 | #392 | publishers/google/models/gemini-3.7-flash | premise | premise fail: The pull request contains significant undisclosed scope far beyond the described documentation mapping of Grok Custom Agents across four fil | **merged over** | PENDING-HUMAN | PENDING-HUMAN — edit this row, then approve |
 
 ## Reading the log
 


### PR DESCRIPTION
PR #392 was **merged over a failing review** (premise ❌, model `publishers/google/models/gemini-3.7-flash`).

This entry is the phase-2 evidence the governance framework requires. Before approving:

1. Edit the row's **Direction** cell: `reviewer too strict` / `reviewer too lenient` / `reviewer wrong domain`.
2. Replace the **Reason** cell with one concrete sentence.

Merging with PENDING-HUMAN still in the row defeats the log's purpose — the edit *is* the attestation.