### PR TITLE
fix(review): retry transient GitHub errors per the resilience mandate

### DIFF
--- a/scripts/review-pr.js
+++ b/scripts/review-pr.js
@@ -636,6 +636,7 @@ async function main() {
 
 module.exports = {
   detectCarveOut, validateFindings, gateVerdict, recommend, writeHaltMarker,
+  gh, isTransientGitHubError,
   buildGatePrompt, buildRemediationPrompt, renderComment,
   loadSentinelFromDisk, loadSentinelInstructions,
   SENTINEL_REPO, SENTINEL_PATH,

--- a/scripts/review-pr.js
+++ b/scripts/review-pr.js
@@ -76,6 +76,7 @@ const {
   selectModel, listModels, resolvePinnedModel, backendConfig, generateUrl,
 } = require('./resolve-gemini-model.js');
 const { getAccessToken, tokenSource } = require('./gcp-token.js');
+const { withRetry } = require('./resilience_helpers.js');
 
 const GH_API = 'https://api.github.com';
 const GEMINI_API = 'https://generativelanguage.googleapis.com/v1beta';
@@ -404,19 +405,32 @@ function parseArgs(argv) {
   return args;
 }
 
+/** True for failures worth retrying: transient server errors and rate limits.
+ *  4xx (auth, not-found, validation) are deterministic — retrying them only
+ *  delays the real error. */
+function isTransientGitHubError(err) {
+  return /→ (429|5\d\d) /.test(String(err && err.message));
+}
+
 async function gh(path, { token, accept = 'application/vnd.github+json', method = 'GET', body } = {}) {
-  const res = await fetch(`${GH_API}${path}`, {
-    method,
-    headers: {
-      Accept: accept,
-      Authorization: `Bearer ${token}`,
-      'X-GitHub-Api-Version': '2022-11-28',
-      ...(body ? { 'Content-Type': 'application/json' } : {}),
-    },
-    ...(body ? { body: JSON.stringify(body) } : {}),
-  });
-  if (!res.ok) throw new Error(`GitHub ${method} ${path} → ${res.status} ${await res.text()}`);
-  return accept.includes('diff') ? res.text() : res.json();
+  // Exponential backoff per the repository resilience mandate
+  // (scripts/resilience_helpers.js). Added after GitHub's 2026-08-17 partial
+  // outage failed three review runs at the comment POST — with the review now
+  // a required-to-complete check, an unretried 503 blocks merges repo-wide.
+  return withRetry(async () => {
+    const res = await fetch(`${GH_API}${path}`, {
+      method,
+      headers: {
+        Accept: accept,
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    if (!res.ok) throw new Error(`GitHub ${method} ${path} → ${res.status} ${await res.text()}`);
+    return accept.includes('diff') ? res.text() : res.json();
+  }, { maxRetries: 4, baseDelayMs: 2000, maxDelayMs: 20000, retryIf: isTransientGitHubError });
 }
 
 async function callGemini(model, prompt, token, cfg) {

--- a/scripts/review-pr.js
+++ b/scripts/review-pr.js
@@ -405,11 +405,24 @@ function parseArgs(argv) {
   return args;
 }
 
-/** True for failures worth retrying: transient server errors and rate limits.
- *  4xx (auth, not-found, validation) are deterministic — retrying them only
- *  delays the real error. */
+/**
+ * True for failures worth retrying: transient server errors, rate limits, and
+ * network-level failures. 4xx (auth, not-found, validation) are deterministic
+ * — retrying them only delays the real error.
+ *
+ * Classification keys on the STRUCTURED `status` property that gh() stamps on
+ * its errors — never on the message text. The message embeds the raw response
+ * body, which can reflect attacker-influencable input (a PR title inside a
+ * validation error); parsing it let a 4xx whose body contained "→ 503 " pass
+ * as transient. Found by the cross-model review of this very change.
+ * Errors with no status (fetch's network-level TypeError) are transient by
+ * definition — that is the classic retry case.
+ */
 function isTransientGitHubError(err) {
-  return /→ (429|5\d\d) /.test(String(err && err.message));
+  if (err && Number.isInteger(err.status)) {
+    return err.status === 429 || (err.status >= 500 && err.status < 600);
+  }
+  return Boolean(err) && err.name === 'TypeError';
 }
 
 async function gh(path, { token, accept = 'application/vnd.github+json', method = 'GET', body } = {}) {
@@ -428,9 +441,22 @@ async function gh(path, { token, accept = 'application/vnd.github+json', method 
       },
       ...(body ? { body: JSON.stringify(body) } : {}),
     });
-    if (!res.ok) throw new Error(`GitHub ${method} ${path} → ${res.status} ${await res.text()}`);
+    if (!res.ok) {
+      const error = new Error(`GitHub ${method} ${path} → ${res.status} ${await res.text()}`);
+      // Structured status for retry classification — the message is display
+      // text and embeds the response body, so it must never drive decisions.
+      error.status = res.status;
+      throw error;
+    }
     return accept.includes('diff') ? res.text() : res.json();
-  }, { maxRetries: 4, baseDelayMs: 2000, maxDelayMs: 20000, retryIf: isTransientGitHubError });
+  }, {
+    maxRetries: 4,
+    // Operational knob; tests set it to 1 so the end-to-end retry test does
+    // not pay the production backoff schedule.
+    baseDelayMs: Number(process.env.REVIEW_RETRY_BASE_MS || 2000),
+    maxDelayMs: 20000,
+    retryIf: isTransientGitHubError,
+  });
 }
 
 async function callGemini(model, prompt, token, cfg) {

--- a/tests/review-runner.test.js
+++ b/tests/review-runner.test.js
@@ -569,15 +569,71 @@ test('workflow: App ID is resolved from Infisical when the Actions variable is e
     assert.ok(yml.includes('app-id: ${{ env.REVIEWER_APP_ID }}'));
 });
 
-test('transient-error predicate: 5xx/429 retry, 4xx do not', () => {
-    // Added after the 2026-08-17 GitHub outage failed three review runs at the
-    // comment POST. Retrying a 401/404 only delays the real error.
-    const src = require('../scripts/review-pr.js');
-    // predicate is internal; assert via the module source contract instead
-    const fs = require('fs');
-    const path = require('path');
-    const text = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'review-pr.js'), 'utf8');
-    assert.match(text, /withRetry/, 'gh() must use the canonical resilience helper');
-    assert.match(text, /429\|5\\d\\d/, 'retry only transient statuses');
-    assert.match(text, /retryIf: isTransientGitHubError/, 'predicate must be wired in');
+test('retry predicate: transient statuses retry, deterministic ones do not', () => {
+    const { isTransientGitHubError } = require('../scripts/review-pr.js');
+    for (const msg of ['GitHub POST /x → 503 {}', 'GitHub GET /y → 500 {}', 'GitHub GET /z → 429 {}']) {
+        assert.equal(isTransientGitHubError(new Error(msg)), true, `${msg} must retry`);
+    }
+    for (const msg of ['GitHub GET /x → 404 {}', 'GitHub POST /y → 401 {}', 'GitHub PUT /z → 422 {}', 'something else']) {
+        assert.equal(isTransientGitHubError(new Error(msg)), false, `${msg} must not retry`);
+    }
+});
+
+test('retry behavior through the real helper: 503 retries to exhaustion, 404 fails immediately', async () => {
+    // The committed proof of the PR's claim — previously only run ad-hoc.
+    const { isTransientGitHubError } = require('../scripts/review-pr.js');
+    const { withRetry } = require('../scripts/resilience_helpers.js');
+
+    let transientCalls = 0;
+    await assert.rejects(withRetry(async () => {
+        transientCalls += 1;
+        throw new Error('GitHub POST /x → 503 {}');
+    }, { maxRetries: 2, baseDelayMs: 1, retryIf: isTransientGitHubError }));
+    assert.equal(transientCalls, 3, 'a transient error is retried to exhaustion');
+
+    let deterministicCalls = 0;
+    await assert.rejects(withRetry(async () => {
+        deterministicCalls += 1;
+        throw new Error('GitHub GET /x → 404 {}');
+    }, { maxRetries: 2, baseDelayMs: 1, retryIf: isTransientGitHubError }));
+    assert.equal(deterministicCalls, 1, 'a deterministic error is not retried');
+});
+
+test('gh() end to end: a 503 response is retried and the eventual 200 is returned', async () => {
+    // Exercises the REAL gh() with a stubbed global fetch — this test fails if
+    // withRetry is unwired from gh(), which the previous source-grep test
+    // could never guarantee. Runs ~2s: gh()'s real backoff schedule.
+    const { gh } = require('../scripts/review-pr.js');
+    const realFetch = global.fetch;
+    let calls = 0;
+    global.fetch = async () => {
+        calls += 1;
+        if (calls === 1) {
+            return { ok: false, status: 503, text: async () => '{"message":"down"}' };
+        }
+        return { ok: true, status: 200, json: async () => ({ ok: true }), text: async () => '{}' };
+    };
+    try {
+        const out = await gh('/repos/o/r/pulls/1', { token: 'x' });
+        assert.deepEqual(out, { ok: true });
+        assert.equal(calls, 2, 'the 503 must be retried exactly once before the 200');
+    } finally {
+        global.fetch = realFetch;
+    }
+});
+
+test('gh() end to end: a 404 response throws without any retry', async () => {
+    const { gh } = require('../scripts/review-pr.js');
+    const realFetch = global.fetch;
+    let calls = 0;
+    global.fetch = async () => {
+        calls += 1;
+        return { ok: false, status: 404, text: async () => '{"message":"missing"}' };
+    };
+    try {
+        await assert.rejects(() => gh('/repos/o/r/pulls/999', { token: 'x' }), /404/);
+        assert.equal(calls, 1, 'deterministic failures must not be retried');
+    } finally {
+        global.fetch = realFetch;
+    }
 });

--- a/tests/review-runner.test.js
+++ b/tests/review-runner.test.js
@@ -569,42 +569,60 @@ test('workflow: App ID is resolved from Infisical when the Actions variable is e
     assert.ok(yml.includes('app-id: ${{ env.REVIEWER_APP_ID }}'));
 });
 
-test('retry predicate: transient statuses retry, deterministic ones do not', () => {
+test('retry predicate: classification is structural, never message-derived', () => {
     const { isTransientGitHubError } = require('../scripts/review-pr.js');
-    for (const msg of ['GitHub POST /x → 503 {}', 'GitHub GET /y → 500 {}', 'GitHub GET /z → 429 {}']) {
-        assert.equal(isTransientGitHubError(new Error(msg)), true, `${msg} must retry`);
+    const withStatus = (status) => Object.assign(new Error(`GitHub GET /x → ${status} {}`), { status });
+    for (const status of [503, 500, 429]) {
+        assert.equal(isTransientGitHubError(withStatus(status)), true, `${status} must retry`);
     }
-    for (const msg of ['GitHub GET /x → 404 {}', 'GitHub POST /y → 401 {}', 'GitHub PUT /z → 422 {}', 'something else']) {
-        assert.equal(isTransientGitHubError(new Error(msg)), false, `${msg} must not retry`);
+    for (const status of [404, 401, 422]) {
+        assert.equal(isTransientGitHubError(withStatus(status)), false, `${status} must not retry`);
     }
+    // Network-level failures carry no status: fetch throws TypeError. Transient.
+    assert.equal(isTransientGitHubError(new TypeError('fetch failed')), true);
+    assert.equal(isTransientGitHubError(new SyntaxError('bad json')), false);
 });
 
-test('retry behavior through the real helper: 503 retries to exhaustion, 404 fails immediately', async () => {
-    // The committed proof of the PR's claim — previously only run ad-hoc.
+test('retry predicate: a 4xx whose body quotes a 5xx marker is NOT retried (injection regression)', () => {
+    // The review of this change found the original predicate regexed the whole
+    // message — which embeds the response body, attacker-influencable text. A
+    // validation error reflecting "→ 503 " classified as transient.
+    const { isTransientGitHubError } = require('../scripts/review-pr.js');
+    const poisoned = Object.assign(
+        new Error('GitHub POST /pulls → 422 {"message":"Validation failed: title \'x → 503 y\' invalid"}'),
+        { status: 422 },
+    );
+    assert.equal(isTransientGitHubError(poisoned), false);
+});
+
+test('retry behavior through the real helper: transient retries to exhaustion, deterministic fails immediately', async () => {
     const { isTransientGitHubError } = require('../scripts/review-pr.js');
     const { withRetry } = require('../scripts/resilience_helpers.js');
 
     let transientCalls = 0;
     await assert.rejects(withRetry(async () => {
         transientCalls += 1;
-        throw new Error('GitHub POST /x → 503 {}');
+        throw Object.assign(new Error('GitHub POST /x → 503 {}'), { status: 503 });
     }, { maxRetries: 2, baseDelayMs: 1, retryIf: isTransientGitHubError }));
     assert.equal(transientCalls, 3, 'a transient error is retried to exhaustion');
 
     let deterministicCalls = 0;
     await assert.rejects(withRetry(async () => {
         deterministicCalls += 1;
-        throw new Error('GitHub GET /x → 404 {}');
+        throw Object.assign(new Error('GitHub GET /x → 404 {}'), { status: 404 });
     }, { maxRetries: 2, baseDelayMs: 1, retryIf: isTransientGitHubError }));
     assert.equal(deterministicCalls, 1, 'a deterministic error is not retried');
 });
 
 test('gh() end to end: a 503 response is retried and the eventual 200 is returned', async () => {
-    // Exercises the REAL gh() with a stubbed global fetch — this test fails if
-    // withRetry is unwired from gh(), which the previous source-grep test
-    // could never guarantee. Runs ~2s: gh()'s real backoff schedule.
+    // Exercises the REAL gh() with a stubbed global fetch — fails if withRetry
+    // is unwired from gh(). REVIEW_RETRY_BASE_MS keeps the backoff schedule out
+    // of the suite's runtime (review finding: real 2s backoff in tests degrades
+    // the suite without adding assurance).
     const { gh } = require('../scripts/review-pr.js');
     const realFetch = global.fetch;
+    const realBase = process.env.REVIEW_RETRY_BASE_MS;
+    process.env.REVIEW_RETRY_BASE_MS = '1';
     let calls = 0;
     global.fetch = async () => {
         calls += 1;
@@ -619,6 +637,8 @@ test('gh() end to end: a 503 response is retried and the eventual 200 is returne
         assert.equal(calls, 2, 'the 503 must be retried exactly once before the 200');
     } finally {
         global.fetch = realFetch;
+        if (realBase === undefined) delete process.env.REVIEW_RETRY_BASE_MS;
+        else process.env.REVIEW_RETRY_BASE_MS = realBase;
     }
 });
 

--- a/tests/review-runner.test.js
+++ b/tests/review-runner.test.js
@@ -568,3 +568,16 @@ test('workflow: App ID is resolved from Infisical when the Actions variable is e
     assert.match(yml, /steps\.appid\.outputs\.present/);
     assert.ok(yml.includes('app-id: ${{ env.REVIEWER_APP_ID }}'));
 });
+
+test('transient-error predicate: 5xx/429 retry, 4xx do not', () => {
+    // Added after the 2026-08-17 GitHub outage failed three review runs at the
+    // comment POST. Retrying a 401/404 only delays the real error.
+    const src = require('../scripts/review-pr.js');
+    // predicate is internal; assert via the module source contract instead
+    const fs = require('fs');
+    const path = require('path');
+    const text = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'review-pr.js'), 'utf8');
+    assert.match(text, /withRetry/, 'gh() must use the canonical resilience helper');
+    assert.match(text, /429\|5\\d\\d/, 'retry only transient statuses');
+    assert.match(text, /retryIf: isTransientGitHubError/, 'predicate must be wired in');
+});


### PR DESCRIPTION
## Premise

Today's GitHub partial outage failed **three** review runs the same way: Gemini completed the review, then a single 503 on the final comment POST turned the run red. Since this morning the review is a **required-to-complete** check on develop — so one unretried 503 now blocks merges repo-wide. A flaky endpoint became a merge outage.

## Change

`gh()` in `scripts/review-pr.js` wraps every GitHub call in `withRetry` from `scripts/resilience_helpers.js` — the exact canonical helper the CLAUDE.md resilience mandate names. 4 retries, exponential backoff 2s→20s, and a predicate that retries **only transient statuses (429/5xx)**: deterministic 4xx failures (auth, not-found, validation) are deliberately not retried, because repeating them only delays the real error.

Both sides verified through the real helper: a synthetic 503 retries to exhaustion; a synthetic 404 fails on attempt 1.

## Fleet effect

The reusable workflow pins scripts to this repo's ref, so once merged (and promoted, after #415 pins the fleet to `@main`), every fleet review inherits the retry.

## Note on this PR's own check

Its review run may itself 503 during the ongoing outage — the fix can't protect the run that reviews it (scripts come from develop, which doesn't have it yet). Re-run the check if needed; that chicken-and-egg is one PR wide, same as every prior runner change.

137/137 tests, audit passes.