### PR TITLE
docs(reviews): add 'reviewer misinterpreted' direction; normalize first rows

### DIFF
--- a/docs/reviews/CALIBRATION.md
+++ b/docs/reviews/CALIBRATION.md
@@ -36,13 +36,19 @@ One row per disagreement. Keep reasons short and concrete.
 - `reviewer too strict` — finding dismissed or severity lowered
 - `reviewer too lenient` — severity raised, or a miss found later
 - `reviewer wrong domain` — finding factually incorrect about the code
+- `reviewer misinterpreted` — the finding is accurate about the diff but
+  misreads the change's intent, authorization, or context (e.g. flags
+  "undisclosed scope" that was intended and authorized). The remedy is
+  supplying the reviewer better context — a fuller description, a linked
+  issue — not tuning its strictness.
 
 ## Log
 
 | Date | PR | Model | Gate | Reviewer said | Human did | Direction | Reason |
 |---|---|---|---|---|---|---|---|
-| 2026-08-15 | #399 | publishers/google/models/gemini-2.5-pro | framing | framing fail: The pull request description misrepresents its contents by claiming not to include changes from another PR that are present in the diff, and | **merged over** | Human Review | Approved because it was intended and the finding was a false positive |
-| 2026-08-14 | #392 | publishers/google/models/gemini-3.7-flash | premise | premise fail: The pull request contains significant undisclosed scope far beyond the described documentation mapping of Grok Custom Agents across four fil | **merged over** | Human Review | Approved because it was intended and the finding was a false positive |
+| 2026-08-15 | #399 | publishers/google/models/gemini-2.5-pro | framing | framing fail: The pull request description misrepresents its contents by claiming not to include changes from another PR that are present in the diff, and | **merged over** | reviewer misinterpreted | Approved because it was intended and the finding was a false positive |
+| 2026-08-14 | #392 | publishers/google/models/gemini-3.7-flash | premise | premise fail: The pull request contains significant undisclosed scope far beyond the described documentation mapping of Grok Custom Agents across four fil | **merged over** | reviewer misinterpreted | Approved because it was intended and the finding was a false positive |
+
 ## Reading the log
 
 When considering phase 2, compute over a stated window (e.g. the last 30
@@ -51,6 +57,10 @@ reviewed PRs):
 - **Override rate** — entries ÷ reviews. High is not automatically bad; a high
   rate of `too strict` with zero `too lenient` is a tunable prompt, not an
   untrustworthy reviewer.
+- **Misinterpretation rate** — a high `misinterpreted` rate is a CONTEXT-supply
+  problem, not a reviewer-quality problem: the fix is richer PR descriptions
+  and linked specs reaching the reviewer, and it counts against phase 2 only
+  until that context path improves.
 - **Lenient misses** — any `too lenient` entry on a `critical`/`high` matter is
   disqualifying for phase 2 until understood, because phase 2 removes the human
   who caught it.

--- a/scripts/calibration-watch.js
+++ b/scripts/calibration-watch.js
@@ -184,7 +184,7 @@ async function main() {
     '',
     'This entry is the phase-2 evidence the governance framework requires. Before approving:',
     '',
-    '1. Edit the row\'s **Direction** cell: `reviewer too strict` / `reviewer too lenient` / `reviewer wrong domain`.',
+    '1. Edit the row\'s **Direction** cell: `reviewer too strict` / `reviewer too lenient` / `reviewer wrong domain` / `reviewer misinterpreted`.',
     '2. Replace the **Reason** cell with one concrete sentence.',
     '',
     'Merging with PENDING-HUMAN still in the row defeats the log\'s purpose — the edit *is* the attestation.',


### PR DESCRIPTION
## Owner request

A taxonomy value for the case where the reviewer's finding is **accurate about the diff but misreads intent, authorization, or context** — the exact shape of both real overrides logged so far (#392, #399: "undisclosed scope" that was in fact intended). Neither existing value fits: `wrong domain` means factually incorrect about the code; `too strict` means a real issue the human accepts anyway.

## Changes

1. **`reviewer misinterpreted`** added, with its remedy stated in the definition: the fix is supplying the reviewer better context (fuller PR descriptions, linked specs) — not tuning strictness.
2. **The two existing rows normalized** from free-text `Human Review` to the new value. This matters mechanically: the reading rules compute override rates *by direction*, so non-taxonomy values silently fall out of the phase-2 math.
3. **Reading rules** gain the interpretation: a high `misinterpreted` rate is a context-supply problem, counting against phase 2 only until the context path improves.
4. **`calibration-watch.js` entry-PR instructions** list all four values, steering future rows to conformant directions.

163/163 tests, audit passes. Not a carve-out path — the cross-model reviewer will judge this one normally.