### PR TITLE
fix(calibration): entries do not generate entries

### DIFF
--- a/scripts/calibration-watch.js
+++ b/scripts/calibration-watch.js
@@ -120,6 +120,17 @@ async function main() {
     return;
   }
 
+  // Recursion guard: entry PRs are themselves reviewable and CAN legitimately
+  // merge over a failing verdict (observed live: #418 merged while the
+  // reviewer's framing gate flagged its then-unfilled PENDING-HUMAN row, which
+  // spawned meta-entry #420). An entry about an entry records nothing the
+  // underlying row does not already record, and each such merge would spawn
+  // the next — an unbounded chain. Entries are exempt from generating entries.
+  if ((pr.head?.ref || '').startsWith('calibration/')) {
+    process.stderr.write(`PR #${prNumber} is itself a calibration entry — entries do not generate entries.\n`);
+    return;
+  }
+
   const raw = JSON.parse(gh(['api', `repos/${repo}/issues/${prNumber}/comments?per_page=100`]));
   const verdict = latestVerdict(raw.map((c) => ({ login: c.user?.login || '', body: c.body || '' })));
 

--- a/tests/calibration-watch.test.js
+++ b/tests/calibration-watch.test.js
@@ -90,3 +90,16 @@ test('dedup: an existing row for the PR is detected', () => {
     assert.equal(alreadyLogged(log, 393), false);
     assert.equal(alreadyLogged(log, 39), false, 'must not prefix-match #392');
 });
+
+test('recursion guard: entry branches are exempt from generating entries', () => {
+    // Observed live: entry PR #418 merged over a failing framing verdict (its
+    // row was still PENDING-HUMAN at review time), spawning meta-entry #420.
+    // Without exemption each such merge spawns the next — an unbounded chain.
+    // The guard is branch-name-based and lives in main(); this pins the
+    // convention the guard keys on so a branch-prefix rename breaks loudly.
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'calibration-watch.js'), 'utf8');
+    assert.match(src, /startsWith\('calibration\/'\)/, 'guard must key on the entry branch prefix');
+    assert.match(src, /`calibration\/pr-\$\{prNumber\}`/, 'entry branches must carry that prefix');
+});


### PR DESCRIPTION
## Live-observed within hours of shipping

Entry PR #418 merged while the reviewer's framing gate (correctly!) flagged its then-unfilled `PENDING-HUMAN` row — so the calibration watch dutifully opened **#420: a calibration entry about a calibration entry**. Each such merge spawns the next: an unbounded chain recording nothing the underlying row doesn't already record.

**Fix:** entry branches (`calibration/*`) are exempt from generating entries. Test-pinned on both halves of the convention (the guard's prefix check and the branch-naming that feeds it), so a rename breaks loudly rather than silently disabling the guard.

**Related human action:** #420 itself should be **closed without merging** — the #418 override it records is an artifact of the entry-filling workflow (row edited, then merged before a fresh review), not a reviewer disagreement worth evidence weight.

163/163 tests.