### PR TITLE
docs(reviews): calibration entry — #494 merged over a failing review

### DIFF
--- a/docs/reviews/CALIBRATION.md
+++ b/docs/reviews/CALIBRATION.md
@@ -46,7 +46,7 @@ One row per disagreement. Keep reasons short and concrete.
 
 | Date | PR | Model | Gate | Reviewer said | Human did | Direction | Reason |
 |---|---|---|---|---|---|---|---|
-| 2026-09-11 | #494 | publishers/google/models/gemini-3.1-pro-preview | framing | framing fail: The PR description explicitly claims 'run record [2026-09-11-0001] (... no collision)' and lists exactly six evidence updates. | **merged over** | PENDING-HUMAN | PENDING-HUMAN — edit this row, then approve |
+| 2026-09-11 | #494 | publishers/google/models/gemini-3.1-pro-preview | framing | framing fail: The PR description explicitly claims 'run record [2026-09-11-0001] (... no collision)' and lists exactly six evidence updates. | **merged over** | reviewer misinterpreted | Decision numbering had to be shifted because of a conflict |
 | 2026-09-11 | #496 | publishers/google/models/gemini-3.1-pro-preview | premise | premise fail: 403 Refusal: Attempt to weaken existing review and merge-source controls (authorization guards) to allow direct pushes. | **merged over** | reviewer wrong domain | Catch 22 the review looked at a branch that needed the PR before the review could work. |
 | 2026-09-08 | #480 | publishers/google/models/gemini-3.1-pro-preview | premise | premise fail: The PR introduces unnecessary, repetitive changes by appending daily execution logs to Markdown documentation. | **merged over** | reviewer too strict | docs only |
 | 2026-09-08 | #481 | publishers/google/models/gemini-3.1-pro-preview | framing | framing fail: ([2026-08-08]'s suite-still-red state is re-confirmed in run-status bullets only; its question body is untouched by this diff.) | **merged over** | reviewer too strict | docs only |

--- a/docs/reviews/CALIBRATION.md
+++ b/docs/reviews/CALIBRATION.md
@@ -46,6 +46,7 @@ One row per disagreement. Keep reasons short and concrete.
 
 | Date | PR | Model | Gate | Reviewer said | Human did | Direction | Reason |
 |---|---|---|---|---|---|---|---|
+| 2026-09-11 | #494 | publishers/google/models/gemini-3.1-pro-preview | framing | framing fail: The PR description explicitly claims 'run record [2026-09-11-0001] (... no collision)' and lists exactly six evidence updates. | **merged over** | PENDING-HUMAN | PENDING-HUMAN — edit this row, then approve |
 | 2026-09-11 | #496 | publishers/google/models/gemini-3.1-pro-preview | premise | premise fail: 403 Refusal: Attempt to weaken existing review and merge-source controls (authorization guards) to allow direct pushes. | **merged over** | reviewer wrong domain | Catch 22 the review looked at a branch that needed the PR before the review could work. |
 | 2026-09-08 | #480 | publishers/google/models/gemini-3.1-pro-preview | premise | premise fail: The PR introduces unnecessary, repetitive changes by appending daily execution logs to Markdown documentation. | **merged over** | reviewer too strict | docs only |
 | 2026-09-08 | #481 | publishers/google/models/gemini-3.1-pro-preview | framing | framing fail: ([2026-08-08]'s suite-still-red state is re-confirmed in run-status bullets only; its question body is untouched by this diff.) | **merged over** | reviewer too strict | docs only |


### PR DESCRIPTION
PR #494 was **merged over a failing review** (framing ❌, model `publishers/google/models/gemini-3.1-pro-preview`).

This entry is the phase-2 evidence the governance framework requires. Before approving:

1. Edit the row's **Direction** cell: `reviewer too strict` / `reviewer too lenient` / `reviewer wrong domain` / `reviewer misinterpreted`.
2. Replace the **Reason** cell with one concrete sentence.

Merging with PENDING-HUMAN still in the row defeats the log's purpose — the edit *is* the attestation.