### PR TITLE
docs(reviews): calibration entry — #423 merged over a failing review

### DIFF
--- a/docs/reviews/CALIBRATION.md
+++ b/docs/reviews/CALIBRATION.md
@@ -46,7 +46,7 @@ One row per disagreement. Keep reasons short and concrete.
 
 | Date | PR | Model | Gate | Reviewer said | Human did | Direction | Reason |
 |---|---|---|---|---|---|---|---|
-| 2026-08-18 | #423 | publishers/google/models/gemini-3.1-pro-preview | code | code fail: The tenant repository allowlist fails open if `limits.repos` is misconfigured as a string instead of an array. | **merged over** | PENDING-HUMAN | PENDING-HUMAN — edit this row, then approve |
+| 2026-08-18 | #423 | publishers/google/models/gemini-3.1-pro-preview | code | code fail: The tenant repository allowlist fails open if `limits.repos` is misconfigured as a string instead of an array. | **merged over** | human-error | correction is slated for PR #425 - great catch by review calibration system |
 | 2026-08-15 | #399 | publishers/google/models/gemini-2.5-pro | framing | framing fail: The pull request description misrepresents its contents by claiming not to include changes from another PR that are present in the diff, and | **merged over** | reviewer misinterpreted | Approved because it was intended and the finding was a false positive |
 | 2026-08-14 | #392 | publishers/google/models/gemini-3.7-flash | premise | premise fail: The pull request contains significant undisclosed scope far beyond the described documentation mapping of Grok Custom Agents across four fil | **merged over** | reviewer misinterpreted | Approved because it was intended and the finding was a false positive |
 

--- a/docs/reviews/CALIBRATION.md
+++ b/docs/reviews/CALIBRATION.md
@@ -46,6 +46,7 @@ One row per disagreement. Keep reasons short and concrete.
 
 | Date | PR | Model | Gate | Reviewer said | Human did | Direction | Reason |
 |---|---|---|---|---|---|---|---|
+| 2026-08-18 | #423 | publishers/google/models/gemini-3.1-pro-preview | code | code fail: The tenant repository allowlist fails open if `limits.repos` is misconfigured as a string instead of an array. | **merged over** | PENDING-HUMAN | PENDING-HUMAN — edit this row, then approve |
 | 2026-08-15 | #399 | publishers/google/models/gemini-2.5-pro | framing | framing fail: The pull request description misrepresents its contents by claiming not to include changes from another PR that are present in the diff, and | **merged over** | reviewer misinterpreted | Approved because it was intended and the finding was a false positive |
 | 2026-08-14 | #392 | publishers/google/models/gemini-3.7-flash | premise | premise fail: The pull request contains significant undisclosed scope far beyond the described documentation mapping of Grok Custom Agents across four fil | **merged over** | reviewer misinterpreted | Approved because it was intended and the finding was a false positive |
 


### PR DESCRIPTION
PR #423 was **merged over a failing review** (code ❌, model `publishers/google/models/gemini-3.1-pro-preview`).

This entry is the phase-2 evidence the governance framework requires. Before approving:

1. Edit the row's **Direction** cell: `reviewer too strict` / `reviewer too lenient` / `reviewer wrong domain` / `reviewer misinterpreted`.
2. Replace the **Reason** cell with one concrete sentence.

Merging with PENDING-HUMAN still in the row defeats the log's purpose — the edit *is* the attestation.